### PR TITLE
TemplateEntry and ToolEntry Models

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -2,9 +2,13 @@
 
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
 
 __all__ = [
     "CatalogValidationError",
     "EntryNotFoundError",
+    "TemplateEntry",
+    "ToolEntry",
     "resolve_env_vars",
 ]

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -2,9 +2,13 @@
 
 from akgentic.catalog.models.agent import _extract_config_type
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
 
 __all__ = [
     "CatalogValidationError",
     "EntryNotFoundError",
+    "TemplateEntry",
+    "ToolEntry",
     "_extract_config_type",
 ]

--- a/src/akgentic/catalog/models/_types.py
+++ b/src/akgentic/catalog/models/_types.py
@@ -1,0 +1,9 @@
+"""Shared type aliases for catalog models."""
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+
+__all__ = ["NonEmptyStr"]

--- a/src/akgentic/catalog/models/template.py
+++ b/src/akgentic/catalog/models/template.py
@@ -1,11 +1,10 @@
 """TemplateEntry model for prompt template catalog entries."""
 
 from string import Formatter
-from typing import Annotated
 
-from pydantic import BaseModel, StringConstraints, computed_field
+from pydantic import BaseModel, computed_field
 
-NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+from akgentic.catalog.models._types import NonEmptyStr
 
 
 class TemplateEntry(BaseModel):

--- a/src/akgentic/catalog/models/template.py
+++ b/src/akgentic/catalog/models/template.py
@@ -1,0 +1,24 @@
+"""TemplateEntry model for prompt template catalog entries."""
+
+from string import Formatter
+from typing import Annotated
+
+from pydantic import BaseModel, StringConstraints, computed_field
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+
+
+class TemplateEntry(BaseModel):
+    """A prompt template catalog entry with unique id and placeholder parsing."""
+
+    id: NonEmptyStr
+    template: NonEmptyStr
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def placeholders(self) -> list[str]:
+        """Parse {placeholder} names from template string, sorted and deduplicated."""
+        return sorted({name for _, name, _, _ in Formatter().parse(self.template) if name})
+
+
+__all__ = ["TemplateEntry"]

--- a/src/akgentic/catalog/models/tool.py
+++ b/src/akgentic/catalog/models/tool.py
@@ -1,13 +1,12 @@
 """ToolEntry model for tool configuration catalog entries."""
 
-from typing import Annotated, Any
+from typing import Any
 
-from pydantic import BaseModel, StringConstraints, model_validator
+from pydantic import BaseModel, model_validator
 
+from akgentic.catalog.models._types import NonEmptyStr
 from akgentic.core.utils.deserializer import import_class
 from akgentic.tool import ToolCard
-
-NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
 
 
 class ToolEntry(BaseModel):

--- a/src/akgentic/catalog/models/tool.py
+++ b/src/akgentic/catalog/models/tool.py
@@ -1,0 +1,40 @@
+"""ToolEntry model for tool configuration catalog entries."""
+
+from typing import Annotated, Any
+
+from pydantic import BaseModel, StringConstraints, model_validator
+
+from akgentic.core.utils.deserializer import import_class
+from akgentic.tool import ToolCard
+
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
+
+
+class ToolEntry(BaseModel):
+    """A tool configuration catalog entry with dynamic class resolution."""
+
+    id: NonEmptyStr
+    tool_class: NonEmptyStr
+    tool: ToolCard
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_tool(cls, data: Any) -> Any:  # noqa: ANN401
+        """Resolve tool_class to concrete class and validate tool config."""
+        if not isinstance(data, dict):
+            return data
+        if isinstance(data.get("tool"), dict):
+            tool_class_path = data.get("tool_class")
+            if not isinstance(tool_class_path, str):
+                return data
+            try:
+                klass = import_class(tool_class_path)
+            except (ImportError, AttributeError) as e:
+                raise ValueError(
+                    f"Cannot resolve tool_class '{tool_class_path}': {e}"
+                ) from e
+            data["tool"] = klass.model_validate(data["tool"])
+        return data
+
+
+__all__ = ["ToolEntry"]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,7 +1,5 @@
 """Tests for environment variable substitution utility."""
 
-import os
-
 import pytest
 
 from akgentic.catalog.env import resolve_env_vars

--- a/tests/test_extract_config_type.py
+++ b/tests/test_extract_config_type.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
-
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState

