### PR TITLE
TeamSpec and TeamMemberSpec models

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -3,6 +3,7 @@
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
@@ -10,6 +11,8 @@ __all__ = [
     "AgentEntry",
     "CatalogValidationError",
     "EntryNotFoundError",
+    "TeamMemberSpec",
+    "TeamSpec",
     "TemplateEntry",
     "ToolEntry",
     "resolve_env_vars",

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -2,6 +2,7 @@
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
@@ -9,6 +10,8 @@ __all__ = [
     "AgentEntry",
     "CatalogValidationError",
     "EntryNotFoundError",
+    "TeamMemberSpec",
+    "TeamSpec",
     "TemplateEntry",
     "ToolEntry",
 ]

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -62,9 +62,17 @@ class TeamSpec(BaseModel):
         resolved: list[type] = []
         for mt in self.message_types:
             try:
-                resolved.append(import_class(mt))
-            except (ImportError, AttributeError) as e:
+                cls = import_class(mt)
+            except (ImportError, AttributeError, ValueError) as e:
                 errors.append(f"Cannot resolve message_type '{mt}': {e}")
+                continue
+            if not isinstance(cls, type):
+                errors.append(
+                    f"Cannot resolve message_type '{mt}': "
+                    f"resolved to {type(cls).__name__}, not a class"
+                )
+                continue
+            resolved.append(cls)
         if errors:
             raise CatalogValidationError(errors)
         return resolved

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -1,0 +1,70 @@
+"""Team catalog entry models with hierarchical member trees."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+from akgentic.catalog.models._types import NonEmptyStr
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.core.utils.deserializer import import_class
+
+__all__ = [
+    "TeamMemberSpec",
+    "TeamSpec",
+]
+
+
+class _AgentCatalogProtocol(Protocol):
+    """Protocol for agent catalog lookup (duck-typed, Epic 3 not yet available)."""
+
+    def get(self, agent_id: str) -> Any:  # noqa: ANN401
+        """Return AgentEntry or None."""
+        ...
+
+
+class TeamMemberSpec(BaseModel):
+    """A member within a team hierarchy, supporting recursive nesting."""
+
+    agent_id: NonEmptyStr
+    headcount: int = Field(default=1, ge=1)
+    members: list[TeamMemberSpec] = []
+
+
+class TeamSpec(BaseModel):
+    """A team composition with entry point, message types, and member hierarchy."""
+
+    id: NonEmptyStr
+    name: NonEmptyStr
+    entry_point: NonEmptyStr
+    message_types: list[NonEmptyStr] = Field(min_length=1)
+    members: list[TeamMemberSpec] = Field(min_length=1)
+    profiles: list[str] = []
+    description: str = ""
+
+    def resolve_entry_point(self, agent_catalog: _AgentCatalogProtocol) -> AgentEntry:
+        """Resolve entry_point id to the full AgentEntry from the catalog."""
+        entry = agent_catalog.get(self.entry_point)
+        if entry is None:
+            raise CatalogValidationError(
+                [f"Entry point '{self.entry_point}' not found in catalog"]
+            )
+        return entry  # type: ignore[no-any-return]
+
+    def resolve_message_types(self) -> list[type]:
+        """Resolve message_type class paths to actual Python classes.
+
+        Collects ALL errors before raising, so users see every problem at once.
+        """
+        errors: list[str] = []
+        resolved: list[type] = []
+        for mt in self.message_types:
+            try:
+                resolved.append(import_class(mt))
+            except (ImportError, AttributeError) as e:
+                errors.append(f"Cannot resolve message_type '{mt}': {e}")
+        if errors:
+            raise CatalogValidationError(errors)
+        return resolved

--- a/tests/test_team_spec.py
+++ b/tests/test_team_spec.py
@@ -204,12 +204,13 @@ class TestResolveMessageTypes:
             id="team-1",
             name="Team",
             entry_point="ep",
-            message_types=["pydantic.BaseModel", "pydantic.Field"],
+            message_types=["pydantic.BaseModel", "pydantic.ValidationError"],
             members=[TeamMemberSpec(agent_id="a")],
         )
         result = team.resolve_message_types()
         assert len(result) == 2
         assert result[0] is BaseModel
+        assert result[1] is ValidationError
 
     def test_single_invalid_path_raises_catalog_validation_error(self) -> None:
         team = TeamSpec(
@@ -237,6 +238,31 @@ class TestResolveMessageTypes:
         assert len(exc_info.value.errors) == 2
         assert "bad.path.One" in exc_info.value.errors[0]
         assert "bad.path.Two" in exc_info.value.errors[1]
+
+    def test_dotless_path_raises_catalog_validation_error(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["nodotpath"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_message_types()
+        assert len(exc_info.value.errors) == 1
+        assert "nodotpath" in exc_info.value.errors[0]
+
+    def test_non_class_importable_raises_catalog_validation_error(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["pydantic.Field"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_message_types()
+        assert "not a class" in exc_info.value.errors[0]
 
     def test_mixed_valid_and_invalid_raises_only_for_invalid(self) -> None:
         team = TeamSpec(

--- a/tests/test_team_spec.py
+++ b/tests/test_team_spec.py
@@ -1,0 +1,269 @@
+"""Tests for TeamMemberSpec and TeamSpec models."""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+
+# --- Mock catalog helper ---
+
+
+class MockAgentCatalog:
+    """Simple catalog mock with .get() returning AgentEntry or None."""
+
+    def __init__(self, entries: dict[str, AgentEntry]) -> None:
+        self._entries = entries
+
+    def get(self, agent_id: str) -> AgentEntry | None:
+        return self._entries.get(agent_id)
+
+
+def _make_agent_entry(agent_id: str) -> AgentEntry:
+    """Create a minimal AgentEntry for testing."""
+    from akgentic.core.agent_card import AgentCard
+    from akgentic.core.agent_config import BaseConfig
+
+    return AgentEntry(
+        id=agent_id,
+        card=AgentCard(
+            role="test-role",
+            description="test",
+            skills=[],
+            agent_class="akgentic.core.agent.Akgent",
+            config=BaseConfig(),
+        ),
+    )
+
+
+# --- TeamMemberSpec tests ---
+
+
+class TestTeamMemberSpec:
+    """Tests for TeamMemberSpec model (AC #1)."""
+
+    def test_simple_member_with_default_headcount(self) -> None:
+        member = TeamMemberSpec(agent_id="engineer")
+        assert member.agent_id == "engineer"
+        assert member.headcount == 1
+        assert member.members == []
+
+    def test_explicit_headcount_greater_than_one(self) -> None:
+        member = TeamMemberSpec(agent_id="dev", headcount=3)
+        assert member.headcount == 3
+
+    def test_headcount_zero_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            TeamMemberSpec(agent_id="dev", headcount=0)
+
+    def test_negative_headcount_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            TeamMemberSpec(agent_id="dev", headcount=-1)
+
+    def test_nested_members_recursive_tree(self) -> None:
+        leaf = TeamMemberSpec(agent_id="junior-dev")
+        mid = TeamMemberSpec(agent_id="senior-dev", members=[leaf])
+        root = TeamMemberSpec(agent_id="eng-manager", members=[mid])
+
+        assert len(root.members) == 1
+        assert root.members[0].agent_id == "senior-dev"
+        assert len(root.members[0].members) == 1
+        assert root.members[0].members[0].agent_id == "junior-dev"
+
+    def test_empty_agent_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            TeamMemberSpec(agent_id="")
+
+
+# --- TeamSpec tests ---
+
+
+class TestTeamSpec:
+    """Tests for TeamSpec model (AC #2)."""
+
+    def _make_team_spec(self, **overrides: object) -> TeamSpec:
+        defaults: dict[str, object] = {
+            "id": "engineering",
+            "name": "Engineering Team",
+            "entry_point": "eng-manager",
+            "message_types": ["pydantic.BaseModel"],
+            "members": [TeamMemberSpec(agent_id="eng-manager")],
+        }
+        defaults.update(overrides)
+        return TeamSpec(**defaults)  # type: ignore[arg-type]
+
+    def test_valid_team_spec_all_required_fields(self) -> None:
+        team = self._make_team_spec()
+        assert team.id == "engineering"
+        assert team.name == "Engineering Team"
+        assert team.entry_point == "eng-manager"
+        assert team.message_types == ["pydantic.BaseModel"]
+        assert len(team.members) == 1
+
+    def test_defaults_profiles_empty_list(self) -> None:
+        team = self._make_team_spec()
+        assert team.profiles == []
+
+    def test_defaults_description_empty_string(self) -> None:
+        team = self._make_team_spec()
+        assert team.description == ""
+
+    def test_empty_id_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_team_spec(id="")
+
+    def test_empty_name_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_team_spec(name="")
+
+    def test_empty_entry_point_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_team_spec(entry_point="")
+
+    def test_empty_message_types_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_team_spec(message_types=[])
+
+    def test_empty_members_raises_validation_error(self) -> None:
+        with pytest.raises(ValidationError):
+            self._make_team_spec(members=[])
+
+    def test_deeply_nested_member_tree(self) -> None:
+        l3 = TeamMemberSpec(agent_id="intern")
+        l2 = TeamMemberSpec(agent_id="junior", members=[l3])
+        l1 = TeamMemberSpec(agent_id="senior", members=[l2])
+        l0 = TeamMemberSpec(agent_id="manager", members=[l1])
+
+        team = self._make_team_spec(members=[l0])
+        assert team.members[0].members[0].members[0].members[0].agent_id == "intern"
+
+    def test_profiles_accepts_strings(self) -> None:
+        team = self._make_team_spec(profiles=["extra-agent-1", "extra-agent-2"])
+        assert team.profiles == ["extra-agent-1", "extra-agent-2"]
+
+    def test_custom_description(self) -> None:
+        team = self._make_team_spec(description="A great team")
+        assert team.description == "A great team"
+
+
+# --- resolve_entry_point tests ---
+
+
+class TestResolveEntryPoint:
+    """Tests for TeamSpec.resolve_entry_point (AC #3)."""
+
+    def test_resolve_entry_point_returns_agent_entry(self) -> None:
+        agent = _make_agent_entry("eng-manager")
+        catalog = MockAgentCatalog({"eng-manager": agent})
+
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="eng-manager",
+            message_types=["pydantic.BaseModel"],
+            members=[TeamMemberSpec(agent_id="eng-manager")],
+        )
+        result = team.resolve_entry_point(catalog)
+        assert result is agent
+
+    def test_resolve_entry_point_raises_for_missing(self) -> None:
+        catalog = MockAgentCatalog({})
+
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="nonexistent",
+            message_types=["pydantic.BaseModel"],
+            members=[TeamMemberSpec(agent_id="eng-manager")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_entry_point(catalog)
+        assert "nonexistent" in exc_info.value.errors[0]
+
+
+# --- resolve_message_types tests ---
+
+
+class TestResolveMessageTypes:
+    """Tests for TeamSpec.resolve_message_types (AC #4)."""
+
+    def test_resolve_valid_class_path(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["pydantic.BaseModel"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        result = team.resolve_message_types()
+        assert result == [BaseModel]
+
+    def test_resolve_multiple_valid_paths(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["pydantic.BaseModel", "pydantic.Field"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        result = team.resolve_message_types()
+        assert len(result) == 2
+        assert result[0] is BaseModel
+
+    def test_single_invalid_path_raises_catalog_validation_error(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["nonexistent.module.FakeClass"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_message_types()
+        assert len(exc_info.value.errors) == 1
+        assert "nonexistent.module.FakeClass" in exc_info.value.errors[0]
+
+    def test_collects_all_errors_for_multiple_invalid_paths(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["bad.path.One", "bad.path.Two"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_message_types()
+        assert len(exc_info.value.errors) == 2
+        assert "bad.path.One" in exc_info.value.errors[0]
+        assert "bad.path.Two" in exc_info.value.errors[1]
+
+    def test_mixed_valid_and_invalid_raises_only_for_invalid(self) -> None:
+        team = TeamSpec(
+            id="team-1",
+            name="Team",
+            entry_point="ep",
+            message_types=["pydantic.BaseModel", "fake.module.Nope"],
+            members=[TeamMemberSpec(agent_id="a")],
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.resolve_message_types()
+        assert len(exc_info.value.errors) == 1
+        assert "fake.module.Nope" in exc_info.value.errors[0]
+
+
+# --- Public API export tests ---
+
+
+class TestPublicAPIExports:
+    """Tests for public API exports (AC #1, #2)."""
+
+    def test_team_member_spec_importable_from_catalog(self) -> None:
+        from akgentic.catalog import TeamMemberSpec as Imported
+
+        assert Imported is TeamMemberSpec
+
+    def test_team_spec_importable_from_catalog(self) -> None:
+        from akgentic.catalog import TeamSpec as Imported
+
+        assert Imported is TeamSpec


### PR DESCRIPTION
## Summary

- Implements `TeamMemberSpec` with recursive self-referential `members` field and `headcount >= 1` validation
- Implements `TeamSpec` with `resolve_entry_point()` and `resolve_message_types()` methods
- `resolve_message_types()` catches `ValueError` for malformed paths and validates resolved objects are actual classes
- 28 tests for team models, 104 total, 97.81% branch coverage

Closes #7