### PR TITLE
Foundational Modules and Error Models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,23 @@ keywords = ["ai", "catalog", "collaboration", "pydantic"]
 
 dependencies = [
     "pydantic>=2.0.0",
+    "pyyaml>=6.0",
     "akgentic",
     "akgentic-tool",
 ]
 
 [project.optional-dependencies]
+api = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.20.0",
+]
+cli = [
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+]
+mongo = [
+    "pymongo>=4.0.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -50,5 +62,5 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W"]
-ignore = []
+select = ["E", "F", "I", "N", "UP", "ANN", "ASYNC"]
+ignore = ["ANN401", "N802"]

--- a/src/akgentic/catalog/env.py
+++ b/src/akgentic/catalog/env.py
@@ -1,0 +1,33 @@
+"""Environment variable substitution utility.
+
+Provides runtime resolution of ``${VAR}`` patterns in catalog values.
+The catalog stores ``${VAR}`` as-is; this utility is called by runtime
+consumers (e.g. create-team), not by catalog services.
+"""
+
+import os
+import re
+
+__all__ = [
+    "resolve_env_vars",
+]
+
+
+def resolve_env_vars(value: str) -> str:
+    """Replace ${VAR} patterns with environment variable values.
+
+    This is a runtime utility — the catalog stores ${VAR} as-is.
+    Called by runtime consumers (e.g. create-team), not by catalog services.
+
+    Raises:
+        OSError: If a referenced environment variable is not set.
+    """
+
+    def replace(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        result = os.environ.get(var_name)
+        if result is None:
+            raise OSError(f"Environment variable '{var_name}' not set")
+        return result
+
+    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", replace, value)

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -1,10 +1,10 @@
-"""akgentic-catalog: Centralized imports for all catalog components."""
+"""Catalog data models."""
 
-from akgentic.catalog.env import resolve_env_vars
+from akgentic.catalog.models.agent import _extract_config_type
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 
 __all__ = [
     "CatalogValidationError",
     "EntryNotFoundError",
-    "resolve_env_vars",
+    "_extract_config_type",
 ]

--- a/src/akgentic/catalog/models/agent.py
+++ b/src/akgentic/catalog/models/agent.py
@@ -1,0 +1,35 @@
+"""Agent model utilities for catalog introspection."""
+
+from typing import get_args
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+
+__all__ = [
+    "_extract_config_type",
+]
+
+
+def _extract_config_type(agent_cls: type) -> type[BaseConfig]:
+    """Extract ConfigType from an Akgent subclass's generic parameters.
+
+    Walks the MRO and each class's ``__orig_bases__`` to find the
+    ``Akgent[ConfigType, StateType]`` generic — handles intermediate base
+    classes that don't re-declare generics.
+
+    Raises:
+        ValueError: If the agent class does not parameterize
+            ``Akgent[ConfigType, StateType]``.
+    """
+    for cls_in_mro in agent_cls.__mro__:
+        for base in getattr(cls_in_mro, "__orig_bases__", ()):
+            origin = getattr(base, "__origin__", None)
+            if origin is not None and issubclass(origin, Akgent):
+                args = get_args(base)
+                if args:
+                    config_type: type[BaseConfig] = args[0]
+                    return config_type
+    raise ValueError(
+        f"{agent_cls.__name__} does not parameterize Akgent[ConfigType, StateType] "
+        f"— cannot resolve config type"
+    )

--- a/src/akgentic/catalog/models/errors.py
+++ b/src/akgentic/catalog/models/errors.py
@@ -1,0 +1,26 @@
+"""Catalog error models.
+
+Provides domain-specific exceptions for catalog operations, distinct from
+Pydantic's ValidationError (which covers object-level validation).
+"""
+
+__all__ = [
+    "CatalogValidationError",
+    "EntryNotFoundError",
+]
+
+
+class CatalogValidationError(Exception):
+    """Raised when catalog business rules are violated.
+
+    Distinct from Pydantic ValidationError — object validation errors are
+    Pydantic, repository/service validation errors are CatalogValidationError.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(f"Catalog validation failed: {'; '.join(errors)}")
+
+
+class EntryNotFoundError(Exception):
+    """Raised when a catalog entry lookup by id returns no result."""

--- a/src/akgentic/catalog/refs.py
+++ b/src/akgentic/catalog/refs.py
@@ -1,0 +1,29 @@
+"""Catalog @-reference utilities.
+
+Handles the catalog reference convention where ``@entry-id`` in
+``PromptTemplate.template`` fields points to another catalog entry.
+
+IMPORTANT: Two ``@`` conventions coexist — ``config.name`` uses ``@`` for
+agent routing names; ``prompt.template`` uses ``@`` for catalog references.
+These functions must ONLY be applied to ``PromptTemplate.template`` fields,
+never to ``config.name`` or ``routes_to`` values.
+"""
+
+__all__ = [
+    "_is_catalog_ref",
+    "_resolve_ref",
+]
+
+
+def _is_catalog_ref(value: str) -> bool:
+    """Check if a string is a catalog @-reference.
+
+    ONLY call this on PromptTemplate.template fields.
+    Never on config.name or routes_to values.
+    """
+    return value.startswith("@")
+
+
+def _resolve_ref(value: str) -> str:
+    """Strip @ prefix to get the catalog entry id."""
+    return value[1:]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for akgentic-agent package."""
+"""Tests for akgentic-catalog package."""

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,49 @@
+"""Tests for environment variable substitution utility."""
+
+import os
+
+import pytest
+
+from akgentic.catalog.env import resolve_env_vars
+
+
+class TestResolveEnvVars:
+    def test_replaces_single_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert resolve_env_vars("${MY_VAR}") == "hello"
+
+    def test_replaces_multiple_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOST", "localhost")
+        monkeypatch.setenv("PORT", "8080")
+        assert resolve_env_vars("${HOST}:${PORT}") == "localhost:8080"
+
+    def test_preserves_text_around_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NAME", "world")
+        assert resolve_env_vars("hello ${NAME}!") == "hello world!"
+
+    def test_no_vars_returns_unchanged(self) -> None:
+        assert resolve_env_vars("plain text") == "plain text"
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert resolve_env_vars("") == ""
+
+    def test_raises_on_missing_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NONEXISTENT_VAR_12345", raising=False)
+        with pytest.raises(OSError, match="NONEXISTENT_VAR_12345"):
+            resolve_env_vars("${NONEXISTENT_VAR_12345}")
+
+    def test_underscore_in_var_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_VAR_2", "value")
+        assert resolve_env_vars("${MY_VAR_2}") == "value"
+
+    def test_ignores_invalid_var_syntax(self) -> None:
+        # $VAR without braces should not be substituted
+        assert resolve_env_vars("$VAR") == "$VAR"
+
+    def test_ignores_empty_braces(self) -> None:
+        # ${} should not match the pattern (requires valid identifier)
+        assert resolve_env_vars("${}") == "${}"
+
+    def test_var_starting_with_digit_not_matched(self) -> None:
+        # ${1VAR} is not a valid identifier per the regex
+        assert resolve_env_vars("${1VAR}") == "${1VAR}"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,50 @@
+"""Tests for catalog error models."""
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+
+class TestCatalogValidationError:
+    def test_stores_error_list(self) -> None:
+        errors = ["field required", "invalid format"]
+        exc = CatalogValidationError(errors)
+        assert exc.errors == errors
+
+    def test_message_joins_errors(self) -> None:
+        errors = ["missing name", "bad type"]
+        exc = CatalogValidationError(errors)
+        assert str(exc) == "Catalog validation failed: missing name; bad type"
+
+    def test_single_error(self) -> None:
+        exc = CatalogValidationError(["only one"])
+        assert exc.errors == ["only one"]
+        assert str(exc) == "Catalog validation failed: only one"
+
+    def test_empty_errors_list(self) -> None:
+        exc = CatalogValidationError([])
+        assert exc.errors == []
+        assert str(exc) == "Catalog validation failed: "
+
+    def test_is_exception(self) -> None:
+        exc = CatalogValidationError(["err"])
+        assert isinstance(exc, Exception)
+
+    def test_raises_and_catches(self) -> None:
+        with pytest.raises(CatalogValidationError) as exc_info:
+            raise CatalogValidationError(["test error"])
+        assert exc_info.value.errors == ["test error"]
+
+
+class TestEntryNotFoundError:
+    def test_is_exception(self) -> None:
+        exc = EntryNotFoundError("not found")
+        assert isinstance(exc, Exception)
+
+    def test_raises_and_catches(self) -> None:
+        with pytest.raises(EntryNotFoundError):
+            raise EntryNotFoundError("agent 'foo' not found")
+
+    def test_message(self) -> None:
+        exc = EntryNotFoundError("agent 'foo' not found")
+        assert str(exc) == "agent 'foo' not found"

--- a/tests/test_extract_config_type.py
+++ b/tests/test_extract_config_type.py
@@ -1,0 +1,63 @@
+"""Tests for _extract_config_type with real agent class hierarchy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
+from akgentic.core.agent_state import BaseState
+
+from akgentic.catalog.models.agent import _extract_config_type
+
+
+class CustomConfig(BaseConfig):
+    custom_field: str = "test"
+
+
+class SimpleAgent(Akgent[BaseConfig, BaseState]):
+    pass
+
+
+class CustomConfigAgent(Akgent[CustomConfig, BaseState]):
+    pass
+
+
+class IntermediateBase(Akgent[CustomConfig, BaseState]):
+    """Intermediate base that declares generic params."""
+
+    pass
+
+
+class DerivedAgent(IntermediateBase):
+    """Derived agent that does NOT re-declare generics."""
+
+    pass
+
+
+class TestExtractConfigType:
+    def test_simple_agent_returns_base_config(self) -> None:
+        result = _extract_config_type(SimpleAgent)
+        assert result is BaseConfig
+
+    def test_custom_config_agent(self) -> None:
+        result = _extract_config_type(CustomConfigAgent)
+        assert result is CustomConfig
+
+    def test_derived_agent_resolves_through_mro(self) -> None:
+        result = _extract_config_type(DerivedAgent)
+        assert result is CustomConfig
+
+    def test_raises_for_non_agent_class(self) -> None:
+        class NotAnAgent:
+            pass
+
+        with pytest.raises(ValueError, match="does not parameterize Akgent"):
+            _extract_config_type(NotAnAgent)
+
+    def test_raises_for_raw_akgent(self) -> None:
+        # Akgent itself doesn't parameterize Akgent[X, Y] in __orig_bases__
+        with pytest.raises(ValueError, match="does not parameterize Akgent"):
+            _extract_config_type(Akgent)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,34 @@
+"""Tests for catalog @-reference utilities."""
+
+from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
+
+
+class TestIsCatalogRef:
+    def test_at_prefixed_string_is_ref(self) -> None:
+        assert _is_catalog_ref("@my-template") is True
+
+    def test_at_only_is_ref(self) -> None:
+        assert _is_catalog_ref("@") is True
+
+    def test_plain_string_is_not_ref(self) -> None:
+        assert _is_catalog_ref("my-template") is False
+
+    def test_empty_string_is_not_ref(self) -> None:
+        assert _is_catalog_ref("") is False
+
+    def test_at_in_middle_is_not_ref(self) -> None:
+        assert _is_catalog_ref("user@example.com") is False
+
+    def test_dollar_prefix_is_not_ref(self) -> None:
+        assert _is_catalog_ref("${VAR}") is False
+
+
+class TestResolveRef:
+    def test_strips_at_prefix(self) -> None:
+        assert _resolve_ref("@my-template") == "my-template"
+
+    def test_at_only_returns_empty(self) -> None:
+        assert _resolve_ref("@") == ""
+
+    def test_preserves_rest_of_string(self) -> None:
+        assert _resolve_ref("@nested/path/id") == "nested/path/id"


### PR DESCRIPTION
## Summary

- Add error models (`CatalogValidationError`, `EntryNotFoundError`) for catalog business rule validation
- Add catalog `@`-reference utilities (`_is_catalog_ref`, `_resolve_ref`) for template resolution
- Add `resolve_env_vars()` for runtime `${VAR}` pattern substitution
- Add `_extract_config_type()` for extracting generic config types from agent class hierarchy
- Add optional dependency extras: `api` (fastapi, uvicorn), `cli` (typer, rich), `mongo` (pymongo)
- Align ruff lint rules with workspace config (adds UP, ANN, ASYNC rule sets)
- 33 tests passing with 98% branch coverage

Closes #1