### PR TITLE
Template and Tool Catalog Services

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -17,6 +17,8 @@ from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogReposi
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+from akgentic.catalog.services.template_catalog import TemplateCatalog
+from akgentic.catalog.services.tool_catalog import ToolCatalog
 
 __all__ = [
     "AgentCatalogRepository",
@@ -28,9 +30,11 @@ __all__ = [
     "TeamMemberSpec",
     "TeamQuery",
     "TeamSpec",
+    "TemplateCatalog",
     "TemplateCatalogRepository",
     "TemplateEntry",
     "TemplateQuery",
+    "ToolCatalog",
     "ToolCatalogRepository",
     "ToolEntry",
     "ToolQuery",

--- a/src/akgentic/catalog/services/__init__.py
+++ b/src/akgentic/catalog/services/__init__.py
@@ -1,0 +1,9 @@
+"""Catalog service layer — domain logic over repositories."""
+
+from akgentic.catalog.services.template_catalog import TemplateCatalog
+from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+__all__ = [
+    "TemplateCatalog",
+    "ToolCatalog",
+]

--- a/src/akgentic/catalog/services/_protocols.py
+++ b/src/akgentic/catalog/services/_protocols.py
@@ -1,0 +1,24 @@
+"""Shared protocols for catalog service duck-typing (avoids circular imports)."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.agent import AgentEntry
+
+_list = builtins.list
+
+
+class _AgentRepoProtocol(Protocol):
+    """Protocol for agent repository list access."""
+
+    def list(self) -> _list[AgentEntry]: ...
+
+
+class _AgentCatalogProtocol(Protocol):
+    """Protocol for agent catalog lookup (duck-typed, avoids circular import)."""
+
+    @property
+    def repository(self) -> _AgentRepoProtocol: ...

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -1,0 +1,110 @@
+"""TemplateCatalog service — domain logic over template repository."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Protocol
+
+from akgentic.agent.config import AgentConfig
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
+from akgentic.catalog.repositories.base import TemplateCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.agent import AgentEntry
+    from akgentic.catalog.models.queries import TemplateQuery
+
+__all__ = ["TemplateCatalog"]
+
+_list = builtins.list
+
+
+class _AgentCatalogProtocol(Protocol):
+    """Protocol for agent catalog lookup (duck-typed, avoids circular import)."""
+
+    @property
+    def repository(self) -> _AgentRepoProtocol: ...
+
+
+class _AgentRepoProtocol(Protocol):
+    """Protocol for agent repository list access."""
+
+    def list(self) -> _list[AgentEntry]: ...
+
+
+class TemplateCatalog:
+    """Service layer for template catalog entries."""
+
+    def __init__(self, repository: TemplateCatalogRepository) -> None:
+        self.repository = repository
+        self._agent_catalog: _AgentCatalogProtocol | None = None
+
+    @property
+    def agent_catalog(self) -> _AgentCatalogProtocol | None:
+        """Optional downstream agent catalog for delete protection."""
+        return self._agent_catalog
+
+    @agent_catalog.setter
+    def agent_catalog(self, value: _AgentCatalogProtocol | None) -> None:
+        self._agent_catalog = value
+
+    def validate_create(self, entry: TemplateEntry) -> _list[str]:
+        """Check for duplicate id. Returns list of error strings."""
+        errors: _list[str] = []
+        if self.repository.get(entry.id) is not None:
+            errors.append(f"Template id '{entry.id}' already exists")
+        return errors
+
+    def create(self, entry: TemplateEntry) -> str:
+        """Persist a new template entry. Raises CatalogValidationError on duplicate id."""
+        errors = self.validate_create(entry)
+        if errors:
+            raise CatalogValidationError(errors)
+        return self.repository.create(entry)
+
+    def get(self, id: str) -> TemplateEntry | None:
+        """Retrieve a template entry by id."""
+        return self.repository.get(id)
+
+    def list(self) -> _list[TemplateEntry]:
+        """List all template entries."""
+        return self.repository.list()
+
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
+        """Search template entries by query."""
+        return self.repository.search(query)
+
+    def update(self, id: str, entry: TemplateEntry) -> None:
+        """Update an existing template entry. Raises EntryNotFoundError if missing."""
+        if self.repository.get(id) is None:
+            raise EntryNotFoundError(f"Template id '{id}' not found")
+        self.repository.update(id, entry)
+
+    def validate_delete(self, id: str) -> _list[str]:
+        """Check existence and downstream references before delete."""
+        errors: _list[str] = []
+        if self.repository.get(id) is None:
+            errors.append(f"Template id '{id}' not found")
+            return errors
+        if self._agent_catalog is not None:
+            for agent in self._agent_catalog.repository.list():
+                config = agent.card.config
+                if isinstance(config, AgentConfig):
+                    if _is_catalog_ref(config.prompt.template):
+                        ref_id = _resolve_ref(config.prompt.template)
+                        if ref_id == id:
+                            errors.append(
+                                f"Agent '{agent.id}' references template '@{id}'"
+                                f" — cannot delete"
+                            )
+        return errors
+
+    def delete(self, id: str) -> None:
+        """Delete a template entry. Raises errors if not found or referenced downstream."""
+        errors = self.validate_delete(id)
+        if errors:
+            if self.repository.get(id) is None:
+                raise EntryNotFoundError(f"Template id '{id}' not found")
+            raise CatalogValidationError(errors)
+        self.repository.delete(id)

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -3,34 +3,21 @@
 from __future__ import annotations
 
 import builtins
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 from akgentic.agent.config import AgentConfig
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
+from akgentic.catalog.services._protocols import _AgentCatalogProtocol
 
 if TYPE_CHECKING:
-    from akgentic.catalog.models.agent import AgentEntry
     from akgentic.catalog.models.queries import TemplateQuery
 
 __all__ = ["TemplateCatalog"]
 
 _list = builtins.list
-
-
-class _AgentCatalogProtocol(Protocol):
-    """Protocol for agent catalog lookup (duck-typed, avoids circular import)."""
-
-    @property
-    def repository(self) -> _AgentRepoProtocol: ...
-
-
-class _AgentRepoProtocol(Protocol):
-    """Protocol for agent repository list access."""
-
-    def list(self) -> _list[AgentEntry]: ...
 
 
 class TemplateCatalog:
@@ -79,6 +66,10 @@ class TemplateCatalog:
         """Update an existing template entry. Raises EntryNotFoundError if missing."""
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Template id '{id}' not found")
+        if entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id '{entry.id}' does not match update target '{id}'"]
+            )
         self.repository.update(id, entry)
 
     def validate_delete(self, id: str) -> _list[str]:
@@ -104,7 +95,7 @@ class TemplateCatalog:
         """Delete a template entry. Raises errors if not found or referenced downstream."""
         errors = self.validate_delete(id)
         if errors:
-            if self.repository.get(id) is None:
-                raise EntryNotFoundError(f"Template id '{id}' not found")
+            if "not found" in errors[0]:
+                raise EntryNotFoundError(errors[0])
             raise CatalogValidationError(errors)
         self.repository.delete(id)

--- a/src/akgentic/catalog/services/tool_catalog.py
+++ b/src/akgentic/catalog/services/tool_catalog.py
@@ -3,32 +3,19 @@
 from __future__ import annotations
 
 import builtins
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
+from akgentic.catalog.services._protocols import _AgentCatalogProtocol
 
 if TYPE_CHECKING:
-    from akgentic.catalog.models.agent import AgentEntry
     from akgentic.catalog.models.queries import ToolQuery
 
 __all__ = ["ToolCatalog"]
 
 _list = builtins.list
-
-
-class _AgentCatalogProtocol(Protocol):
-    """Protocol for agent catalog lookup (duck-typed, avoids circular import)."""
-
-    @property
-    def repository(self) -> _AgentRepoProtocol: ...
-
-
-class _AgentRepoProtocol(Protocol):
-    """Protocol for agent repository list access."""
-
-    def list(self) -> _list[AgentEntry]: ...
 
 
 class ToolCatalog:
@@ -77,6 +64,10 @@ class ToolCatalog:
         """Update an existing tool entry. Raises EntryNotFoundError if missing."""
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Tool id '{id}' not found")
+        if entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id '{entry.id}' does not match update target '{id}'"]
+            )
         self.repository.update(id, entry)
 
     def validate_delete(self, id: str) -> _list[str]:
