### PR TITLE
Environment Variable Substitution Utility

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,8 +3,42 @@
 import builtins
 
 from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
 
 _list = builtins.list
+
+
+class InMemoryToolCatalogRepository(ToolCatalogRepository):
+    """Simple in-memory repository for testing service logic."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ToolEntry] = {}
+
+    def create(self, tool_entry: ToolEntry) -> str:
+        self._entries[tool_entry.id] = tool_entry
+        return tool_entry.id
+
+    def get(self, id: str) -> ToolEntry | None:
+        return self._entries.get(id)
+
+    def list(self) -> _list[ToolEntry]:
+        return _list(self._entries.values())
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        results = self.list()
+        if query.id is not None:
+            results = [e for e in results if e.id == query.id]
+        if query.tool_class is not None:
+            results = [e for e in results if e.tool_class == query.tool_class]
+        return results
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        self._entries[id] = tool_entry
+
+    def delete(self, id: str) -> None:
+        del self._entries[id]
 
 
 class MockAgentCatalogRepository:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,9 +3,6 @@
 import pytest
 
 from akgentic.catalog.env import resolve_env_vars
-from akgentic.catalog.models.tool import ToolEntry
-from akgentic.catalog.services.tool_catalog import ToolCatalog
-from tests.test_tool_catalog import InMemoryToolCatalogRepository
 
 
 class TestResolveEnvVars:
@@ -49,22 +46,16 @@ class TestResolveEnvVars:
         # ${1VAR} is not a valid identifier per the regex
         assert resolve_env_vars("${1VAR}") == "${1VAR}"
 
+    def test_empty_env_var_value_resolves_to_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EMPTY_VAR", "")
+        assert resolve_env_vars("prefix-${EMPTY_VAR}-suffix") == "prefix--suffix"
 
-class TestCatalogStoresPlaceholdersAsIs:
-    """AC5: Catalog stores ${VAR} placeholders as-is, not resolved at persistence time."""
-
-    def test_tool_entry_with_env_var_placeholder_persists_unchanged(self) -> None:
-        """Create a ToolEntry with ${VAR} in a string field, persist via repo, verify unchanged."""
-        entry = ToolEntry(
-            id="figma-tool",
-            tool_class="akgentic.tool.search.search.SearchTool",
-            tool={"name": "Figma", "description": "Figma API with key ${FIGMA_API_KEY}"},
-        )
-
-        repo = InMemoryToolCatalogRepository()
-        catalog = ToolCatalog(repository=repo)
-        catalog.create(entry)
-
-        retrieved = catalog.get("figma-tool")
-        assert retrieved is not None
-        assert "${FIGMA_API_KEY}" in retrieved.tool.description
+    def test_partial_resolution_raises_on_first_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOD_VAR", "resolved")
+        monkeypatch.delenv("BAD_VAR", raising=False)
+        with pytest.raises(OSError, match="BAD_VAR"):
+            resolve_env_vars("${GOOD_VAR}/${BAD_VAR}")

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,6 +3,9 @@
 import pytest
 
 from akgentic.catalog.env import resolve_env_vars
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.services.tool_catalog import ToolCatalog
+from tests.test_tool_catalog import InMemoryToolCatalogRepository
 
 
 class TestResolveEnvVars:
@@ -45,3 +48,23 @@ class TestResolveEnvVars:
     def test_var_starting_with_digit_not_matched(self) -> None:
         # ${1VAR} is not a valid identifier per the regex
         assert resolve_env_vars("${1VAR}") == "${1VAR}"
+
+
+class TestCatalogStoresPlaceholdersAsIs:
+    """AC5: Catalog stores ${VAR} placeholders as-is, not resolved at persistence time."""
+
+    def test_tool_entry_with_env_var_placeholder_persists_unchanged(self) -> None:
+        """Create a ToolEntry with ${VAR} in a string field, persist via repo, verify unchanged."""
+        entry = ToolEntry(
+            id="figma-tool",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={"name": "Figma", "description": "Figma API with key ${FIGMA_API_KEY}"},
+        )
+
+        repo = InMemoryToolCatalogRepository()
+        catalog = ToolCatalog(repository=repo)
+        catalog.create(entry)
+
+        retrieved = catalog.get("figma-tool")
+        assert retrieved is not None
+        assert "${FIGMA_API_KEY}" in retrieved.tool.description

--- a/tests/test_tool_catalog.py
+++ b/tests/test_tool_catalog.py
@@ -8,45 +8,10 @@ from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import ToolQuery
 from akgentic.catalog.models.tool import ToolEntry
-from akgentic.catalog.repositories.base import ToolCatalogRepository
 from akgentic.catalog.services.tool_catalog import ToolCatalog
-from tests.helpers import MockAgentCatalog
+from tests.helpers import InMemoryToolCatalogRepository, MockAgentCatalog
 
 _list = builtins.list
-
-
-# --- In-memory repository for testing ---
-
-
-class InMemoryToolCatalogRepository(ToolCatalogRepository):
-    """Simple in-memory repository for testing service logic."""
-
-    def __init__(self) -> None:
-        self._entries: dict[str, ToolEntry] = {}
-
-    def create(self, tool_entry: ToolEntry) -> str:
-        self._entries[tool_entry.id] = tool_entry
-        return tool_entry.id
-
-    def get(self, id: str) -> ToolEntry | None:
-        return self._entries.get(id)
-
-    def list(self) -> _list[ToolEntry]:
-        return _list(self._entries.values())
-
-    def search(self, query: ToolQuery) -> _list[ToolEntry]:
-        results = self.list()
-        if query.id is not None:
-            results = [e for e in results if e.id == query.id]
-        if query.tool_class is not None:
-            results = [e for e in results if e.tool_class == query.tool_class]
-        return results
-
-    def update(self, id: str, tool_entry: ToolEntry) -> None:
-        self._entries[id] = tool_entry
-
-    def delete(self, id: str) -> None:
-        del self._entries[id]
 
 
 # --- Helpers ---
@@ -264,3 +229,23 @@ class TestValidateDelete:
         errors = catalog.validate_delete("nonexistent")
         assert len(errors) == 1
         assert "not found" in errors[0]
+
+
+class TestCatalogStoresPlaceholdersAsIs:
+    """AC5: Catalog stores ${VAR} placeholders as-is, not resolved at persistence time."""
+
+    def test_tool_entry_with_env_var_placeholder_persists_unchanged(self) -> None:
+        """Create a ToolEntry with ${VAR} in a string field, persist via repo, verify unchanged."""
+        entry = ToolEntry(
+            id="figma-tool",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={"name": "Figma", "description": "Figma API with key ${FIGMA_API_KEY}"},
+        )
+
+        repo = InMemoryToolCatalogRepository()
+        catalog = ToolCatalog(repository=repo)
+        catalog.create(entry)
+
+        retrieved = catalog.get("figma-tool")
+        assert retrieved is not None
+        assert retrieved.tool.description == "Figma API with key ${FIGMA_API_KEY}"


### PR DESCRIPTION
## Summary

- Implement story 3.4: verify existing `resolve_env_vars()` utility and add missing test coverage
- `resolve_env_vars()` resolves `${VAR}` patterns from environment at runtime; catalog stores placeholders as-is
- Code review fixes: consolidated test helpers, relocated misplaced test, strengthened assertions, added edge cases

Closes #21