### PR TITLE
Abstract Repository Interfaces and Query Models

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -3,17 +3,32 @@
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
 from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import (
+    AgentCatalogRepository,
+    TeamCatalogRepository,
+    TemplateCatalogRepository,
+    ToolCatalogRepository,
+)
 
 __all__ = [
+    "AgentCatalogRepository",
     "AgentEntry",
+    "AgentQuery",
     "CatalogValidationError",
     "EntryNotFoundError",
+    "TeamCatalogRepository",
     "TeamMemberSpec",
+    "TeamQuery",
     "TeamSpec",
+    "TemplateCatalogRepository",
     "TemplateEntry",
+    "TemplateQuery",
+    "ToolCatalogRepository",
     "ToolEntry",
+    "ToolQuery",
     "resolve_env_vars",
 ]

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -2,16 +2,21 @@
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
 from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
 __all__ = [
     "AgentEntry",
+    "AgentQuery",
     "CatalogValidationError",
     "EntryNotFoundError",
     "TeamMemberSpec",
+    "TeamQuery",
     "TeamSpec",
     "TemplateEntry",
+    "TemplateQuery",
     "ToolEntry",
+    "ToolQuery",
 ]

--- a/src/akgentic/catalog/models/queries.py
+++ b/src/akgentic/catalog/models/queries.py
@@ -1,0 +1,52 @@
+"""Query models for catalog repository search operations."""
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "AgentQuery",
+    "TeamQuery",
+    "TemplateQuery",
+    "ToolQuery",
+]
+
+
+class TemplateQuery(BaseModel):
+    """Query model for filtering template entries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str | None = None
+    placeholder: str | None = None
+
+
+class ToolQuery(BaseModel):
+    """Query model for filtering tool entries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str | None = None
+    tool_class: str | None = None
+    name: str | None = None
+    description: str | None = None
+
+
+class AgentQuery(BaseModel):
+    """Query model for filtering agent entries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str | None = None
+    role: str | None = None
+    skills: list[str] | None = None
+    description: str | None = None
+
+
+class TeamQuery(BaseModel):
+    """Query model for filtering team specs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
+    agent_id: str | None = None

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -1,0 +1,15 @@
+"""Catalog repository interfaces."""
+
+from akgentic.catalog.repositories.base import (
+    AgentCatalogRepository,
+    TeamCatalogRepository,
+    TemplateCatalogRepository,
+    ToolCatalogRepository,
+)
+
+__all__ = [
+    "AgentCatalogRepository",
+    "TeamCatalogRepository",
+    "TemplateCatalogRepository",
+    "ToolCatalogRepository",
+]

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -1,0 +1,107 @@
+"""Abstract base classes for catalog repositories."""
+
+import builtins
+from abc import ABC, abstractmethod
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
+from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
+
+__all__ = [
+    "AgentCatalogRepository",
+    "TeamCatalogRepository",
+    "TemplateCatalogRepository",
+    "ToolCatalogRepository",
+]
+
+_list = builtins.list
+
+
+class TemplateCatalogRepository(ABC):
+    """Abstract repository for template catalog entries."""
+
+    @abstractmethod
+    def create(self, template_entry: TemplateEntry) -> str: ...
+
+    @abstractmethod
+    def get(self, id: str) -> TemplateEntry | None: ...
+
+    @abstractmethod
+    def list(self) -> _list[TemplateEntry]: ...
+
+    @abstractmethod
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]: ...
+
+    @abstractmethod
+    def update(self, id: str, template_entry: TemplateEntry) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...
+
+
+class ToolCatalogRepository(ABC):
+    """Abstract repository for tool catalog entries."""
+
+    @abstractmethod
+    def create(self, tool_entry: ToolEntry) -> str: ...
+
+    @abstractmethod
+    def get(self, id: str) -> ToolEntry | None: ...
+
+    @abstractmethod
+    def list(self) -> _list[ToolEntry]: ...
+
+    @abstractmethod
+    def search(self, query: ToolQuery) -> _list[ToolEntry]: ...
+
+    @abstractmethod
+    def update(self, id: str, tool_entry: ToolEntry) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...
+
+
+class AgentCatalogRepository(ABC):
+    """Abstract repository for agent catalog entries."""
+
+    @abstractmethod
+    def create(self, agent_entry: AgentEntry) -> str: ...
+
+    @abstractmethod
+    def get(self, id: str) -> AgentEntry | None: ...
+
+    @abstractmethod
+    def list(self) -> _list[AgentEntry]: ...
+
+    @abstractmethod
+    def search(self, query: AgentQuery) -> _list[AgentEntry]: ...
+
+    @abstractmethod
+    def update(self, id: str, agent_entry: AgentEntry) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...
+
+
+class TeamCatalogRepository(ABC):
+    """Abstract repository for team catalog entries."""
+
+    @abstractmethod
+    def create(self, team_spec: TeamSpec) -> str: ...
+
+    @abstractmethod
+    def get(self, id: str) -> TeamSpec | None: ...
+
+    @abstractmethod
+    def list(self) -> _list[TeamSpec]: ...
+
+    @abstractmethod
+    def search(self, query: TeamQuery) -> _list[TeamSpec]: ...
+
+    @abstractmethod
+    def update(self, id: str, team_spec: TeamSpec) -> None: ...
+
+    @abstractmethod
+    def delete(self, id: str) -> None: ...

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,95 @@
+"""Tests for query models."""
+
+from akgentic.catalog.models.queries import (
+    AgentQuery,
+    TeamQuery,
+    TemplateQuery,
+    ToolQuery,
+)
+
+
+class TestTemplateQuery:
+    """Tests for TemplateQuery model."""
+
+    def test_default_all_none(self) -> None:
+        query = TemplateQuery()
+        assert query.id is None
+        assert query.placeholder is None
+
+    def test_single_field(self) -> None:
+        query = TemplateQuery(id="foo")
+        assert query.id == "foo"
+        assert query.placeholder is None
+
+    def test_multiple_fields(self) -> None:
+        query = TemplateQuery(id="foo", placeholder="role")
+        assert query.id == "foo"
+        assert query.placeholder == "role"
+
+
+class TestToolQuery:
+    """Tests for ToolQuery model."""
+
+    def test_default_all_none(self) -> None:
+        query = ToolQuery()
+        assert query.id is None
+        assert query.tool_class is None
+        assert query.name is None
+        assert query.description is None
+
+    def test_multiple_fields(self) -> None:
+        query = ToolQuery(tool_class="akgentic.tool.SearchTool", name="search")
+        assert query.tool_class == "akgentic.tool.SearchTool"
+        assert query.name == "search"
+        assert query.id is None
+        assert query.description is None
+
+
+class TestAgentQuery:
+    """Tests for AgentQuery model."""
+
+    def test_default_all_none(self) -> None:
+        query = AgentQuery()
+        assert query.id is None
+        assert query.role is None
+        assert query.skills is None
+        assert query.description is None
+
+    def test_list_field(self) -> None:
+        query = AgentQuery(skills=["research", "writing"])
+        assert query.skills == ["research", "writing"]
+        assert query.id is None
+        assert query.role is None
+        assert query.description is None
+
+    def test_multiple_fields_including_list(self) -> None:
+        query = AgentQuery(role="Manager", skills=["coordination"])
+        assert query.role == "Manager"
+        assert query.skills == ["coordination"]
+        assert query.id is None
+        assert query.description is None
+
+
+class TestTeamQuery:
+    """Tests for TeamQuery model."""
+
+    def test_default_all_none(self) -> None:
+        query = TeamQuery()
+        assert query.id is None
+        assert query.name is None
+        assert query.description is None
+        assert query.agent_id is None
+
+    def test_agent_id_filter(self) -> None:
+        query = TeamQuery(agent_id="eng-manager")
+        assert query.agent_id == "eng-manager"
+        assert query.id is None
+        assert query.name is None
+        assert query.description is None
+
+    def test_multiple_fields(self) -> None:
+        query = TeamQuery(name="Engineering", agent_id="eng-manager")
+        assert query.name == "Engineering"
+        assert query.agent_id == "eng-manager"
+        assert query.id is None
+        assert query.description is None

