### PR TITLE
YAML Repository for Templates and Tools

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -13,6 +13,8 @@ from akgentic.catalog.repositories.base import (
     TemplateCatalogRepository,
     ToolCatalogRepository,
 )
+from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
+from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
 
 __all__ = [
     "AgentCatalogRepository",
@@ -30,5 +32,7 @@ __all__ = [
     "ToolCatalogRepository",
     "ToolEntry",
     "ToolQuery",
+    "YamlTemplateCatalogRepository",
+    "YamlToolCatalogRepository",
     "resolve_env_vars",
 ]

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -6,10 +6,14 @@ from akgentic.catalog.repositories.base import (
     TemplateCatalogRepository,
     ToolCatalogRepository,
 )
+from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
+from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
 
 __all__ = [
     "AgentCatalogRepository",
     "TeamCatalogRepository",
     "TemplateCatalogRepository",
     "ToolCatalogRepository",
+    "YamlTemplateCatalogRepository",
+    "YamlToolCatalogRepository",
 ]

--- a/src/akgentic/catalog/repositories/yaml/__init__.py
+++ b/src/akgentic/catalog/repositories/yaml/__init__.py
@@ -1,0 +1,9 @@
+"""YAML-backed catalog repositories."""
+
+from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
+from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+
+__all__ = [
+    "YamlTemplateCatalogRepository",
+    "YamlToolCatalogRepository",
+]

--- a/src/akgentic/catalog/repositories/yaml/_base.py
+++ b/src/akgentic/catalog/repositories/yaml/_base.py
@@ -88,18 +88,27 @@ class YamlRepositoryBase[T: BaseModel]:
     def create(self, entry: T) -> str:
         """Persist a new entry to a YAML file and invalidate cache."""
         entry_id: str = getattr(entry, "id")
+
+        # Pre-check: reject duplicate IDs across all existing files
+        existing = self._ensure_loaded()
+        for e in existing:
+            if getattr(e, "id") == entry_id:
+                raise CatalogValidationError(
+                    [f"Entry with id '{entry_id}' already exists in the catalog"]
+                )
+
         file_path = self._catalog_dir / f"{entry_id}.yaml"
         self._catalog_dir.mkdir(parents=True, exist_ok=True)
 
-        data = [entry.model_dump()]
+        data: _list[dict[str, object]] = [entry.model_dump()]
         if file_path.exists():
-            existing = yaml.safe_load(file_path.read_text(encoding="utf-8"))
-            if existing is None:
-                existing = []
-            if not isinstance(existing, builtins.list):
-                existing = [existing]
-            existing.append(entry.model_dump())
-            data = existing
+            file_data = yaml.safe_load(file_path.read_text(encoding="utf-8"))
+            if file_data is None:
+                file_data = []
+            if not isinstance(file_data, builtins.list):
+                file_data = [file_data]
+            file_data.append(entry.model_dump())
+            data = file_data
 
         file_path.write_text(
             yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),

--- a/src/akgentic/catalog/repositories/yaml/_base.py
+++ b/src/akgentic/catalog/repositories/yaml/_base.py
@@ -1,0 +1,160 @@
+"""Shared base for YAML-backed catalog repositories."""
+
+import builtins
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+_list = builtins.list
+
+
+class YamlRepositoryBase[T: BaseModel]:
+    """Generic base providing YAML file loading, caching, duplicate detection, and CRUD.
+
+    Subclasses must set ``_entry_type`` to the concrete Pydantic model class.
+    """
+
+    _entry_type: type[T]
+
+    def __init__(self, catalog_dir: Path) -> None:
+        self._catalog_dir = catalog_dir
+        self._entries: _list[T] | None = None
+
+    # ------------------------------------------------------------------
+    # Loading & caching
+    # ------------------------------------------------------------------
+
+    def _load_all(self) -> _list[T]:
+        """Scan catalog_dir for *.yaml files, validate entries, detect duplicates."""
+        entries: _list[T] = []
+        seen_ids: dict[str, Path] = {}
+
+        if not self._catalog_dir.exists():
+            return entries
+
+        for yaml_path in sorted(self._catalog_dir.glob("*.yaml")):
+            raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            if raw is None:
+                continue
+            if not isinstance(raw, builtins.list):
+                raw = [raw]
+            for item in raw:
+                entry = self._entry_type.model_validate(item)
+                entry_id: str = getattr(entry, "id")
+                if entry_id in seen_ids:
+                    raise CatalogValidationError(
+                        [
+                            f"Duplicate id '{entry_id}' found in "
+                            f"'{seen_ids[entry_id]}' and '{yaml_path}'"
+                        ]
+                    )
+                seen_ids[entry_id] = yaml_path
+                entries.append(entry)
+
+        return entries
+
+    def _ensure_loaded(self) -> _list[T]:
+        """Return cached entries, loading from disk on first access."""
+        if self._entries is None:
+            self._entries = self._load_all()
+        return self._entries
+
+    def reload(self) -> None:
+        """Force a re-scan from disk on next access."""
+        self._entries = None
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def get(self, id: str) -> T | None:
+        """Return entry by id, or None if not found."""
+        for entry in self._ensure_loaded():
+            if getattr(entry, "id") == id:
+                return entry
+        return None
+
+    def list(self) -> _list[T]:
+        """Return all cached entries."""
+        return _list(self._ensure_loaded())
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    def create(self, entry: T) -> str:
+        """Persist a new entry to a YAML file and invalidate cache."""
+        entry_id: str = getattr(entry, "id")
+        file_path = self._catalog_dir / f"{entry_id}.yaml"
+        self._catalog_dir.mkdir(parents=True, exist_ok=True)
+
+        data = [entry.model_dump()]
+        if file_path.exists():
+            existing = yaml.safe_load(file_path.read_text(encoding="utf-8"))
+            if existing is None:
+                existing = []
+            if not isinstance(existing, builtins.list):
+                existing = [existing]
+            existing.append(entry.model_dump())
+            data = existing
+
+        file_path.write_text(
+            yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        self._entries = None
+        return entry_id
+
+    def update(self, id: str, entry: T) -> None:
+        """Find file containing id, update entry in place, invalidate cache."""
+        for yaml_path in sorted(self._catalog_dir.glob("*.yaml")):
+            raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            if raw is None:
+                continue
+            if not isinstance(raw, builtins.list):
+                raw = [raw]
+            for i, item in enumerate(raw):
+                if item.get("id") == id:
+                    raw[i] = entry.model_dump()
+                    yaml_path.write_text(
+                        yaml.dump(
+                            raw,
+                            default_flow_style=False,
+                            sort_keys=False,
+                            allow_unicode=True,
+                        ),
+                        encoding="utf-8",
+                    )
+                    self._entries = None
+                    return
+        raise EntryNotFoundError(f"Entry with id '{id}' not found")
+
+    def delete(self, id: str) -> None:
+        """Find file containing id, remove entry, delete file if empty, invalidate cache."""
+        for yaml_path in sorted(self._catalog_dir.glob("*.yaml")):
+            raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            if raw is None:
+                continue
+            if not isinstance(raw, builtins.list):
+                raw = [raw]
+            for i, item in enumerate(raw):
+                if item.get("id") == id:
+                    raw.pop(i)
+                    if raw:
+                        yaml_path.write_text(
+                            yaml.dump(
+                                raw,
+                                default_flow_style=False,
+                                sort_keys=False,
+                                allow_unicode=True,
+                            ),
+                            encoding="utf-8",
+                        )
+                    else:
+                        yaml_path.unlink()
+                    self._entries = None
+                    return
+        raise EntryNotFoundError(f"Entry with id '{id}' not found")

--- a/src/akgentic/catalog/repositories/yaml/template_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/template_repo.py
@@ -1,0 +1,46 @@
+"""YAML-backed repository for template catalog entries."""
+
+import builtins
+from pathlib import Path
+
+from akgentic.catalog.models.queries import TemplateQuery
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.base import TemplateCatalogRepository
+from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+_list = builtins.list
+
+
+class YamlTemplateCatalogRepository(TemplateCatalogRepository, YamlRepositoryBase[TemplateEntry]):
+    """YAML directory-backed template catalog repository."""
+
+    _entry_type = TemplateEntry
+
+    def __init__(self, catalog_dir: Path) -> None:
+        YamlRepositoryBase.__init__(self, catalog_dir)
+
+    def create(self, template_entry: TemplateEntry) -> str:
+        return YamlRepositoryBase.create(self, template_entry)
+
+    def get(self, id: str) -> TemplateEntry | None:
+        return YamlRepositoryBase.get(self, id)
+
+    def list(self) -> _list[TemplateEntry]:
+        return YamlRepositoryBase.list(self)
+
+    def update(self, id: str, template_entry: TemplateEntry) -> None:
+        YamlRepositoryBase.update(self, id, template_entry)
+
+    def delete(self, id: str) -> None:
+        YamlRepositoryBase.delete(self, id)
+
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
+        """Filter templates: AND all non-None fields."""
+        results: _list[TemplateEntry] = []
+        for entry in self._ensure_loaded():
+            if query.id is not None and entry.id != query.id:
+                continue
+            if query.placeholder is not None and query.placeholder not in entry.placeholders:
+                continue
+            results.append(entry)
+        return results

--- a/src/akgentic/catalog/repositories/yaml/tool_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/tool_repo.py
@@ -1,0 +1,53 @@
+"""YAML-backed repository for tool catalog entries."""
+
+import builtins
+from pathlib import Path
+
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
+from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+_list = builtins.list
+
+
+class YamlToolCatalogRepository(ToolCatalogRepository, YamlRepositoryBase[ToolEntry]):
+    """YAML directory-backed tool catalog repository."""
+
+    _entry_type = ToolEntry
+
+    def __init__(self, catalog_dir: Path) -> None:
+        YamlRepositoryBase.__init__(self, catalog_dir)
+
+    def create(self, tool_entry: ToolEntry) -> str:
+        return YamlRepositoryBase.create(self, tool_entry)
+
+    def get(self, id: str) -> ToolEntry | None:
+        return YamlRepositoryBase.get(self, id)
+
+    def list(self) -> _list[ToolEntry]:
+        return YamlRepositoryBase.list(self)
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        YamlRepositoryBase.update(self, id, tool_entry)
+
+    def delete(self, id: str) -> None:
+        YamlRepositoryBase.delete(self, id)
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        """Filter tools: AND all non-None fields."""
+        results: _list[ToolEntry] = []
+        for entry in self._ensure_loaded():
+            if query.id is not None and entry.id != query.id:
+                continue
+            if query.tool_class is not None and entry.tool_class != query.tool_class:
+                continue
+            if query.name is not None and query.name.lower() not in entry.tool.name.lower():
+                continue
+            if (
+                query.description is not None
+                and query.description.lower() not in entry.tool.description.lower()
+            ):
+                continue
+            results.append(entry)
+        return results

--- a/tests/test_yaml_template_repo.py
+++ b/tests/test_yaml_template_repo.py
@@ -1,0 +1,307 @@
+"""Tests for YamlTemplateCatalogRepository."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TemplateQuery
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
+
+
+def _write_yaml(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+# ---- Loading ----
+
+
+def test_load_single_yaml_file(tmp_path: Path) -> None:
+    """AC #1: Load entries from a single YAML file containing list of dicts."""
+    _write_yaml(
+        tmp_path / "templates.yaml",
+        [
+            {"id": "t1", "template": "Hello {name}"},
+            {"id": "t2", "template": "Bye {name}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 2
+    assert all(isinstance(e, TemplateEntry) for e in entries)
+
+
+def test_load_multiple_yaml_files(tmp_path: Path) -> None:
+    """AC #1: Multiple YAML files merged into single registry."""
+    _write_yaml(tmp_path / "coordinator.yaml", [{"id": "c1", "template": "Coord {role}"}])
+    _write_yaml(tmp_path / "specialist.yaml", [{"id": "s1", "template": "Spec {skill}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 2
+    ids = {e.id for e in entries}
+    assert ids == {"c1", "s1"}
+
+
+def test_duplicate_id_across_files_raises(tmp_path: Path) -> None:
+    """AC #2: Duplicate id across files raises CatalogValidationError with file paths."""
+    _write_yaml(tmp_path / "file_a.yaml", [{"id": "dup", "template": "A {x}"}])
+    _write_yaml(tmp_path / "file_b.yaml", [{"id": "dup", "template": "B {y}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.list()
+    assert "dup" in str(exc_info.value)
+    assert "file_a.yaml" in str(exc_info.value)
+    assert "file_b.yaml" in str(exc_info.value)
+
+
+def test_empty_directory(tmp_path: Path) -> None:
+    """Edge case: empty directory returns empty list."""
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    assert repo.list() == []
+
+
+def test_nonexistent_directory(tmp_path: Path) -> None:
+    """Edge case: nonexistent directory returns empty list."""
+    repo = YamlTemplateCatalogRepository(tmp_path / "nonexistent")
+    assert repo.list() == []
+
+
+def test_empty_yaml_file(tmp_path: Path) -> None:
+    """Edge case: YAML file with None content (empty file) is skipped."""
+    (tmp_path / "empty.yaml").write_text("", encoding="utf-8")
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    assert repo.list() == []
+
+
+# ---- get() ----
+
+
+def test_get_returns_entry_by_id(tmp_path: Path) -> None:
+    """AC #4: get() returns entry by id."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {name}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entry = repo.get("t1")
+    assert entry is not None
+    assert entry.id == "t1"
+
+
+def test_get_returns_none_for_missing(tmp_path: Path) -> None:
+    """get() returns None for non-existent id."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {name}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    assert repo.get("missing") is None
+
+
+# ---- list() ----
+
+
+def test_list_returns_all_entries(tmp_path: Path) -> None:
+    """list() returns all cached entries."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "a", "template": "A {x}"},
+            {"id": "b", "template": "B {y}"},
+            {"id": "c", "template": "C {z}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    assert len(repo.list()) == 3
+
+
+# ---- search() ----
+
+
+def test_search_by_placeholder(tmp_path: Path) -> None:
+    """AC #5: search(TemplateQuery(placeholder='role')) returns only matching templates."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "t1", "template": "Hello {role} and {name}"},
+            {"id": "t2", "template": "Only {name} here"},
+            {"id": "t3", "template": "Agent {role}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    results = repo.search(TemplateQuery(placeholder="role"))
+    assert len(results) == 2
+    ids = {e.id for e in results}
+    assert ids == {"t1", "t3"}
+
+
+def test_search_by_id(tmp_path: Path) -> None:
+    """search(TemplateQuery(id='foo')) exact id match."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "foo", "template": "Foo {x}"},
+            {"id": "bar", "template": "Bar {y}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    results = repo.search(TemplateQuery(id="foo"))
+    assert len(results) == 1
+    assert results[0].id == "foo"
+
+
+def test_search_and_semantics(tmp_path: Path) -> None:
+    """search(TemplateQuery(id='foo', placeholder='role')) AND semantics."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "foo", "template": "Foo {role}"},
+            {"id": "bar", "template": "Bar {role}"},
+            {"id": "foo2", "template": "Foo2 {name}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    results = repo.search(TemplateQuery(id="foo", placeholder="role"))
+    assert len(results) == 1
+    assert results[0].id == "foo"
+
+
+def test_search_no_filters_returns_all(tmp_path: Path) -> None:
+    """search with all None fields returns all entries."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "a", "template": "A {x}"},
+            {"id": "b", "template": "B {y}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    results = repo.search(TemplateQuery())
+    assert len(results) == 2
+
+
+# ---- Caching ----
+
+
+def test_caching_no_reread(tmp_path: Path) -> None:
+    """AC #4: second list() doesn't re-read files."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {name}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entries1 = repo.list()
+    assert len(entries1) == 1
+
+    # Modify file on disk
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "t1", "template": "Hello {name}"},
+            {"id": "t2", "template": "New {item}"},
+        ],
+    )
+    # Cache should return stale data
+    entries2 = repo.list()
+    assert len(entries2) == 1
+
+
+def test_reload_forces_rescan(tmp_path: Path) -> None:
+    """AC #4: reload() forces re-scan from disk."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {name}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    # Modify file on disk
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [
+            {"id": "t1", "template": "Hello {name}"},
+            {"id": "t2", "template": "New {item}"},
+        ],
+    )
+    repo.reload()
+    assert len(repo.list()) == 2
+
+
+# ---- create() ----
+
+
+def test_create_persists_entry(tmp_path: Path) -> None:
+    """AC #3: create() persists entry to YAML file."""
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entry = TemplateEntry(id="new-t", template="New {placeholder}")
+    result_id = repo.create(entry)
+    assert result_id == "new-t"
+
+    # Verify persisted on disk
+    repo2 = YamlTemplateCatalogRepository(tmp_path)
+    loaded = repo2.get("new-t")
+    assert loaded is not None
+    assert loaded.template == "New {placeholder}"
+
+
+# ---- update() ----
+
+
+def test_update_modifies_entry(tmp_path: Path) -> None:
+    """AC #3: update() modifies entry in file."""
+    _write_yaml(tmp_path / "t1.yaml", [{"id": "t1", "template": "Old {x}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    updated = TemplateEntry(id="t1", template="Updated {y}")
+    repo.update("t1", updated)
+
+    entry = repo.get("t1")
+    assert entry is not None
+    assert entry.template == "Updated {y}"
+
+
+def test_update_raises_for_missing_id(tmp_path: Path) -> None:
+    """update() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {x}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    with pytest.raises(EntryNotFoundError):
+        repo.update("nonexistent", TemplateEntry(id="nonexistent", template="T {x}"))
+
+
+# ---- delete() ----
+
+
+def test_delete_removes_entry_and_deletes_file_if_empty(tmp_path: Path) -> None:
+    """AC #3: delete() removes entry, deletes file if empty."""
+    _write_yaml(tmp_path / "t1.yaml", [{"id": "t1", "template": "Hello {x}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    repo.delete("t1")
+    assert repo.get("t1") is None
+    assert not (tmp_path / "t1.yaml").exists()
+
+
+def test_delete_keeps_file_with_remaining_entries(tmp_path: Path) -> None:
+    """delete() removes entry but keeps file if other entries remain."""
+    _write_yaml(
+        tmp_path / "multi.yaml",
+        [
+            {"id": "a", "template": "A {x}"},
+            {"id": "b", "template": "B {y}"},
+        ],
+    )
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    repo.delete("a")
+    assert repo.get("a") is None
+    assert repo.get("b") is not None
+    assert (tmp_path / "multi.yaml").exists()
+
+
+def test_delete_raises_for_missing_id(tmp_path: Path) -> None:
+    """delete() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [{"id": "t1", "template": "Hello {x}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    with pytest.raises(EntryNotFoundError):
+        repo.delete("nonexistent")
+
+
+# ---- Public API export ----
+
+
+def test_public_api_export() -> None:
+    """YamlTemplateCatalogRepository is importable from public API."""
+    from akgentic.catalog import YamlTemplateCatalogRepository as Exported
+
+    assert Exported is YamlTemplateCatalogRepository

--- a/tests/test_yaml_template_repo.py
+++ b/tests/test_yaml_template_repo.py
@@ -79,6 +79,15 @@ def test_empty_yaml_file(tmp_path: Path) -> None:
     assert repo.list() == []
 
 
+def test_single_dict_yaml_normalized_to_list(tmp_path: Path) -> None:
+    """Edge case: YAML file with single dict (not list) is normalized."""
+    _write_yaml(tmp_path / "single.yaml", {"id": "solo", "template": "Solo {x}"})
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 1
+    assert entries[0].id == "solo"
+
+
 # ---- get() ----
 
 
@@ -238,6 +247,30 @@ def test_create_persists_entry(tmp_path: Path) -> None:
     assert loaded.template == "New {placeholder}"
 
 
+def test_create_appends_to_existing_file(tmp_path: Path) -> None:
+    """create() appends to existing {id}.yaml file if it already exists."""
+    target = tmp_path / "shared.yaml"
+    _write_yaml(target, [{"id": "shared", "template": "First {x}"}])
+    # create() writes to {id}.yaml — create an entry whose id matches the file
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    entry = TemplateEntry(id="new-entry", template="Second {y}")
+    repo.create(entry)
+
+    # The new entry should be in its own file
+    repo2 = YamlTemplateCatalogRepository(tmp_path)
+    assert repo2.get("shared") is not None
+    assert repo2.get("new-entry") is not None
+
+
+def test_create_duplicate_id_raises(tmp_path: Path) -> None:
+    """create() raises CatalogValidationError if id already exists."""
+    _write_yaml(tmp_path / "existing.yaml", [{"id": "dup", "template": "T {x}"}])
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.create(TemplateEntry(id="dup", template="New {y}"))
+    assert "dup" in str(exc_info.value)
+
+
 # ---- update() ----
 
 
@@ -251,6 +284,16 @@ def test_update_modifies_entry(tmp_path: Path) -> None:
     entry = repo.get("t1")
     assert entry is not None
     assert entry.template == "Updated {y}"
+
+
+def test_update_single_dict_yaml(tmp_path: Path) -> None:
+    """update() handles YAML file containing a single dict (not a list)."""
+    _write_yaml(tmp_path / "solo.yaml", {"id": "solo", "template": "Old {x}"})
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    repo.update("solo", TemplateEntry(id="solo", template="New {y}"))
+    entry = repo.get("solo")
+    assert entry is not None
+    assert entry.template == "New {y}"
 
 
 def test_update_raises_for_missing_id(tmp_path: Path) -> None:
@@ -287,6 +330,15 @@ def test_delete_keeps_file_with_remaining_entries(tmp_path: Path) -> None:
     assert repo.get("a") is None
     assert repo.get("b") is not None
     assert (tmp_path / "multi.yaml").exists()
+
+
+def test_delete_single_dict_yaml(tmp_path: Path) -> None:
+    """delete() handles YAML file containing a single dict (not a list)."""
+    _write_yaml(tmp_path / "solo.yaml", {"id": "solo", "template": "T {x}"})
+    repo = YamlTemplateCatalogRepository(tmp_path)
+    repo.delete("solo")
+    assert repo.get("solo") is None
+    assert not (tmp_path / "solo.yaml").exists()
 
 
 def test_delete_raises_for_missing_id(tmp_path: Path) -> None:

--- a/tests/test_yaml_tool_repo.py
+++ b/tests/test_yaml_tool_repo.py
@@ -151,6 +151,27 @@ def test_create_tool_entry(tmp_path: Path) -> None:
     assert loaded.tool.name == "new-search"
 
 
+def test_create_duplicate_id_raises(tmp_path: Path) -> None:
+    """create() raises CatalogValidationError if id already exists."""
+    _write_yaml(tmp_path / "existing.yaml", [_tool_dict("dup")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    entry = ToolEntry.model_validate(_tool_dict("dup"))
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.create(entry)
+    assert "dup" in str(exc_info.value)
+
+
+def test_search_by_description_case_insensitive(tmp_path: Path) -> None:
+    """Description search is case-insensitive."""
+    _write_yaml(
+        tmp_path / "tools.yaml",
+        [_tool_dict("s1", description="Searches The WEB")],
+    )
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery(description="the web"))
+    assert len(results) == 1
+
+
 def test_update_tool_entry(tmp_path: Path) -> None:
     """AC #3: update() modifies entry in file."""
     _write_yaml(tmp_path / "t1.yaml", [_tool_dict("t1", name="old-name")])

--- a/tests/test_yaml_tool_repo.py
+++ b/tests/test_yaml_tool_repo.py
@@ -1,0 +1,219 @@
+"""Tests for YamlToolCatalogRepository."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+
+SEARCH_TOOL_CLASS = "akgentic.tool.search.search.SearchTool"
+
+
+def _tool_dict(
+    id: str,
+    *,
+    name: str = "test-tool",
+    description: str = "A test tool",
+    tool_class: str = SEARCH_TOOL_CLASS,
+) -> dict[str, object]:
+    return {
+        "id": id,
+        "tool_class": tool_class,
+        "tool": {"name": name, "description": description},
+    }
+
+
+def _write_yaml(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+# ---- Loading ----
+
+
+def test_load_tool_entry_from_yaml(tmp_path: Path) -> None:
+    """AC #1: Load ToolEntry from YAML with tool_class resolution."""
+    _write_yaml(
+        tmp_path / "tools.yaml",
+        [_tool_dict("s1", name="search", description="Web search tool")],
+    )
+    repo = YamlToolCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 1
+    assert isinstance(entries[0], ToolEntry)
+    assert entries[0].tool.name == "search"
+
+
+def test_duplicate_id_detection(tmp_path: Path) -> None:
+    """AC #2: Duplicate id across files raises CatalogValidationError."""
+    _write_yaml(tmp_path / "a.yaml", [_tool_dict("dup")])
+    _write_yaml(tmp_path / "b.yaml", [_tool_dict("dup")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.list()
+    assert "dup" in str(exc_info.value)
+    assert "a.yaml" in str(exc_info.value)
+    assert "b.yaml" in str(exc_info.value)
+
+
+# ---- search() ----
+
+
+def test_search_by_tool_class(tmp_path: Path) -> None:
+    """AC #5: search(ToolQuery(tool_class=...)) exact match."""
+    _write_yaml(
+        tmp_path / "tools.yaml",
+        [
+            _tool_dict("s1", tool_class=SEARCH_TOOL_CLASS),
+            _tool_dict(
+                "p1",
+                tool_class="akgentic.tool.planning.planning.PlanningTool",
+                name="planner",
+                description="Planning tool",
+            ),
+        ],
+    )
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery(tool_class=SEARCH_TOOL_CLASS))
+    assert len(results) == 1
+    assert results[0].id == "s1"
+
+
+def test_search_by_name_substring(tmp_path: Path) -> None:
+    """AC #5: search(ToolQuery(name='search')) substring match on tool.name."""
+    _write_yaml(
+        tmp_path / "tools.yaml",
+        [
+            _tool_dict("s1", name="web-search"),
+            _tool_dict("s2", name="planner"),
+        ],
+    )
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery(name="search"))
+    assert len(results) == 1
+    assert results[0].id == "s1"
+
+
+def test_search_by_name_case_insensitive(tmp_path: Path) -> None:
+    """Name search is case-insensitive."""
+    _write_yaml(tmp_path / "tools.yaml", [_tool_dict("s1", name="WebSearch")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery(name="websearch"))
+    assert len(results) == 1
+
+
+def test_search_by_description_substring(tmp_path: Path) -> None:
+    """search by description substring match."""
+    _write_yaml(
+        tmp_path / "tools.yaml",
+        [
+            _tool_dict("s1", description="Searches the web for information"),
+            _tool_dict("s2", description="Plans agent tasks"),
+        ],
+    )
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery(description="web"))
+    assert len(results) == 1
+    assert results[0].id == "s1"
+
+
+def test_search_no_filters_returns_all(tmp_path: Path) -> None:
+    """search with no filters returns all entries."""
+    _write_yaml(tmp_path / "tools.yaml", [_tool_dict("s1"), _tool_dict("s2", name="other")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    results = repo.search(ToolQuery())
+    assert len(results) == 2
+
+
+# ---- CRUD ----
+
+
+def test_create_tool_entry(tmp_path: Path) -> None:
+    """AC #3: create() persists entry to YAML."""
+    repo = YamlToolCatalogRepository(tmp_path)
+    entry = ToolEntry.model_validate(
+        _tool_dict("new-tool", name="new-search", description="A new search tool")
+    )
+    result_id = repo.create(entry)
+    assert result_id == "new-tool"
+
+    # Verify via fresh repo
+    repo2 = YamlToolCatalogRepository(tmp_path)
+    loaded = repo2.get("new-tool")
+    assert loaded is not None
+    assert loaded.tool.name == "new-search"
+
+
+def test_update_tool_entry(tmp_path: Path) -> None:
+    """AC #3: update() modifies entry in file."""
+    _write_yaml(tmp_path / "t1.yaml", [_tool_dict("t1", name="old-name")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    updated = ToolEntry.model_validate(
+        _tool_dict("t1", name="new-name", description="Updated tool")
+    )
+    repo.update("t1", updated)
+
+    entry = repo.get("t1")
+    assert entry is not None
+    assert entry.tool.name == "new-name"
+
+
+def test_update_raises_for_missing_id(tmp_path: Path) -> None:
+    """update() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [_tool_dict("t1")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    entry = ToolEntry.model_validate(_tool_dict("missing"))
+    with pytest.raises(EntryNotFoundError):
+        repo.update("missing", entry)
+
+
+def test_delete_tool_entry(tmp_path: Path) -> None:
+    """AC #3: delete() removes entry, deletes file if empty."""
+    _write_yaml(tmp_path / "t1.yaml", [_tool_dict("t1")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    repo.delete("t1")
+    assert repo.get("t1") is None
+    assert not (tmp_path / "t1.yaml").exists()
+
+
+def test_delete_raises_for_missing_id(tmp_path: Path) -> None:
+    """delete() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [_tool_dict("t1")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    with pytest.raises(EntryNotFoundError):
+        repo.delete("nonexistent")
+
+
+# ---- Caching ----
+
+
+def test_caching_and_reload(tmp_path: Path) -> None:
+    """AC #4: Caching and reload behavior."""
+    _write_yaml(tmp_path / "t.yaml", [_tool_dict("t1")])
+    repo = YamlToolCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    # Modify on disk — cache is stale
+    _write_yaml(tmp_path / "t.yaml", [_tool_dict("t1"), _tool_dict("t2", name="second")])
+    assert len(repo.list()) == 1  # still cached
+
+    # Reload forces re-read
+    repo.reload()
+    assert len(repo.list()) == 2
+
+
+# ---- Public API export ----
+
+
+def test_public_api_export() -> None:
+    """YamlToolCatalogRepository is importable from public API."""
+    from akgentic.catalog import YamlToolCatalogRepository as Exported
+
+    assert Exported is YamlToolCatalogRepository


### PR DESCRIPTION
## Summary
- Implements `YamlTemplateCatalogRepository` and `YamlToolCatalogRepository` with shared `YamlRepositoryBase[T]` generic base class
- Supports multi-file YAML directory loading, lazy caching, duplicate ID detection, and full CRUD operations
- Search supports AND semantics with exact match (`id`, `tool_class`) and case-insensitive substring match (`name`, `description`)
- Code review fix: added duplicate ID pre-check in `create()` to prevent data corruption

## Changes
- **New**: `repositories/yaml/_base.py` — generic base with YAML loading, caching, CRUD
- **New**: `repositories/yaml/template_repo.py` — template catalog YAML repository
- **New**: `repositories/yaml/tool_repo.py` — tool catalog YAML repository
- **Modified**: `repositories/__init__.py`, `catalog/__init__.py` — export wiring
- **New**: `tests/test_yaml_template_repo.py` (27 tests), `tests/test_yaml_tool_repo.py` (16 tests)
- 178 total tests passing, 95% branch coverage, ruff + mypy clean

Closes #11