### PR TITLE
YAML Repository for Agents and Teams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "mypy>=1.8.0",
     "ruff>=0.1.0",
+    "types-PyYAML>=6.0",
 ]
 
 [build-system]

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -13,6 +13,8 @@ from akgentic.catalog.repositories.base import (
     TemplateCatalogRepository,
     ToolCatalogRepository,
 )
+from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
+from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
 
@@ -32,6 +34,8 @@ __all__ = [
     "ToolCatalogRepository",
     "ToolEntry",
     "ToolQuery",
+    "YamlAgentCatalogRepository",
+    "YamlTeamCatalogRepository",
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
     "resolve_env_vars",

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -6,6 +6,8 @@ from akgentic.catalog.repositories.base import (
     TemplateCatalogRepository,
     ToolCatalogRepository,
 )
+from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
+from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
 
@@ -14,6 +16,8 @@ __all__ = [
     "TeamCatalogRepository",
     "TemplateCatalogRepository",
     "ToolCatalogRepository",
+    "YamlAgentCatalogRepository",
+    "YamlTeamCatalogRepository",
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
 ]

--- a/src/akgentic/catalog/repositories/yaml/__init__.py
+++ b/src/akgentic/catalog/repositories/yaml/__init__.py
@@ -1,9 +1,13 @@
 """YAML-backed catalog repositories."""
 
+from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
+from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
 
 __all__ = [
+    "YamlAgentCatalogRepository",
+    "YamlTeamCatalogRepository",
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
 ]

--- a/src/akgentic/catalog/repositories/yaml/agent_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/agent_repo.py
@@ -1,0 +1,55 @@
+"""YAML-backed repository for agent catalog entries."""
+
+import builtins
+from pathlib import Path
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.queries import AgentQuery
+from akgentic.catalog.repositories.base import AgentCatalogRepository
+from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+_list = builtins.list
+
+
+class YamlAgentCatalogRepository(AgentCatalogRepository, YamlRepositoryBase[AgentEntry]):
+    """YAML directory-backed agent catalog repository."""
+
+    _entry_type = AgentEntry
+
+    def __init__(self, catalog_dir: Path) -> None:
+        YamlRepositoryBase.__init__(self, catalog_dir)
+
+    def create(self, agent_entry: AgentEntry) -> str:
+        return YamlRepositoryBase.create(self, agent_entry)
+
+    def get(self, id: str) -> AgentEntry | None:
+        return YamlRepositoryBase.get(self, id)
+
+    def list(self) -> _list[AgentEntry]:
+        return YamlRepositoryBase.list(self)
+
+    def update(self, id: str, agent_entry: AgentEntry) -> None:
+        YamlRepositoryBase.update(self, id, agent_entry)
+
+    def delete(self, id: str) -> None:
+        YamlRepositoryBase.delete(self, id)
+
+    def search(self, query: AgentQuery) -> _list[AgentEntry]:
+        """Filter agents: AND all non-None fields."""
+        results: _list[AgentEntry] = []
+        for entry in self._ensure_loaded():
+            if query.id is not None and entry.id != query.id:
+                continue
+            if query.role is not None and entry.card.role != query.role:
+                continue
+            if query.skills is not None and not (
+                set(query.skills) & set(entry.card.skills)
+            ):
+                continue
+            if (
+                query.description is not None
+                and query.description.lower() not in entry.card.description.lower()
+            ):
+                continue
+            results.append(entry)
+        return results

--- a/src/akgentic/catalog/repositories/yaml/team_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/team_repo.py
@@ -1,0 +1,65 @@
+"""YAML-backed repository for team catalog entries."""
+
+import builtins
+from pathlib import Path
+
+from akgentic.catalog.models.queries import TeamQuery
+from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.repositories.base import TeamCatalogRepository
+from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+_list = builtins.list
+
+
+def _agent_in_members(agent_id: str, members: _list[TeamMemberSpec]) -> bool:
+    """Recursively check if agent_id appears anywhere in the members tree."""
+    for member in members:
+        if member.agent_id == agent_id:
+            return True
+        if member.members and _agent_in_members(agent_id, member.members):
+            return True
+    return False
+
+
+class YamlTeamCatalogRepository(TeamCatalogRepository, YamlRepositoryBase[TeamSpec]):
+    """YAML directory-backed team catalog repository."""
+
+    _entry_type = TeamSpec
+
+    def __init__(self, catalog_dir: Path) -> None:
+        YamlRepositoryBase.__init__(self, catalog_dir)
+
+    def create(self, team_spec: TeamSpec) -> str:
+        return YamlRepositoryBase.create(self, team_spec)
+
+    def get(self, id: str) -> TeamSpec | None:
+        return YamlRepositoryBase.get(self, id)
+
+    def list(self) -> _list[TeamSpec]:
+        return YamlRepositoryBase.list(self)
+
+    def update(self, id: str, team_spec: TeamSpec) -> None:
+        YamlRepositoryBase.update(self, id, team_spec)
+
+    def delete(self, id: str) -> None:
+        YamlRepositoryBase.delete(self, id)
+
+    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+        """Filter teams: AND all non-None fields."""
+        results: _list[TeamSpec] = []
+        for entry in self._ensure_loaded():
+            if query.id is not None and entry.id != query.id:
+                continue
+            if query.name is not None and query.name.lower() not in entry.name.lower():
+                continue
+            if (
+                query.description is not None
+                and query.description.lower() not in entry.description.lower()
+            ):
+                continue
+            if query.agent_id is not None and not _agent_in_members(
+                query.agent_id, entry.members
+            ):
+                continue
+            results.append(entry)
+        return results

--- a/tests/test_yaml_agent_repo.py
+++ b/tests/test_yaml_agent_repo.py
@@ -86,6 +86,15 @@ def test_create_persists_agent(tmp_path: Path) -> None:
     assert loaded.card.role == "Tester"
 
 
+def test_create_duplicate_id_raises(tmp_path: Path) -> None:
+    """create() raises CatalogValidationError for duplicate id."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("dup")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    entry = AgentEntry.model_validate(_agent_dict("dup", role="Manager"))
+    with pytest.raises(CatalogValidationError):
+        repo.create(entry)
+
+
 def test_get_returns_entry_by_id(tmp_path: Path) -> None:
     """get() returns agent by id."""
     _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
@@ -162,6 +171,25 @@ def test_duplicate_id_across_files_raises(tmp_path: Path) -> None:
 
 
 # ---- search() (AC #3) ----
+
+
+def test_search_by_id(tmp_path: Path) -> None:
+    """search(AgentQuery(id='a1')) exact id match."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [_agent_dict("a1", role="Expert"), _agent_dict("a2", role="Manager")],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(id="a1"))
+    assert len(results) == 1
+    assert results[0].id == "a1"
+
+
+def test_search_by_id_no_match(tmp_path: Path) -> None:
+    """search(AgentQuery(id='missing')) returns empty."""
+    _write_yaml(tmp_path / "agents.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    assert repo.search(AgentQuery(id="missing")) == []
 
 
 def test_search_by_role(tmp_path: Path) -> None:

--- a/tests/test_yaml_agent_repo.py
+++ b/tests/test_yaml_agent_repo.py
@@ -1,0 +1,278 @@
+"""Tests for YamlAgentCatalogRepository."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery
+from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
+
+AGENT_CLASS = "akgentic.agent.BaseAgent"
+
+
+def _agent_dict(
+    id: str,
+    *,
+    role: str = "Expert",
+    description: str = "A test agent",
+    skills: list[str] | None = None,
+) -> dict[str, object]:
+    if skills is None:
+        skills = ["testing"]
+    return {
+        "id": id,
+        "tool_ids": [],
+        "card": {
+            "role": role,
+            "description": description,
+            "skills": skills,
+            "agent_class": AGENT_CLASS,
+            "config": {
+                "name": f"@{role}",
+                "role": role,
+                "prompt": {"template": f"You are a {role}.", "params": {}},
+                "model_cfg": {
+                    "provider": "openai",
+                    "model": "gpt-4",
+                    "temperature": 0.3,
+                },
+            },
+            "routes_to": [],
+        },
+    }
+
+
+def _write_yaml(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+# ---- Loading (AC #1) ----
+
+
+def test_load_agent_entry_from_yaml(tmp_path: Path) -> None:
+    """AC #1: Load AgentEntry from YAML with agent_class resolution."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [_agent_dict("mgr", role="Manager", description="Coordinates team work")],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 1
+    assert isinstance(entries[0], AgentEntry)
+    assert entries[0].card.role == "Manager"
+
+
+# ---- CRUD (AC #1) ----
+
+
+def test_create_persists_agent(tmp_path: Path) -> None:
+    """AC #1: create() persists agent entry to YAML file."""
+    repo = YamlAgentCatalogRepository(tmp_path)
+    data = _agent_dict("new-agent", role="Tester")
+    entry = AgentEntry.model_validate(data)
+    result_id = repo.create(entry)
+    assert result_id == "new-agent"
+
+    repo2 = YamlAgentCatalogRepository(tmp_path)
+    loaded = repo2.get("new-agent")
+    assert loaded is not None
+    assert loaded.card.role == "Tester"
+
+
+def test_get_returns_entry_by_id(tmp_path: Path) -> None:
+    """get() returns agent by id."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    entry = repo.get("a1")
+    assert entry is not None
+    assert entry.id == "a1"
+
+
+def test_get_returns_none_for_missing(tmp_path: Path) -> None:
+    """get() returns None for non-existent id."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    assert repo.get("missing") is None
+
+
+def test_list_returns_all_entries(tmp_path: Path) -> None:
+    """list() returns all cached entries."""
+    _write_yaml(
+        tmp_path / "a.yaml",
+        [_agent_dict("a1"), _agent_dict("a2", role="Manager")],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    assert len(repo.list()) == 2
+
+
+def test_update_modifies_agent(tmp_path: Path) -> None:
+    """update() modifies agent entry in file."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1", role="Expert")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    updated = AgentEntry.model_validate(_agent_dict("a1", role="Manager"))
+    repo.update("a1", updated)
+    entry = repo.get("a1")
+    assert entry is not None
+    assert entry.card.role == "Manager"
+
+
+def test_update_raises_for_missing_id(tmp_path: Path) -> None:
+    """update() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    entry = AgentEntry.model_validate(_agent_dict("nope"))
+    with pytest.raises(EntryNotFoundError):
+        repo.update("nope", entry)
+
+
+def test_delete_removes_agent(tmp_path: Path) -> None:
+    """delete() removes agent entry and deletes file if empty."""
+    _write_yaml(tmp_path / "a1.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    repo.delete("a1")
+    assert repo.get("a1") is None
+    assert not (tmp_path / "a1.yaml").exists()
+
+
+def test_delete_raises_for_missing_id(tmp_path: Path) -> None:
+    """delete() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    with pytest.raises(EntryNotFoundError):
+        repo.delete("nonexistent")
+
+
+def test_duplicate_id_across_files_raises(tmp_path: Path) -> None:
+    """Duplicate id across files raises CatalogValidationError."""
+    _write_yaml(tmp_path / "file_a.yaml", [_agent_dict("dup")])
+    _write_yaml(tmp_path / "file_b.yaml", [_agent_dict("dup", role="Manager")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.list()
+    assert "dup" in str(exc_info.value)
+    assert "file_a.yaml" in str(exc_info.value)
+    assert "file_b.yaml" in str(exc_info.value)
+
+
+# ---- search() (AC #3) ----
+
+
+def test_search_by_role(tmp_path: Path) -> None:
+    """AC #3: search(AgentQuery(role='Manager')) exact role match."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [
+            _agent_dict("m1", role="Manager", description="Coordinates team work"),
+            _agent_dict("e1", role="Expert", description="Domain expert"),
+        ],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(role="Manager"))
+    assert len(results) == 1
+    assert results[0].id == "m1"
+
+
+def test_search_by_skills_match_any(tmp_path: Path) -> None:
+    """AC #3: search(AgentQuery(skills=['research'])) match-any semantics."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [
+            _agent_dict("a1", skills=["research", "writing"]),
+            _agent_dict("a2", skills=["coding"]),
+        ],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(skills=["research"]))
+    assert len(results) == 1
+    assert results[0].id == "a1"
+
+
+def test_search_by_skills_no_match(tmp_path: Path) -> None:
+    """search(AgentQuery(skills=['unknown'])) returns empty when no match."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [_agent_dict("a1", skills=["research", "writing"])],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(skills=["unknown"]))
+    assert results == []
+
+
+def test_search_by_description(tmp_path: Path) -> None:
+    """search(AgentQuery(description='coord')) case-insensitive substring match."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [
+            _agent_dict("m1", description="Coordinates team work"),
+            _agent_dict("e1", description="Domain expert"),
+        ],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(description="coord"))
+    assert len(results) == 1
+    assert results[0].id == "m1"
+
+
+def test_search_and_semantics(tmp_path: Path) -> None:
+    """search(AgentQuery(role='Manager', description='coord')) AND semantics."""
+    _write_yaml(
+        tmp_path / "agents.yaml",
+        [
+            _agent_dict("m1", role="Manager", description="Coordinates team work"),
+            _agent_dict("m2", role="Manager", description="Manages budget"),
+            _agent_dict("e1", role="Expert", description="Coordinates research"),
+        ],
+    )
+    repo = YamlAgentCatalogRepository(tmp_path)
+    results = repo.search(AgentQuery(role="Manager", description="coord"))
+    assert len(results) == 1
+    assert results[0].id == "m1"
+
+
+# ---- Caching ----
+
+
+def test_caching_no_reread(tmp_path: Path) -> None:
+    """Second list() call doesn't re-read files."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    # Modify file on disk
+    _write_yaml(
+        tmp_path / "a.yaml",
+        [_agent_dict("a1"), _agent_dict("a2", role="Manager")],
+    )
+    # Cache should return stale data
+    assert len(repo.list()) == 1
+
+
+def test_reload_forces_rescan(tmp_path: Path) -> None:
+    """reload() forces re-scan from disk."""
+    _write_yaml(tmp_path / "a.yaml", [_agent_dict("a1")])
+    repo = YamlAgentCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    _write_yaml(
+        tmp_path / "a.yaml",
+        [_agent_dict("a1"), _agent_dict("a2", role="Manager")],
+    )
+    repo.reload()
+    assert len(repo.list()) == 2
+
+
+# ---- Public API export ----
+
+
+def test_public_api_export() -> None:
+    """YamlAgentCatalogRepository is importable from public API."""
+    from akgentic.catalog import YamlAgentCatalogRepository as Exported
+
+    assert Exported is YamlAgentCatalogRepository

--- a/tests/test_yaml_team_repo.py
+++ b/tests/test_yaml_team_repo.py
@@ -1,0 +1,294 @@
+"""Tests for YamlTeamCatalogRepository."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TeamQuery
+from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
+
+
+def _team_dict(
+    id: str,
+    *,
+    name: str = "Test Team",
+    description: str = "A test team",
+    entry_point: str = "test-manager",
+    members: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    if members is None:
+        members = [{"agent_id": "test-manager", "headcount": 1}]
+    return {
+        "id": id,
+        "name": name,
+        "description": description,
+        "entry_point": entry_point,
+        "message_types": ["akgentic.agent.AgentMessage"],
+        "members": members,
+        "profiles": [],
+    }
+
+
+def _write_yaml(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+# ---- Loading (AC #2) ----
+
+
+def test_load_team_spec_from_yaml(tmp_path: Path) -> None:
+    """AC #2: Load TeamSpec from YAML with recursive TeamMemberSpec trees."""
+    members = [
+        {
+            "agent_id": "eng-manager",
+            "headcount": 1,
+            "members": [
+                {"agent_id": "eng-assistant", "headcount": 2},
+            ],
+        },
+    ]
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [_team_dict("eng-team", name="Engineering", members=members)],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    entries = repo.list()
+    assert len(entries) == 1
+    assert isinstance(entries[0], TeamSpec)
+    assert entries[0].members[0].agent_id == "eng-manager"
+    assert entries[0].members[0].members[0].agent_id == "eng-assistant"
+
+
+# ---- CRUD (AC #2) ----
+
+
+def test_create_persists_team(tmp_path: Path) -> None:
+    """AC #2: create() persists team spec to YAML file."""
+    repo = YamlTeamCatalogRepository(tmp_path)
+    data = _team_dict("new-team", name="New Team")
+    entry = TeamSpec.model_validate(data)
+    result_id = repo.create(entry)
+    assert result_id == "new-team"
+
+    repo2 = YamlTeamCatalogRepository(tmp_path)
+    loaded = repo2.get("new-team")
+    assert loaded is not None
+    assert loaded.name == "New Team"
+
+
+def test_get_returns_team_by_id(tmp_path: Path) -> None:
+    """get() returns team by id."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    entry = repo.get("t1")
+    assert entry is not None
+    assert entry.id == "t1"
+
+
+def test_get_returns_none_for_missing(tmp_path: Path) -> None:
+    """get() returns None for non-existent id."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    assert repo.get("missing") is None
+
+
+def test_list_returns_all_entries(tmp_path: Path) -> None:
+    """list() returns all cached entries."""
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [_team_dict("t1"), _team_dict("t2", name="Second Team")],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    assert len(repo.list()) == 2
+
+
+def test_update_modifies_team(tmp_path: Path) -> None:
+    """update() modifies team spec in file."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1", name="Old Name")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    updated = TeamSpec.model_validate(_team_dict("t1", name="New Name"))
+    repo.update("t1", updated)
+    entry = repo.get("t1")
+    assert entry is not None
+    assert entry.name == "New Name"
+
+
+def test_update_raises_for_missing_id(tmp_path: Path) -> None:
+    """update() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    entry = TeamSpec.model_validate(_team_dict("nope"))
+    with pytest.raises(EntryNotFoundError):
+        repo.update("nope", entry)
+
+
+def test_delete_removes_team(tmp_path: Path) -> None:
+    """delete() removes team spec and deletes file if empty."""
+    _write_yaml(tmp_path / "t1.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    repo.delete("t1")
+    assert repo.get("t1") is None
+    assert not (tmp_path / "t1.yaml").exists()
+
+
+def test_delete_raises_for_missing_id(tmp_path: Path) -> None:
+    """delete() raises EntryNotFoundError for missing id."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    with pytest.raises(EntryNotFoundError):
+        repo.delete("nonexistent")
+
+
+def test_duplicate_id_across_files_raises(tmp_path: Path) -> None:
+    """Duplicate id across files raises CatalogValidationError."""
+    _write_yaml(tmp_path / "file_a.yaml", [_team_dict("dup")])
+    _write_yaml(tmp_path / "file_b.yaml", [_team_dict("dup", name="Another")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    with pytest.raises(CatalogValidationError) as exc_info:
+        repo.list()
+    assert "dup" in str(exc_info.value)
+    assert "file_a.yaml" in str(exc_info.value)
+    assert "file_b.yaml" in str(exc_info.value)
+
+
+# ---- search() (AC #4) ----
+
+
+def test_search_by_name(tmp_path: Path) -> None:
+    """AC #4: search(TeamQuery(name='engineering')) case-insensitive substring."""
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [
+            _team_dict("eng", name="Engineering Team"),
+            _team_dict("mkt", name="Marketing Team"),
+        ],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(name="engineering"))
+    assert len(results) == 1
+    assert results[0].id == "eng"
+
+
+def test_search_by_agent_id_root_member(tmp_path: Path) -> None:
+    """AC #4: search(TeamQuery(agent_id='eng-manager')) finds team where agent is root member."""
+    members = [{"agent_id": "eng-manager", "headcount": 1}]
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [_team_dict("eng", name="Engineering", members=members)],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(agent_id="eng-manager"))
+    assert len(results) == 1
+    assert results[0].id == "eng"
+
+
+def test_search_by_agent_id_nested_child(tmp_path: Path) -> None:
+    """AC #4: search(TeamQuery(agent_id='eng-assistant')) finds team where agent is nested."""
+    members = [
+        {
+            "agent_id": "eng-manager",
+            "headcount": 1,
+            "members": [
+                {"agent_id": "eng-assistant", "headcount": 2},
+            ],
+        },
+    ]
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [_team_dict("eng", name="Engineering", members=members)],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(agent_id="eng-assistant"))
+    assert len(results) == 1
+    assert results[0].id == "eng"
+
+
+def test_search_by_agent_id_not_found(tmp_path: Path) -> None:
+    """search(TeamQuery(agent_id='nonexistent')) returns empty."""
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [_team_dict("eng", name="Engineering")],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(agent_id="nonexistent"))
+    assert results == []
+
+
+def test_search_and_semantics(tmp_path: Path) -> None:
+    """search(TeamQuery(name='eng', agent_id='eng-manager')) AND semantics."""
+    members_eng = [{"agent_id": "eng-manager", "headcount": 1}]
+    members_mkt = [{"agent_id": "eng-manager", "headcount": 1}]
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [
+            _team_dict("eng", name="Engineering Team", members=members_eng),
+            _team_dict("mkt", name="Marketing Team", members=members_mkt),
+        ],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    # Both teams have eng-manager, but only one matches name "eng"
+    results = repo.search(TeamQuery(name="eng", agent_id="eng-manager"))
+    assert len(results) == 1
+    assert results[0].id == "eng"
+
+
+def test_search_by_description(tmp_path: Path) -> None:
+    """search(TeamQuery(description='software')) case-insensitive substring."""
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [
+            _team_dict("eng", description="Software engineering team"),
+            _team_dict("mkt", description="Digital marketing team"),
+        ],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(description="software"))
+    assert len(results) == 1
+    assert results[0].id == "eng"
+
+
+# ---- Caching ----
+
+
+def test_caching_no_reread(tmp_path: Path) -> None:
+    """Second list() call doesn't re-read files."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [_team_dict("t1"), _team_dict("t2", name="Second")],
+    )
+    assert len(repo.list()) == 1
+
+
+def test_reload_forces_rescan(tmp_path: Path) -> None:
+    """reload() forces re-scan from disk."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    assert len(repo.list()) == 1
+
+    _write_yaml(
+        tmp_path / "t.yaml",
+        [_team_dict("t1"), _team_dict("t2", name="Second")],
+    )
+    repo.reload()
+    assert len(repo.list()) == 2
+
+
+# ---- Public API export ----
+
+
+def test_public_api_export() -> None:
+    """YamlTeamCatalogRepository is importable from public API."""
+    from akgentic.catalog import YamlTeamCatalogRepository as Exported
+
+    assert Exported is YamlTeamCatalogRepository