--- a/tests/test_template_entry.py
+++ b/tests/test_template_entry.py
@@ -1,0 +1,54 @@
+"""Tests for TemplateEntry model."""
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.catalog.models.template import TemplateEntry
+
+
+class TestTemplateEntryValid:
+    """Tests for valid TemplateEntry creation."""
+
+    def test_valid_id_and_template(self) -> None:
+        entry = TemplateEntry(id="coordinator-v1", template="You are {role} for {team}.")
+        assert entry.id == "coordinator-v1"
+        assert entry.template == "You are {role} for {team}."
+
+    def test_placeholders_sorted_unique(self) -> None:
+        entry = TemplateEntry(
+            id="test",
+            template="You are {role} for the {team} team. {instructions}",
+        )
+        assert entry.placeholders == ["instructions", "role", "team"]
+
+    def test_placeholders_no_placeholders(self) -> None:
+        entry = TemplateEntry(id="static", template="Hello world")
+        assert entry.placeholders == []
+
+    def test_placeholders_duplicate_names(self) -> None:
+        entry = TemplateEntry(
+            id="dup",
+            template="{role} does {task} and {role} does {task} again",
+        )
+        assert entry.placeholders == ["role", "task"]
+
+    def test_placeholders_single(self) -> None:
+        entry = TemplateEntry(id="single", template="Hello {name}!")
+        assert entry.placeholders == ["name"]
+
+    def test_placeholders_in_model_dump(self) -> None:
+        entry = TemplateEntry(id="test", template="{a} and {b}")
+        dump = entry.model_dump()
+        assert dump["placeholders"] == ["a", "b"]
+
+
+class TestTemplateEntryInvalid:
+    """Tests for TemplateEntry validation errors."""
+
+    def test_empty_id_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            TemplateEntry(id="", template="some template")
+
+    def test_empty_template_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            TemplateEntry(id="valid-id", template="")

--- a/tests/test_tool_entry.py
+++ b/tests/test_tool_entry.py
@@ -75,6 +75,33 @@ class TestToolEntryInvalid:
                 tool={"name": "x", "description": "x"},
             )
 
+    def test_empty_tool_class_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolEntry(
+                id="valid",
+                tool_class="",
+                tool={"name": "x", "description": "x"},
+            )
+
+    def test_non_dict_data_passes_through(self) -> None:
+        from akgentic.tool.search.search import SearchTool
+
+        tool_instance = SearchTool(name="search", description="test")
+        entry = ToolEntry.model_validate(
+            ToolEntry(
+                id="s",
+                tool_class="akgentic.tool.search.search.SearchTool",
+                tool=tool_instance,
+            )
+        )
+        assert entry.id == "s"
+
+    def test_non_string_tool_class_skips_resolution(self) -> None:
+        with pytest.raises((ValidationError, TypeError)):
+            ToolEntry.model_validate(
+                {"id": "x", "tool_class": 123, "tool": {"name": "x", "description": "x"}}
+            )
+
     def test_unresolvable_attribute_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
             ToolEntry(

--- a/tests/test_tool_entry.py
+++ b/tests/test_tool_entry.py
@@ -1,0 +1,86 @@
+"""Tests for ToolEntry model."""
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.catalog.models.tool import ToolEntry
+
+
+class TestToolEntryValid:
+    """Tests for valid ToolEntry creation."""
+
+    def test_valid_search_tool(self) -> None:
+        entry = ToolEntry(
+            id="search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={"name": "Web Search", "description": "Search the web"},
+        )
+        assert entry.id == "search"
+        assert entry.tool_class == "akgentic.tool.search.search.SearchTool"
+        assert entry.tool.name == "Web Search"
+
+    def test_tool_validated_against_resolved_class(self) -> None:
+        entry = ToolEntry(
+            id="search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Custom Search",
+                "description": "Custom",
+                "web_search": False,
+            },
+        )
+        from akgentic.tool.search.search import SearchTool
+
+        assert isinstance(entry.tool, SearchTool)
+        assert entry.tool.web_search is False
+
+    def test_planning_tool(self) -> None:
+        entry = ToolEntry(
+            id="planner",
+            tool_class="akgentic.tool.planning.planning.PlanningTool",
+            tool={"name": "Planning", "description": "Manage plans"},
+        )
+        from akgentic.tool.planning.planning import PlanningTool
+
+        assert isinstance(entry.tool, PlanningTool)
+
+    def test_tool_as_instance_skips_resolution(self) -> None:
+        from akgentic.tool.search.search import SearchTool
+
+        tool_instance = SearchTool(name="search", description="test")
+        entry = ToolEntry(
+            id="search", tool_class="akgentic.tool.search.search.SearchTool", tool=tool_instance
+        )
+        assert entry.tool is tool_instance
+
+
+class TestToolEntryInvalid:
+    """Tests for ToolEntry validation errors."""
+
+    def test_unresolvable_class_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ToolEntry(
+                id="bad",
+                tool_class="nonexistent.module.FakeClass",
+                tool={"name": "x", "description": "x"},
+            )
+        errors = exc_info.value.errors()
+        assert any("Cannot resolve tool_class" in str(e) for e in errors)
+
+    def test_empty_id_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolEntry(
+                id="",
+                tool_class="akgentic.tool.search.search.SearchTool",
+                tool={"name": "x", "description": "x"},
+            )
+
+    def test_unresolvable_attribute_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ToolEntry(
+                id="bad",
+                tool_class="akgentic.tool.NonExistentTool",
+                tool={"name": "x", "description": "x"},
+            )
+        errors = exc_info.value.errors()
+        assert any("Cannot resolve tool_class" in str(e) for e in errors)


### PR DESCRIPTION
## Summary

- Add `TemplateEntry` model with `@computed_field` placeholder parsing from template strings
- Add `ToolEntry` model with `@model_validator(mode="before")` for dynamic `tool_class` resolution
- Extract shared `NonEmptyStr` type alias to `models/_types.py`
- Wire exports through `models/__init__.py` and catalog `__init__.py`
- 51 tests passing, 95% branch coverage, ruff clean, mypy strict clean

Closes #3