@@ -98,7 +89,7 @@ class ToolCatalog:
         """Delete a tool entry. Raises errors if not found or referenced downstream."""
         errors = self.validate_delete(id)
         if errors:
-            if self.repository.get(id) is None:
-                raise EntryNotFoundError(f"Tool id '{id}' not found")
+            if "not found" in errors[0]:
+                raise EntryNotFoundError(errors[0])
             raise CatalogValidationError(errors)
         self.repository.delete(id)

--- a/src/akgentic/catalog/services/tool_catalog.py
+++ b/src/akgentic/catalog/services/tool_catalog.py
@@ -1,0 +1,104 @@
+"""ToolCatalog service — domain logic over tool repository."""
+
+from __future__ import annotations
+
+import builtins
+from typing import TYPE_CHECKING, Protocol
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.agent import AgentEntry
+    from akgentic.catalog.models.queries import ToolQuery
+
+__all__ = ["ToolCatalog"]
+
+_list = builtins.list
+
+
+class _AgentCatalogProtocol(Protocol):
+    """Protocol for agent catalog lookup (duck-typed, avoids circular import)."""
+
+    @property
+    def repository(self) -> _AgentRepoProtocol: ...
+
+
+class _AgentRepoProtocol(Protocol):
+    """Protocol for agent repository list access."""
+
+    def list(self) -> _list[AgentEntry]: ...
+
+
+class ToolCatalog:
+    """Service layer for tool catalog entries."""
+
+    def __init__(self, repository: ToolCatalogRepository) -> None:
+        self.repository = repository
+        self._agent_catalog: _AgentCatalogProtocol | None = None
+
+    @property
+    def agent_catalog(self) -> _AgentCatalogProtocol | None:
+        """Optional downstream agent catalog for delete protection."""
+        return self._agent_catalog
+
+    @agent_catalog.setter
+    def agent_catalog(self, value: _AgentCatalogProtocol | None) -> None:
+        self._agent_catalog = value
+
+    def validate_create(self, entry: ToolEntry) -> _list[str]:
+        """Check for duplicate id. Returns list of error strings."""
+        errors: _list[str] = []
+        if self.repository.get(entry.id) is not None:
+            errors.append(f"Tool id '{entry.id}' already exists")
+        return errors
+
+    def create(self, entry: ToolEntry) -> str:
+        """Persist a new tool entry. Raises CatalogValidationError on duplicate id."""
+        errors = self.validate_create(entry)
+        if errors:
+            raise CatalogValidationError(errors)
+        return self.repository.create(entry)
+
+    def get(self, id: str) -> ToolEntry | None:
+        """Retrieve a tool entry by id."""
+        return self.repository.get(id)
+
+    def list(self) -> _list[ToolEntry]:
+        """List all tool entries."""
+        return self.repository.list()
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        """Search tool entries by query."""
+        return self.repository.search(query)
+
+    def update(self, id: str, entry: ToolEntry) -> None:
+        """Update an existing tool entry. Raises EntryNotFoundError if missing."""
+        if self.repository.get(id) is None:
+            raise EntryNotFoundError(f"Tool id '{id}' not found")
+        self.repository.update(id, entry)
+
+    def validate_delete(self, id: str) -> _list[str]:
+        """Check existence and downstream references before delete."""
+        errors: _list[str] = []
+        if self.repository.get(id) is None:
+            errors.append(f"Tool id '{id}' not found")
+            return errors
+        if self._agent_catalog is not None:
+            for agent in self._agent_catalog.repository.list():
+                if id in agent.tool_ids:
+                    errors.append(
+                        f"Agent '{agent.id}' references tool '{id}'"
+                        f" in tool_ids — cannot delete"
+                    )
+        return errors
+
+    def delete(self, id: str) -> None:
+        """Delete a tool entry. Raises errors if not found or referenced downstream."""
+        errors = self.validate_delete(id)
+        if errors:
+            if self.repository.get(id) is None:
+                raise EntryNotFoundError(f"Tool id '{id}' not found")
+            raise CatalogValidationError(errors)
+        self.repository.delete(id)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,28 @@
+"""Shared test fixtures for catalog service tests."""
+
+import builtins
+
+from akgentic.catalog.models.agent import AgentEntry
+
+_list = builtins.list
+
+
+class MockAgentCatalogRepository:
+    """Mock repository that returns a fixed list of AgentEntry objects."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._entries = entries
+
+    def list(self) -> _list[AgentEntry]:
+        return self._entries
+
+
+class MockAgentCatalog:
+    """Mock agent catalog with .repository.list() for delete protection."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._repository = MockAgentCatalogRepository(entries)
+
+    @property
+    def repository(self) -> MockAgentCatalogRepository:
+        return self._repository