--- a/tests/test_yaml_team_repo.py
+++ b/tests/test_yaml_team_repo.py
@@ -83,6 +83,15 @@ def test_create_persists_team(tmp_path: Path) -> None:
     assert loaded.name == "New Team"
 
 
+def test_create_duplicate_id_raises(tmp_path: Path) -> None:
+    """create() raises CatalogValidationError for duplicate id."""
+    _write_yaml(tmp_path / "t.yaml", [_team_dict("dup")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    entry = TeamSpec.model_validate(_team_dict("dup", name="Another"))
+    with pytest.raises(CatalogValidationError):
+        repo.create(entry)
+
+
 def test_get_returns_team_by_id(tmp_path: Path) -> None:
     """get() returns team by id."""
     _write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
@@ -159,6 +168,25 @@ def test_duplicate_id_across_files_raises(tmp_path: Path) -> None:
 
 
 # ---- search() (AC #4) ----
+
+
+def test_search_by_id(tmp_path: Path) -> None:
+    """search(TeamQuery(id='t1')) exact id match."""
+    _write_yaml(
+        tmp_path / "teams.yaml",
+        [_team_dict("t1", name="Alpha"), _team_dict("t2", name="Beta")],
+    )
+    repo = YamlTeamCatalogRepository(tmp_path)
+    results = repo.search(TeamQuery(id="t1"))
+    assert len(results) == 1
+    assert results[0].id == "t1"
+
+
+def test_search_by_id_no_match(tmp_path: Path) -> None:
+    """search(TeamQuery(id='missing')) returns empty."""
+    _write_yaml(tmp_path / "teams.yaml", [_team_dict("t1")])
+    repo = YamlTeamCatalogRepository(tmp_path)
+    assert repo.search(TeamQuery(id="missing")) == []
 
 
 def test_search_by_name(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Implements `YamlAgentCatalogRepository` and `YamlTeamCatalogRepository` following the same delegation pattern established in Story 2.2
- Agent search supports exact match on id/role, match-any on skills, case-insensitive substring on description
- Team search supports exact match on id, case-insensitive substring on name/description, and recursive tree walk for agent_id
- Code review fixes: added `types-PyYAML` dev dependency, 6 additional tests for search-by-id and create-duplicate coverage

## Test Results

- 221 tests passing, 96.21% branch coverage
- agent_repo.py and team_repo.py at 100% branch coverage
- ruff check: zero errors
- mypy --strict: zero issues

Closes #13