--- a/tests/test_repositories_base.py
+++ b/tests/test_repositories_base.py
@@ -1,0 +1,284 @@
+"""Tests for abstract repository interfaces."""
+
+from __future__ import annotations
+
+import builtins
+import typing
+
+import pytest
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
+from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import (
+    AgentCatalogRepository,
+    TeamCatalogRepository,
+    TemplateCatalogRepository,
+    ToolCatalogRepository,
+)
+
+# --- Concrete test implementations ---
+
+
+class ConcreteTemplateRepo(TemplateCatalogRepository):
+    def create(self, template_entry: TemplateEntry) -> str:
+        return template_entry.id
+
+    def get(self, id: str) -> TemplateEntry | None:
+        return None
+
+    def list(self) -> list[TemplateEntry]:
+        return []
+
+    def search(self, query: TemplateQuery) -> list[TemplateEntry]:
+        return []
+
+    def update(self, id: str, template_entry: TemplateEntry) -> None:
+        return None
+
+    def delete(self, id: str) -> None:
+        return None
+
+
+class ConcreteToolRepo(ToolCatalogRepository):
+    def create(self, tool_entry: ToolEntry) -> str:
+        return tool_entry.id
+
+    def get(self, id: str) -> ToolEntry | None:
+        return None
+
+    def list(self) -> list[ToolEntry]:
+        return []
+
+    def search(self, query: ToolQuery) -> list[ToolEntry]:
+        return []
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        return None
+
+    def delete(self, id: str) -> None:
+        return None
+
+
+class ConcreteAgentRepo(AgentCatalogRepository):
+    def create(self, agent_entry: AgentEntry) -> str:
+        return agent_entry.id
+
+    def get(self, id: str) -> AgentEntry | None:
+        return None
+
+    def list(self) -> list[AgentEntry]:
+        return []
+
+    def search(self, query: AgentQuery) -> list[AgentEntry]:
+        return []
+
+    def update(self, id: str, agent_entry: AgentEntry) -> None:
+        return None
+
+    def delete(self, id: str) -> None:
+        return None
+
+
+class ConcreteTeamRepo(TeamCatalogRepository):
+    def create(self, team_spec: TeamSpec) -> str:
+        return team_spec.id
+
+    def get(self, id: str) -> TeamSpec | None:
+        return None
+
+    def list(self) -> list[TeamSpec]:
+        return []
+
+    def search(self, query: TeamQuery) -> list[TeamSpec]:
+        return []
+
+    def update(self, id: str, team_spec: TeamSpec) -> None:
+        return None
+
+    def delete(self, id: str) -> None:
+        return None
+
+
+# --- Partial implementations for negative tests ---
+
+
+class PartialTemplateRepo(TemplateCatalogRepository):  # type: ignore[abstract]
+    def create(self, template_entry: TemplateEntry) -> str:
+        return template_entry.id
+
+
+class PartialToolRepo(ToolCatalogRepository):  # type: ignore[abstract]
+    def create(self, tool_entry: ToolEntry) -> str:
+        return tool_entry.id
+
+
+class PartialAgentRepo(AgentCatalogRepository):  # type: ignore[abstract]
+    def create(self, agent_entry: AgentEntry) -> str:
+        return agent_entry.id
+
+
+class PartialTeamRepo(TeamCatalogRepository):  # type: ignore[abstract]
+    def create(self, team_spec: TeamSpec) -> str:
+        return team_spec.id
+
+
+# --- Tests ---
+
+
+class TestTemplateCatalogRepository:
+    """Tests for TemplateCatalogRepository ABC."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            TemplateCatalogRepository()  # type: ignore[abstract]
+
+    def test_concrete_subclass_can_instantiate(self) -> None:
+        repo = ConcreteTemplateRepo()
+        assert isinstance(repo, TemplateCatalogRepository)
+
+    def test_partial_subclass_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            PartialTemplateRepo()
+
+    def test_method_signatures(self) -> None:
+        hints = typing.get_type_hints(TemplateCatalogRepository.create)
+        assert hints["return"] is str
+
+        hints = typing.get_type_hints(TemplateCatalogRepository.get)
+        assert hints["return"] == TemplateEntry | None
+
+        hints = typing.get_type_hints(TemplateCatalogRepository.list)
+        assert hints["return"] == builtins.list[TemplateEntry]
+
+        hints = typing.get_type_hints(TemplateCatalogRepository.search)
+        assert hints["return"] == builtins.list[TemplateEntry]
+
+        hints = typing.get_type_hints(TemplateCatalogRepository.update)
+        assert hints["return"] is type(None)
+
+        hints = typing.get_type_hints(TemplateCatalogRepository.delete)
+        assert hints["return"] is type(None)
+
+
+class TestToolCatalogRepository:
+    """Tests for ToolCatalogRepository ABC."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            ToolCatalogRepository()  # type: ignore[abstract]
+
+    def test_concrete_subclass_can_instantiate(self) -> None:
+        repo = ConcreteToolRepo()
+        assert isinstance(repo, ToolCatalogRepository)
+
+    def test_partial_subclass_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            PartialToolRepo()
+
+
+class TestAgentCatalogRepository:
+    """Tests for AgentCatalogRepository ABC."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            AgentCatalogRepository()  # type: ignore[abstract]
+
+    def test_concrete_subclass_can_instantiate(self) -> None:
+        repo = ConcreteAgentRepo()
+        assert isinstance(repo, AgentCatalogRepository)
+
+    def test_partial_subclass_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            PartialAgentRepo()
+
+
+class TestTeamCatalogRepository:
+    """Tests for TeamCatalogRepository ABC."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            TeamCatalogRepository()  # type: ignore[abstract]
+
+    def test_concrete_subclass_can_instantiate(self) -> None:
+        repo = ConcreteTeamRepo()
+        assert isinstance(repo, TeamCatalogRepository)
+
+    def test_partial_subclass_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            PartialTeamRepo()
+
+
+class TestMethodSignatures:
+    """Test that method signatures match expected types across all repositories."""
+
+    def _hints(self, cls: type, method: str) -> dict[str, type]:
+        return typing.get_type_hints(getattr(cls, method))
+
+    def test_tool_repo_signatures(self) -> None:
+        assert self._hints(ToolCatalogRepository, "create")["return"] is str
+        assert self._hints(ToolCatalogRepository, "get")["return"] == ToolEntry | None
+        assert self._hints(ToolCatalogRepository, "list")["return"] == builtins.list[ToolEntry]
+        assert self._hints(ToolCatalogRepository, "search")["return"] == builtins.list[ToolEntry]
+        assert self._hints(ToolCatalogRepository, "update")["return"] is type(None)
+        assert self._hints(ToolCatalogRepository, "delete")["return"] is type(None)
+
+    def test_agent_repo_signatures(self) -> None:
+        assert self._hints(AgentCatalogRepository, "create")["return"] is str
+        assert self._hints(AgentCatalogRepository, "get")["return"] == AgentEntry | None
+        assert self._hints(AgentCatalogRepository, "list")["return"] == builtins.list[AgentEntry]
+        assert self._hints(AgentCatalogRepository, "search")["return"] == builtins.list[AgentEntry]
+        assert self._hints(AgentCatalogRepository, "update")["return"] is type(None)
+        assert self._hints(AgentCatalogRepository, "delete")["return"] is type(None)
+
+    def test_team_repo_signatures(self) -> None:
+        assert self._hints(TeamCatalogRepository, "create")["return"] is str
+        assert self._hints(TeamCatalogRepository, "get")["return"] == TeamSpec | None
+        assert self._hints(TeamCatalogRepository, "list")["return"] == builtins.list[TeamSpec]
+        assert self._hints(TeamCatalogRepository, "search")["return"] == builtins.list[TeamSpec]
+        assert self._hints(TeamCatalogRepository, "update")["return"] is type(None)
+        assert self._hints(TeamCatalogRepository, "delete")["return"] is type(None)
+
+
+class TestPublicAPIExports:
+    """Test that all query models and repository ABCs are importable from akgentic.catalog."""
+
+    def test_query_models_importable_from_catalog(self) -> None:
+        from akgentic.catalog import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
+
+        assert AgentQuery is not None
+        assert TeamQuery is not None
+        assert TemplateQuery is not None
+        assert ToolQuery is not None
+
+    def test_repository_abcs_importable_from_catalog(self) -> None:
+        from akgentic.catalog import (
+            AgentCatalogRepository,
+            TeamCatalogRepository,
+            TemplateCatalogRepository,
+            ToolCatalogRepository,
+        )
+
+        assert AgentCatalogRepository is not None
+        assert TeamCatalogRepository is not None
+        assert TemplateCatalogRepository is not None
+        assert ToolCatalogRepository is not None
+
+    def test_query_models_in_catalog_all(self) -> None:
+        import akgentic.catalog
+
+        for name in ["TemplateQuery", "ToolQuery", "AgentQuery", "TeamQuery"]:
+            assert name in akgentic.catalog.__all__
+
+    def test_repository_abcs_in_catalog_all(self) -> None:
+        import akgentic.catalog
+
+        for name in [
+            "TemplateCatalogRepository",
+            "ToolCatalogRepository",
+            "AgentCatalogRepository",
+            "TeamCatalogRepository",
+        ]:
+            assert name in akgentic.catalog.__all__


### PR DESCRIPTION
## Summary

- Implements 4 query models (`TemplateQuery`, `ToolQuery`, `AgentQuery`, `TeamQuery`) with typed optional fields and `frozen=True` for immutability
- Implements 4 abstract repository classes (`TemplateCatalogRepository`, `ToolCatalogRepository`, `AgentCatalogRepository`, `TeamCatalogRepository`) with full CRUD + search contract
- Wires all exports through `models/__init__.py`, `repositories/__init__.py`, and `catalog/__init__.py`
- 135 tests pass, 98.15% branch coverage, ruff clean, mypy strict clean

Closes #9