--- a/tests/test_template_catalog.py
+++ b/tests/test_template_catalog.py
@@ -10,6 +10,7 @@ from akgentic.catalog.models.queries import TemplateQuery
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
 from akgentic.catalog.services.template_catalog import TemplateCatalog
+from tests.helpers import MockAgentCatalog
 
 _list = builtins.list
 
@@ -46,30 +47,6 @@ class InMemoryTemplateCatalogRepository(TemplateCatalogRepository):
 
     def delete(self, id: str) -> None:
         del self._entries[id]
-
-
-# --- Mock agent catalog for delete protection ---
-
-
-class MockAgentCatalogRepository:
-    """Mock repository that returns a fixed list of AgentEntry objects."""
-
-    def __init__(self, entries: _list[AgentEntry]) -> None:
-        self._entries = entries
-
-    def list(self) -> _list[AgentEntry]:
-        return self._entries
-
-
-class MockAgentCatalog:
-    """Mock agent catalog with .repository.list() for delete protection."""
-
-    def __init__(self, entries: _list[AgentEntry]) -> None:
-        self._repository = MockAgentCatalogRepository(entries)
-
-    @property
-    def repository(self) -> MockAgentCatalogRepository:
-        return self._repository
 
 
 # --- Helper ---
@@ -178,6 +155,12 @@ class TestUpdate:
         entry = _make_template("tpl-1")
         with pytest.raises(EntryNotFoundError, match="not found"):
             catalog.update("tpl-1", entry)
