### PR TITLE
Add structured logging to service, repository, and env modules

### DIFF
--- a/src/akgentic/catalog/env.py
+++ b/src/akgentic/catalog/env.py
@@ -5,12 +5,15 @@ The catalog stores ``${VAR}`` as-is; this utility is called by runtime
 consumers (e.g. create-team), not by catalog services.
 """
 
+import logging
 import os
 import re
 
 __all__ = [
     "resolve_env_vars",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_env_vars(value: str) -> str:
@@ -35,6 +38,7 @@ def resolve_env_vars(value: str) -> str:
         result = os.environ.get(var_name)
         if result is None:
             raise OSError(f"Environment variable '{var_name}' not set")
+        logger.debug("resolved env var %s", var_name)
         return result
 
     return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", replace, value)

--- a/src/akgentic/catalog/repositories/yaml/agent_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/agent_repo.py
@@ -1,12 +1,15 @@
 """YAML-backed repository for agent catalog entries."""
 
 import builtins
+import logging
 from pathlib import Path
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.queries import AgentQuery
 from akgentic.catalog.repositories.base import AgentCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the repository's list() method shadows the built-in
 

--- a/src/akgentic/catalog/repositories/yaml/team_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/team_repo.py
@@ -1,12 +1,15 @@
 """YAML-backed repository for team catalog entries."""
 
 import builtins
+import logging
 from pathlib import Path
 
 from akgentic.catalog.models.queries import TeamQuery
 from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.repositories.base import TeamCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the repository's list() method shadows the built-in
 

--- a/src/akgentic/catalog/repositories/yaml/template_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/template_repo.py
@@ -1,12 +1,15 @@
 """YAML-backed repository for template catalog entries."""
 
 import builtins
+import logging
 from pathlib import Path
 
 from akgentic.catalog.models.queries import TemplateQuery
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the repository's list() method shadows the built-in
 

--- a/src/akgentic/catalog/repositories/yaml/tool_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/tool_repo.py
@@ -1,12 +1,15 @@
 """YAML-backed repository for tool catalog entries."""
 
 import builtins
+import logging
 from pathlib import Path
 
 from akgentic.catalog.models.queries import ToolQuery
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the repository's list() method shadows the built-in
 

--- a/src/akgentic/catalog/services/agent_catalog.py
+++ b/src/akgentic/catalog/services/agent_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from akgentic.agent.config import AgentConfig
@@ -18,6 +19,8 @@ if TYPE_CHECKING:
     from akgentic.catalog.models.queries import AgentQuery
 
 __all__ = ["AgentCatalog"]
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
@@ -163,10 +166,13 @@ class AgentCatalog:
         Raises:
             CatalogValidationError: If cross-validation fails.
         """
+        logger.debug("creating agent %s", entry.id)
         errors = self.validate_create(entry, pending_names)
         if errors:
             raise CatalogValidationError(errors)
-        return self.repository.create(entry)
+        result = self.repository.create(entry)
+        logger.info("agent created: %s", entry.id)
+        return result
 
     def get(self, id: str) -> AgentEntry | None:
         """Retrieve an agent entry by id.
@@ -215,6 +221,7 @@ class AgentCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If id mismatch or cross-validation fails.
         """
+        logger.debug("updating agent %s", id)
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Agent id '{id}' not found")
         if entry.id != id:
@@ -225,6 +232,7 @@ class AgentCatalog:
         if errors:
             raise CatalogValidationError(errors)
         self.repository.update(id, entry)
+        logger.info("agent updated: %s", id)
 
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence, routing deps, and team refs before delete.
@@ -278,10 +286,12 @@ class AgentCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If the agent is referenced by other entries.
         """
+        logger.debug("deleting agent %s", id)
         errors = self.validate_delete(id)
         if errors:
             if "not found" in errors[0]:
                 raise EntryNotFoundError(errors[0])
             raise CatalogValidationError(errors)
         self.repository.delete(id)
+        logger.info("agent deleted: %s", id)
 

--- a/src/akgentic/catalog/services/team_catalog.py
+++ b/src/akgentic/catalog/services/team_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import logging
 from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TeamQuery
 
 __all__ = ["TeamCatalog"]
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
@@ -126,10 +129,13 @@ class TeamCatalog:
         Raises:
             CatalogValidationError: If cross-validation fails.
         """
+        logger.debug("creating team %s", entry.id)
         errors = self.validate_create(entry)
         if errors:
             raise CatalogValidationError(errors)
-        return self.repository.create(entry)
+        result = self.repository.create(entry)
+        logger.info("team created: %s", entry.id)
+        return result
 
     def get(self, id: str) -> TeamSpec | None:
         """Retrieve a team entry by id.
@@ -172,6 +178,7 @@ class TeamCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If id mismatch or cross-validation fails.
         """