+
+    def test_update_id_mismatch_raises(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        mismatched = _make_template("tpl-2", template="Updated {name}")
+        with pytest.raises(CatalogValidationError, match="does not match"):
+            catalog.update("tpl-1", mismatched)
 
 
 class TestDelete:

--- a/tests/test_template_catalog.py
+++ b/tests/test_template_catalog.py
@@ -1,0 +1,283 @@
+"""Tests for TemplateCatalog service."""
+
+import builtins
+
+import pytest
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TemplateQuery
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.base import TemplateCatalogRepository
+from akgentic.catalog.services.template_catalog import TemplateCatalog
+
+_list = builtins.list
+
+
+# --- In-memory repository for testing ---
+
+
+class InMemoryTemplateCatalogRepository(TemplateCatalogRepository):
+    """Simple in-memory repository for testing service logic."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, TemplateEntry] = {}
+
+    def create(self, template_entry: TemplateEntry) -> str:
+        self._entries[template_entry.id] = template_entry
+        return template_entry.id
+
+    def get(self, id: str) -> TemplateEntry | None:
+        return self._entries.get(id)
+
+    def list(self) -> _list[TemplateEntry]:
+        return _list(self._entries.values())
+
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
+        results = self.list()
+        if query.id is not None:
+            results = [e for e in results if e.id == query.id]
+        if query.placeholder is not None:
+            results = [e for e in results if query.placeholder in e.placeholders]
+        return results
+
+    def update(self, id: str, template_entry: TemplateEntry) -> None:
+        self._entries[id] = template_entry
+
+    def delete(self, id: str) -> None:
+        del self._entries[id]
+
+
+# --- Mock agent catalog for delete protection ---
+
+
+class MockAgentCatalogRepository:
+    """Mock repository that returns a fixed list of AgentEntry objects."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._entries = entries
+
+    def list(self) -> _list[AgentEntry]:
+        return self._entries
+
+
+class MockAgentCatalog:
+    """Mock agent catalog with .repository.list() for delete protection."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._repository = MockAgentCatalogRepository(entries)
+
+    @property
+    def repository(self) -> MockAgentCatalogRepository:
+        return self._repository
+
+
+# --- Helper ---
+
+
+def _make_template(id: str = "tpl-1", template: str = "Hello {name}") -> TemplateEntry:
+    return TemplateEntry(id=id, template=template)
+
+
+def _make_agent_with_template_ref(
+    agent_id: str, template_ref: str
+) -> AgentEntry:
+    """Create an AgentEntry whose config.prompt.template is a catalog @-ref."""
+    return AgentEntry(
+        id=agent_id,
+        card={
+            "role": "engineer",
+            "description": "test",
+            "skills": ["coding"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {
+                "name": "test-agent",
+                "prompt": {"template": template_ref},
+            },
+        },
+    )
+
+
+# --- Tests ---
+
+
+@pytest.fixture
+def repo() -> InMemoryTemplateCatalogRepository:
+    return InMemoryTemplateCatalogRepository()
+
+
+@pytest.fixture
+def catalog(repo: InMemoryTemplateCatalogRepository) -> TemplateCatalog:
+    return TemplateCatalog(repository=repo)
+
+
+class TestCreate:
+    """AC #1: create with unique id persists, duplicate raises CatalogValidationError."""
+
+    def test_create_unique_id_persists(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        result = catalog.create(entry)
+        assert result == "tpl-1"
+        assert catalog.get("tpl-1") is not None
+
+    def test_create_duplicate_id_raises(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        catalog.create(entry)
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            catalog.create(entry)
+
+
+class TestGet:
+    """AC #3: get delegates to repository."""
+
+    def test_get_existing(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        catalog.create(entry)
+        result = catalog.get("tpl-1")
+        assert result is not None
+        assert result.id == "tpl-1"
+
+    def test_get_nonexistent_returns_none(self, catalog: TemplateCatalog) -> None:
+        assert catalog.get("nonexistent") is None
+
+
+class TestList:
+    """AC #3: list delegates to repository."""
+
+    def test_list_delegates(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        catalog.create(_make_template("tpl-2", template="Bye {name}"))
+        result = catalog.list()
+        assert len(result) == 2
+
+
+class TestSearch:
+    """AC #3: search delegates to repository."""
+
+    def test_search_delegates(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        catalog.create(_make_template("tpl-2", template="Bye {name}"))
+        query = TemplateQuery(id="tpl-1")
+        result = catalog.search(query)
+        assert len(result) == 1
+        assert result[0].id == "tpl-1"
+
+
+class TestUpdate:
+    """AC #3: update validates id exists, then delegates."""
+
+    def test_update_existing_delegates(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        updated = _make_template("tpl-1", template="Updated {name}")
+        catalog.update("tpl-1", updated)
+        result = catalog.get("tpl-1")
+        assert result is not None
+        assert result.template == "Updated {name}"
+
+    def test_update_nonexistent_raises(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            catalog.update("tpl-1", entry)
+
+
+class TestDelete:
+    """AC #3: delete validates id exists and checks downstream refs."""
+
+    def test_delete_existing_no_downstream(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        catalog.delete("tpl-1")
+        assert catalog.get("tpl-1") is None
+
+    def test_delete_nonexistent_raises(self, catalog: TemplateCatalog) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            catalog.delete("nonexistent")
+
+
+class TestAgentCatalogAttribute:
+    """AC #3: agent_catalog defaults to None."""
+
+    def test_defaults_to_none(self, catalog: TemplateCatalog) -> None:
+        assert catalog.agent_catalog is None
+
+    def test_can_be_set(self, catalog: TemplateCatalog) -> None:
+        mock_ac = MockAgentCatalog([])
+        catalog.agent_catalog = mock_ac
+        assert catalog.agent_catalog is mock_ac
+
+
+class TestDeleteProtection:
+    """Delete protection when agent_catalog is set."""
+
+    def test_delete_blocked_when_agent_references_template(
+        self, catalog: TemplateCatalog
+    ) -> None:
+        catalog.create(_make_template("sys-prompt"))
+        agent = _make_agent_with_template_ref("agent-1", "@sys-prompt")
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        with pytest.raises(CatalogValidationError, match="cannot delete"):
+            catalog.delete("sys-prompt")
+
+    def test_delete_allowed_when_agent_catalog_is_none(
+        self, catalog: TemplateCatalog
+    ) -> None:
+        catalog.create(_make_template("sys-prompt"))
+        catalog.delete("sys-prompt")
+        assert catalog.get("sys-prompt") is None
+
+    def test_delete_allowed_when_no_agent_references_template(
+        self, catalog: TemplateCatalog
+    ) -> None:
+        catalog.create(_make_template("sys-prompt"))
+        agent = _make_agent_with_template_ref("agent-1", "@other-template")
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        catalog.delete("sys-prompt")
+        assert catalog.get("sys-prompt") is None
+
+    def test_delete_blocked_multiple_agents_reference_template(
+        self, catalog: TemplateCatalog
+    ) -> None:
+        catalog.create(_make_template("sys-prompt"))
+        agent1 = _make_agent_with_template_ref("agent-1", "@sys-prompt")
+        agent2 = _make_agent_with_template_ref("agent-2", "@sys-prompt")
+        catalog.agent_catalog = MockAgentCatalog([agent1, agent2])
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.delete("sys-prompt")
+        assert len(exc_info.value.errors) == 2
+
+
+class TestValidateCreate:
+    """validate_create returns list[str], not raises."""
+
+    def test_returns_empty_list_for_unique(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        errors = catalog.validate_create(entry)
+        assert errors == []
+
+    def test_returns_errors_for_duplicate(self, catalog: TemplateCatalog) -> None:
+        entry = _make_template("tpl-1")
+        catalog.create(entry)
+        errors = catalog.validate_create(entry)
+        assert len(errors) == 1
+        assert "already exists" in errors[0]
+
+
+class TestValidateDelete:
+    """validate_delete returns list[str] for downstream checks."""
+
+    def test_returns_empty_when_no_refs(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("tpl-1"))
+        errors = catalog.validate_delete("tpl-1")
+        assert errors == []
+
+    def test_returns_errors_when_referenced(self, catalog: TemplateCatalog) -> None:
+        catalog.create(_make_template("sys-prompt"))
+        agent = _make_agent_with_template_ref("agent-1", "@sys-prompt")
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        errors = catalog.validate_delete("sys-prompt")
+        assert len(errors) == 1
+        assert "cannot delete" in errors[0]
+
+    def test_returns_not_found_error(self, catalog: TemplateCatalog) -> None:
+        errors = catalog.validate_delete("nonexistent")
+        assert len(errors) == 1
+        assert "not found" in errors[0]

--- a/tests/test_tool_catalog.py
+++ b/tests/test_tool_catalog.py
@@ -1,0 +1,283 @@
+"""Tests for ToolCatalog service."""
+
+import builtins
+
+import pytest
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
+from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+_list = builtins.list
+
+
+# --- In-memory repository for testing ---
+
+
+class InMemoryToolCatalogRepository(ToolCatalogRepository):
+    """Simple in-memory repository for testing service logic."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ToolEntry] = {}
+
+    def create(self, tool_entry: ToolEntry) -> str:
+        self._entries[tool_entry.id] = tool_entry
+        return tool_entry.id
+
+    def get(self, id: str) -> ToolEntry | None:
+        return self._entries.get(id)
+
+    def list(self) -> _list[ToolEntry]:
+        return _list(self._entries.values())
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        results = self.list()
+        if query.id is not None:
+            results = [e for e in results if e.id == query.id]
+        if query.tool_class is not None:
+            results = [e for e in results if e.tool_class == query.tool_class]
+        return results
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        self._entries[id] = tool_entry
+
+    def delete(self, id: str) -> None:
+        del self._entries[id]
+
+
+# --- Mock agent catalog for delete protection ---
+
+
+class MockAgentCatalogRepository:
+    """Mock repository that returns a fixed list of AgentEntry objects."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._entries = entries
+
+    def list(self) -> _list[AgentEntry]:
+        return self._entries
+
+
+class MockAgentCatalog:
+    """Mock agent catalog with .repository.list() for delete protection."""
+
+    def __init__(self, entries: _list[AgentEntry]) -> None:
+        self._repository = MockAgentCatalogRepository(entries)
+
+    @property
+    def repository(self) -> MockAgentCatalogRepository:
+        return self._repository
+
+
+# --- Helpers ---
+
+
+def _make_tool(id: str = "search-1") -> ToolEntry:
+    """Create a minimal ToolEntry using SearchTool (a real ToolCard subclass)."""
+    return ToolEntry(
+        id=id,
+        tool_class="akgentic.tool.search.search.SearchTool",
+        tool={"name": "search", "description": "Search the web"},
+    )
+
+
+def _make_agent_with_tool(agent_id: str, tool_ids: _list[str]) -> AgentEntry:
+    """Create an AgentEntry with given tool_ids."""
+    return AgentEntry(
+        id=agent_id,
+        tool_ids=tool_ids,
+        card={
+            "role": "engineer",
+            "description": "test",
+            "skills": ["coding"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {"name": "test-agent"},
+        },
+    )
+
+
+# --- Tests ---
+
+
+@pytest.fixture
+def repo() -> InMemoryToolCatalogRepository:
+    return InMemoryToolCatalogRepository()
+
+
+@pytest.fixture
+def catalog(repo: InMemoryToolCatalogRepository) -> ToolCatalog:
+    return ToolCatalog(repository=repo)
+
+
+class TestCreate:
+    """AC #2: create with unique id persists, duplicate raises CatalogValidationError."""
+
+    def test_create_unique_id_persists(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        result = catalog.create(entry)
+        assert result == "search-1"
+        assert catalog.get("search-1") is not None
+
+    def test_create_duplicate_id_raises(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        catalog.create(entry)
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            catalog.create(entry)
+
+
+class TestGet:
+    """AC #3: get delegates correctly."""
+
+    def test_get_existing(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        catalog.create(entry)
+        result = catalog.get("search-1")
+        assert result is not None
+        assert result.id == "search-1"
+
+    def test_get_nonexistent_returns_none(self, catalog: ToolCatalog) -> None:
+        assert catalog.get("nonexistent") is None
+
+
+class TestList:
+    """AC #3: list delegates correctly."""
+
+    def test_list_delegates(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        catalog.create(_make_tool("search-2"))
+        result = catalog.list()
+        assert len(result) == 2
+
+
+class TestSearch:
+    """AC #3: search delegates correctly."""
+
+    def test_search_delegates(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        catalog.create(_make_tool("search-2"))
+        query = ToolQuery(id="search-1")
+        result = catalog.search(query)
+        assert len(result) == 1
+        assert result[0].id == "search-1"
+
+
+class TestUpdate:
+    """AC #3: update with existing id delegates, nonexistent raises."""
+
+    def test_update_existing_delegates(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        updated = _make_tool("search-1")
+        catalog.update("search-1", updated)
+        result = catalog.get("search-1")
+        assert result is not None
+
+    def test_update_nonexistent_raises(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            catalog.update("search-1", entry)
+
+
+class TestDelete:
+    """AC #3: delete with existing id delegates, nonexistent raises."""
+
+    def test_delete_existing_no_downstream(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        catalog.delete("search-1")
+        assert catalog.get("search-1") is None
+
+    def test_delete_nonexistent_raises(self, catalog: ToolCatalog) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            catalog.delete("nonexistent")
+
+
+class TestAgentCatalogAttribute:
+    """AC #3: agent_catalog defaults to None."""
+
+    def test_defaults_to_none(self, catalog: ToolCatalog) -> None:
+        assert catalog.agent_catalog is None
+
+    def test_can_be_set(self, catalog: ToolCatalog) -> None:
+        mock_ac = MockAgentCatalog([])
+        catalog.agent_catalog = mock_ac
+        assert catalog.agent_catalog is mock_ac
+
+
+class TestDeleteProtection:
+    """Delete protection when agent_catalog is set."""
+
+    def test_delete_blocked_when_agent_references_tool(
+        self, catalog: ToolCatalog
+    ) -> None:
+        catalog.create(_make_tool("search-1"))
+        agent = _make_agent_with_tool("agent-1", ["search-1"])
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        with pytest.raises(CatalogValidationError, match="cannot delete"):
+            catalog.delete("search-1")
+
+    def test_delete_allowed_when_agent_catalog_is_none(
+        self, catalog: ToolCatalog
+    ) -> None:
+        catalog.create(_make_tool("search-1"))
+        catalog.delete("search-1")
+        assert catalog.get("search-1") is None
+
+    def test_delete_allowed_when_no_agent_references_tool(
+        self, catalog: ToolCatalog
+    ) -> None:
+        catalog.create(_make_tool("search-1"))
+        agent = _make_agent_with_tool("agent-1", ["other-tool"])
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        catalog.delete("search-1")
+        assert catalog.get("search-1") is None
+
+    def test_delete_blocked_multiple_agents_reference_tool(
+        self, catalog: ToolCatalog
+    ) -> None:
+        catalog.create(_make_tool("search-1"))
+        agent1 = _make_agent_with_tool("agent-1", ["search-1"])
+        agent2 = _make_agent_with_tool("agent-2", ["search-1"])
+        catalog.agent_catalog = MockAgentCatalog([agent1, agent2])
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.delete("search-1")
+        assert len(exc_info.value.errors) == 2
+
+
+class TestValidateCreate:
+    """validate_create returns list[str], not raises."""
+
+    def test_returns_empty_for_unique(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        errors = catalog.validate_create(entry)
+        assert errors == []
+
+    def test_returns_errors_for_duplicate(self, catalog: ToolCatalog) -> None:
+        entry = _make_tool("search-1")
+        catalog.create(entry)
+        errors = catalog.validate_create(entry)
+        assert len(errors) == 1
+        assert "already exists" in errors[0]
+
+
+class TestValidateDelete:
+    """validate_delete returns list[str] for downstream checks."""
+
+    def test_returns_empty_when_no_refs(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        errors = catalog.validate_delete("search-1")
+        assert errors == []
+
+    def test_returns_errors_when_referenced(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        agent = _make_agent_with_tool("agent-1", ["search-1"])
+        catalog.agent_catalog = MockAgentCatalog([agent])
+        errors = catalog.validate_delete("search-1")
+        assert len(errors) == 1
+        assert "cannot delete" in errors[0]
+
+    def test_returns_not_found_error(self, catalog: ToolCatalog) -> None:
+        errors = catalog.validate_delete("nonexistent")
+        assert len(errors) == 1
+        assert "not found" in errors[0]

--- a/tests/test_tool_catalog.py
+++ b/tests/test_tool_catalog.py
@@ -10,6 +10,7 @@ from akgentic.catalog.models.queries import ToolQuery
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
 from akgentic.catalog.services.tool_catalog import ToolCatalog
+from tests.helpers import MockAgentCatalog
 
 _list = builtins.list
 
@@ -46,30 +47,6 @@ class InMemoryToolCatalogRepository(ToolCatalogRepository):
 
     def delete(self, id: str) -> None:
         del self._entries[id]
-
-
-# --- Mock agent catalog for delete protection ---
-
-
-class MockAgentCatalogRepository:
-    """Mock repository that returns a fixed list of AgentEntry objects."""
-
-    def __init__(self, entries: _list[AgentEntry]) -> None:
-        self._entries = entries
-
-    def list(self) -> _list[AgentEntry]:
-        return self._entries
-
-
-class MockAgentCatalog:
-    """Mock agent catalog with .repository.list() for delete protection."""
-
-    def __init__(self, entries: _list[AgentEntry]) -> None:
-        self._repository = MockAgentCatalogRepository(entries)
-
-    @property
-    def repository(self) -> MockAgentCatalogRepository:
-        return self._repository
 
 
 # --- Helpers ---
@@ -178,6 +155,12 @@ class TestUpdate:
         entry = _make_tool("search-1")
         with pytest.raises(EntryNotFoundError, match="not found"):
             catalog.update("search-1", entry)
+
+    def test_update_id_mismatch_raises(self, catalog: ToolCatalog) -> None:
+        catalog.create(_make_tool("search-1"))
+        mismatched = _make_tool("search-2")
+        with pytest.raises(CatalogValidationError, match="does not match"):
+            catalog.update("search-1", mismatched)
 
 
 class TestDelete:


### PR DESCRIPTION
## Summary

- Implement `TemplateCatalog` and `ToolCatalog` service classes wrapping repositories with domain logic (validation, delete protection)
- Use `_AgentCatalogProtocol` (Protocol pattern) for duck-typed downstream delete protection, avoiding circular imports
- Code review fixes: extracted shared protocols, shared test mocks, added update id consistency checks, removed redundant queries

## Changes

- `services/_protocols.py` — shared `_AgentCatalogProtocol` and `_AgentRepoProtocol`
- `services/template_catalog.py` — `TemplateCatalog` with create/get/list/search/update/delete + validation
- `services/tool_catalog.py` — `ToolCatalog` with create/get/list/search/update/delete + validation  
- `tests/helpers.py` — shared `MockAgentCatalog` test infrastructure
- 44 new tests (22 per service), 265 total passing, 99% branch coverage
- ruff check: zero errors, mypy --strict: zero errors

Closes #15