+        logger.debug("updating team %s", id)
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Team id '{id}' not found")
         if entry.id != id:
@@ -182,6 +189,7 @@ class TeamCatalog:
         if errors:
             raise CatalogValidationError(errors)
         self.repository.update(id, entry)
+        logger.info("team updated: %s", id)
 
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence before delete. No downstream refs for teams (v1: D9).
@@ -206,7 +214,9 @@ class TeamCatalog:
         Raises:
             EntryNotFoundError: If no entry with the given id exists.
         """
+        logger.debug("deleting team %s", id)
         errors = self.validate_delete(id)
         if errors:
             raise EntryNotFoundError(errors[0])
         self.repository.delete(id)
+        logger.info("team deleted: %s", id)

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import logging
 from typing import TYPE_CHECKING
 
 from akgentic.agent.config import AgentConfig
@@ -16,6 +17,8 @@ if TYPE_CHECKING:
     from akgentic.catalog.services.agent_catalog import AgentCatalog
 
 __all__ = ["TemplateCatalog"]
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
@@ -68,10 +71,13 @@ class TemplateCatalog:
         Raises:
             CatalogValidationError: If an entry with the same id already exists.
         """
+        logger.debug("creating template %s", entry.id)
         errors = self.validate_create(entry)
         if errors:
             raise CatalogValidationError(errors)
-        return self.repository.create(entry)
+        result = self.repository.create(entry)
+        logger.info("template created: %s", entry.id)
+        return result
 
     def get(self, id: str) -> TemplateEntry | None:
         """Retrieve a template entry by id.
@@ -114,6 +120,7 @@ class TemplateCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If the entry id does not match the update target.
         """
+        logger.debug("updating template %s", id)
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Template id '{id}' not found")
         if entry.id != id:
@@ -121,6 +128,7 @@ class TemplateCatalog:
                 [f"Entry id '{entry.id}' does not match update target '{id}'"]
             )
         self.repository.update(id, entry)
+        logger.info("template updated: %s", id)
 
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence and downstream references before delete.
@@ -158,9 +166,11 @@ class TemplateCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If the template is referenced by agents.
         """
+        logger.debug("deleting template %s", id)
         errors = self.validate_delete(id)
         if errors:
             if "not found" in errors[0]:
                 raise EntryNotFoundError(errors[0])
             raise CatalogValidationError(errors)
         self.repository.delete(id)
+        logger.info("template deleted: %s", id)

--- a/src/akgentic/catalog/services/tool_catalog.py
+++ b/src/akgentic/catalog/services/tool_catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import logging
 from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
@@ -14,6 +15,8 @@ if TYPE_CHECKING:
     from akgentic.catalog.services.agent_catalog import AgentCatalog
 
 __all__ = ["ToolCatalog"]
+
+logger = logging.getLogger(__name__)
 
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
@@ -66,10 +69,13 @@ class ToolCatalog:
         Raises:
             CatalogValidationError: If an entry with the same id already exists.
         """
+        logger.debug("creating tool %s", entry.id)
         errors = self.validate_create(entry)
         if errors:
             raise CatalogValidationError(errors)
-        return self.repository.create(entry)
+        result = self.repository.create(entry)
+        logger.info("tool created: %s", entry.id)
+        return result
 
     def get(self, id: str) -> ToolEntry | None:
         """Retrieve a tool entry by id.
@@ -112,6 +118,7 @@ class ToolCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If the entry id does not match the update target.
         """
+        logger.debug("updating tool %s", id)
         if self.repository.get(id) is None:
             raise EntryNotFoundError(f"Tool id '{id}' not found")
         if entry.id != id:
@@ -119,6 +126,7 @@ class ToolCatalog:
                 [f"Entry id '{entry.id}' does not match update target '{id}'"]
             )
         self.repository.update(id, entry)
+        logger.info("tool updated: %s", id)
 
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence and downstream references before delete.
@@ -152,9 +160,11 @@ class ToolCatalog:
             EntryNotFoundError: If no entry with the given id exists.
             CatalogValidationError: If the tool is referenced by agents.
         """
+        logger.debug("deleting tool %s", id)
         errors = self.validate_delete(id)
         if errors:
             if "not found" in errors[0]:
                 raise EntryNotFoundError(errors[0])
             raise CatalogValidationError(errors)
         self.repository.delete(id)
+        logger.info("tool deleted: %s", id)


### PR DESCRIPTION
## Summary

The original story 7-2 implementation (logging for 9 source files) was never committed — it existed only as uncommitted working tree changes. PR #26 only contained the code review fix for `_base.py`.

This PR adds the missing implementation:
- 4 service modules: DEBUG on CUD entry, INFO on success
- 4 repository subclasses: module-level logger declaration
- env.py: DEBUG on successful env var resolution

All log calls use lazy `%s` formatting, identifiers only, zero f-strings.

Closes #25