### PR TITLE
Code Style Alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ disallow_untyped_defs = true
 target-version = "py312"
 line-length = 100
 
+[tool.ruff.format]
+quote-style = "double"
+
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "ANN", "ASYNC"]
 ignore = ["ANN401", "N802"]

--- a/src/akgentic/__init__.py
+++ b/src/akgentic/__init__.py
@@ -1,2 +1,4 @@
 # Namespace package - allows akgentic.core, akgentic.llm, akgentic.agent to coexist
+from __future__ import annotations
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -5,6 +5,8 @@ query models, error types, abstract and YAML repository interfaces,
 catalog services, and the resolve_env_vars utility.
 """
 
+from __future__ import annotations
+
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError

--- a/src/akgentic/catalog/env.py
+++ b/src/akgentic/catalog/env.py
@@ -5,6 +5,8 @@ The catalog stores ``${VAR}`` as-is; this utility is called by runtime
 consumers (e.g. create-team), not by catalog services.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import re

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -5,6 +5,8 @@ TeamMemberSpec), query filter models (TemplateQuery, ToolQuery, AgentQuery,
 TeamQuery), and error types (CatalogValidationError, EntryNotFoundError).
 """
 
+from __future__ import annotations
+
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery

--- a/src/akgentic/catalog/models/_types.py
+++ b/src/akgentic/catalog/models/_types.py
@@ -1,5 +1,7 @@
 """Shared type aliases for catalog models."""
 
+from __future__ import annotations
+
 from typing import Annotated
 
 from pydantic import StringConstraints

--- a/src/akgentic/catalog/models/agent.py
+++ b/src/akgentic/catalog/models/agent.py
@@ -1,5 +1,7 @@
 """Agent catalog entry with dynamic config resolution."""
 
+from __future__ import annotations
+
 from typing import Any, Protocol, get_args
 
 from pydantic import BaseModel, Field, model_validator
@@ -112,9 +114,7 @@ class AgentEntry(BaseModel):
                 agent_cls = import_class(agent_class_path)
                 config_cls = _extract_config_type(agent_cls)
             except (ImportError, AttributeError, ValueError) as e:
-                raise ValueError(
-                    f"Cannot resolve agent_class '{agent_class_path}': {e}"
-                ) from e
+                raise ValueError(f"Cannot resolve agent_class '{agent_class_path}': {e}") from e
             config_data = card_data["config"]
             config_data.pop("tools", None)
             card_data["config"] = config_cls.model_validate(config_data)
@@ -140,9 +140,7 @@ class AgentEntry(BaseModel):
             tools.append(entry.tool)
         return tools
 
-    def resolve_template(
-        self, template_catalog: _TemplateCatalogProtocol
-    ) -> PromptTemplate | None:
+    def resolve_template(self, template_catalog: _TemplateCatalogProtocol) -> PromptTemplate | None:
         """Resolve @-reference to PromptTemplate, or None if no prompt.
 
         Does NOT render templates (rendering is a runtime concern, D4).

--- a/src/akgentic/catalog/models/errors.py
+++ b/src/akgentic/catalog/models/errors.py
@@ -4,6 +4,8 @@ Provides domain-specific exceptions for catalog operations, distinct from
 Pydantic's ValidationError (which covers object-level validation).
 """
 
+from __future__ import annotations
+
 __all__ = [
     "CatalogValidationError",
     "EntryNotFoundError",

--- a/src/akgentic/catalog/models/queries.py
+++ b/src/akgentic/catalog/models/queries.py
@@ -1,5 +1,7 @@
 """Query models for catalog repository search operations."""
 
+from __future__ import annotations
+
 from pydantic import BaseModel, ConfigDict, Field
 
 __all__ = [
@@ -27,9 +29,7 @@ class ToolQuery(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     id: str | None = Field(default=None, description="Filter by exact tool id")
-    tool_class: str | None = Field(
-        default=None, description="Filter by exact tool class path"
-    )
+    tool_class: str | None = Field(default=None, description="Filter by exact tool class path")
     name: str | None = Field(default=None, description="Filter by tool name substring")
     description: str | None = Field(
         default=None, description="Filter by tool description substring"

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -89,9 +89,7 @@ class TeamSpec(BaseModel):
         """
         entry = agent_catalog.get(self.entry_point)
         if entry is None:
-            raise CatalogValidationError(
-                [f"Entry point '{self.entry_point}' not found in catalog"]
-            )
+            raise CatalogValidationError([f"Entry point '{self.entry_point}' not found in catalog"])
         return entry  # type: ignore[no-any-return]
 
     def resolve_message_types(self) -> list[type]:

--- a/src/akgentic/catalog/models/template.py
+++ b/src/akgentic/catalog/models/template.py
@@ -1,5 +1,7 @@
 """TemplateEntry model for prompt template catalog entries."""
 
+from __future__ import annotations
+
 from string import Formatter
 
 from pydantic import BaseModel, Field, computed_field

--- a/src/akgentic/catalog/models/tool.py
+++ b/src/akgentic/catalog/models/tool.py
@@ -1,5 +1,7 @@
 """ToolEntry model for tool configuration catalog entries."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
@@ -49,9 +51,7 @@ class ToolEntry(BaseModel):
             try:
                 klass = import_class(tool_class_path)
             except (ImportError, AttributeError) as e:
-                raise ValueError(
-                    f"Cannot resolve tool_class '{tool_class_path}': {e}"
-                ) from e
+                raise ValueError(f"Cannot resolve tool_class '{tool_class_path}': {e}") from e
             data["tool"] = klass.model_validate(data["tool"])
         return data
 

--- a/src/akgentic/catalog/refs.py
+++ b/src/akgentic/catalog/refs.py
@@ -9,6 +9,8 @@ These functions must ONLY be applied to ``PromptTemplate.template`` fields,
 never to ``config.name`` or ``routes_to`` values.
 """
 
+from __future__ import annotations
+
 __all__ = [
     "_is_catalog_ref",
     "_resolve_ref",

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -6,6 +6,8 @@ and their YAML-backed implementations. New backends (e.g. MongoDB) will
 add their concrete repositories here.
 """
 
+from __future__ import annotations
+
 from akgentic.catalog.repositories.base import (
     AgentCatalogRepository,
     TeamCatalogRepository,

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -5,6 +5,8 @@ Each entity type (template, tool, agent, team) gets its own ABC with ``create``,
 (e.g. ``YamlRepositoryBase``) implement these interfaces.
 """
 
+from __future__ import annotations
+
 import builtins
 from abc import ABC, abstractmethod
 

--- a/src/akgentic/catalog/repositories/yaml/__init__.py
+++ b/src/akgentic/catalog/repositories/yaml/__init__.py
@@ -5,6 +5,8 @@ using a shared base class for file I/O and caching. Re-exports all four
 YAML repository implementations.
 """
 
+from __future__ import annotations
+
 from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository

--- a/src/akgentic/catalog/repositories/yaml/_base.py
+++ b/src/akgentic/catalog/repositories/yaml/_base.py
@@ -5,6 +5,8 @@ with cross-file duplicate-id detection on load and automatic cache invalidation 
 writes.
 """
 
+from __future__ import annotations
+
 import builtins
 import logging
 from pathlib import Path
@@ -36,9 +38,7 @@ class YamlRepositoryBase[T: BaseModel]:
         self._catalog_dir = catalog_dir
         self._entries: _list[T] | None = None
 
-    # ------------------------------------------------------------------
-    # Loading & caching
-    # ------------------------------------------------------------------
+    # --- Loading & Caching ---
 
     def _load_all(self) -> _list[T]:
         """Scan catalog_dir for *.yaml files, validate entries, detect duplicates.
@@ -102,9 +102,7 @@ class YamlRepositoryBase[T: BaseModel]:
         self._entries = None
         logger.debug("cache invalidated, will reload on next access")
 
-    # ------------------------------------------------------------------
-    # Read operations
-    # ------------------------------------------------------------------
+    # --- Read Operations ---
 
     def get(self, id: str) -> T | None:
         """Return entry by id, or None if not found.
@@ -128,9 +126,7 @@ class YamlRepositoryBase[T: BaseModel]:
         """
         return _list(self._ensure_loaded())
 
-    # ------------------------------------------------------------------
-    # Write operations
-    # ------------------------------------------------------------------
+    # --- Write Operations ---
 
     def create(self, entry: T) -> str:
         """Persist a new entry to a YAML file and invalidate cache.

--- a/src/akgentic/catalog/repositories/yaml/agent_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/agent_repo.py
@@ -1,13 +1,18 @@
 """YAML-backed repository for agent catalog entries."""
 
+from __future__ import annotations
+
 import builtins
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.queries import AgentQuery
 from akgentic.catalog.repositories.base import AgentCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import AgentQuery
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +67,7 @@ class YamlAgentCatalogRepository(AgentCatalogRepository, YamlRepositoryBase[Agen
                 continue
             if query.role is not None and entry.card.role != query.role:
                 continue
-            if query.skills is not None and not (
-                set(query.skills) & set(entry.card.skills)
-            ):
+            if query.skills is not None and not (set(query.skills) & set(entry.card.skills)):
                 continue
             if (
                 query.description is not None

--- a/src/akgentic/catalog/repositories/yaml/team_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/team_repo.py
@@ -1,13 +1,18 @@
 """YAML-backed repository for team catalog entries."""
 
+from __future__ import annotations
+
 import builtins
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from akgentic.catalog.models.queries import TeamQuery
 from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
 from akgentic.catalog.repositories.base import TeamCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import TeamQuery
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +90,7 @@ class YamlTeamCatalogRepository(TeamCatalogRepository, YamlRepositoryBase[TeamSp
                 and query.description.lower() not in entry.description.lower()
             ):
                 continue
-            if query.agent_id is not None and not _agent_in_members(
-                query.agent_id, entry.members
-            ):
+            if query.agent_id is not None and not _agent_in_members(query.agent_id, entry.members):
                 continue
             results.append(entry)
         return results

--- a/src/akgentic/catalog/repositories/yaml/template_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/template_repo.py
@@ -1,13 +1,18 @@
 """YAML-backed repository for template catalog entries."""
 
+from __future__ import annotations
+
 import builtins
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from akgentic.catalog.models.queries import TemplateQuery
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import TemplateQuery
 
 logger = logging.getLogger(__name__)
 

--- a/src/akgentic/catalog/repositories/yaml/tool_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/tool_repo.py
@@ -1,13 +1,18 @@
 """YAML-backed repository for tool catalog entries."""
 
+from __future__ import annotations
+
 import builtins
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from akgentic.catalog.models.queries import ToolQuery
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import ToolQuery
 
 logger = logging.getLogger(__name__)
 

--- a/src/akgentic/catalog/services/__init__.py
+++ b/src/akgentic/catalog/services/__init__.py
@@ -5,6 +5,8 @@ Services wrap repositories with CRUD operations, cross-catalog reference
 validation, and delete-protection for entries referenced downstream.
 """
 
+from __future__ import annotations
+
 from akgentic.catalog.services.agent_catalog import AgentCatalog
 from akgentic.catalog.services.team_catalog import TeamCatalog
 from akgentic.catalog.services.template_catalog import TemplateCatalog

--- a/src/akgentic/catalog/services/agent_catalog.py
+++ b/src/akgentic/catalog/services/agent_catalog.py
@@ -37,6 +37,8 @@ class _TeamCatalogProtocol(Protocol):
 class AgentCatalog:
     """Service layer for agent catalog entries with cross-validation."""
 
+    # --- Initialization ---
+
     def __init__(
         self,
         repository: AgentCatalogRepository,
@@ -64,6 +66,8 @@ class AgentCatalog:
     def team_catalog(self, value: _TeamCatalogProtocol | None) -> None:
         """Set the downstream team catalog for delete protection."""
         self._team_catalog = value
+
+    # --- Validation ---
 
     def _validate_entry(
         self,
@@ -101,9 +105,7 @@ class AgentCatalog:
                 template_id = _resolve_ref(prompt.template)
                 tpl_entry = self._template_catalog.get(template_id)
                 if tpl_entry is None:
-                    errors.append(
-                        f"Template '@{template_id}' not found in TemplateCatalog"
-                    )
+                    errors.append(f"Template '@{template_id}' not found in TemplateCatalog")
                 else:
                     expected = set(tpl_entry.placeholders)
                     actual = set(prompt.params.keys())
@@ -116,20 +118,15 @@ class AgentCatalog:
                         )
                     if extra:
                         errors.append(
-                            f"Template '@{template_id}' extra params: "
-                            f"{', '.join(sorted(extra))}"
+                            f"Template '@{template_id}' extra params: {', '.join(sorted(extra))}"
                         )
 
         # AC3/AC4: Route target validation
         valid_names = pending_names or set()
-        existing_names = {
-            a.card.config.name for a in self.repository.list()
-        }
+        existing_names = {a.card.config.name for a in self.repository.list()}
         for route_name in entry.card.routes_to:
             if route_name not in existing_names and route_name not in valid_names:
-                errors.append(
-                    f"Route target '{route_name}' not found in AgentCatalog"
-                )
+                errors.append(f"Route target '{route_name}' not found in AgentCatalog")
 
         return errors
 
@@ -148,6 +145,8 @@ class AgentCatalog:
             List of validation error strings (empty if valid).
         """
         return self._validate_entry(entry, pending_names)
+
+    # --- CRUD Operations ---
 
     def create(
         self,
@@ -234,6 +233,8 @@ class AgentCatalog:
         self.repository.update(id, entry)
         logger.info("agent updated: %s", id)
 
+    # --- Delete Protection ---
+
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence, routing deps, and team refs before delete.
 
@@ -256,22 +257,18 @@ class AgentCatalog:
             if other.id == id:
                 continue
             if agent_name in other.card.routes_to:
-                errors.append(
-                    f"Agent '{other.id}' routes to '{agent_name}' — cannot delete"
-                )
+                errors.append(f"Agent '{other.id}' routes to '{agent_name}' — cannot delete")
 
         # Check downstream TeamCatalog references (only when wired)
         if self._team_catalog is not None:
             for team in self._team_catalog.list():
                 if agent_in_members(id, team.members):
                     errors.append(
-                        f"Team '{team.id}' references agent '{id}'"
-                        f" in members — cannot delete"
+                        f"Team '{team.id}' references agent '{id}' in members — cannot delete"
                     )
                 if id in team.profiles:
                     errors.append(
-                        f"Team '{team.id}' references agent '{id}'"
-                        f" in profiles — cannot delete"
+                        f"Team '{team.id}' references agent '{id}' in profiles — cannot delete"
                     )
 
         return errors
@@ -294,4 +291,3 @@ class AgentCatalog:
             raise CatalogValidationError(errors)
         self.repository.delete(id)
         logger.info("agent deleted: %s", id)
-

--- a/src/akgentic/catalog/services/team_catalog.py
+++ b/src/akgentic/catalog/services/team_catalog.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec, agent_in_members
 from akgentic.catalog.repositories.base import TeamCatalogRepository
-from akgentic.catalog.services.agent_catalog import AgentCatalog
 from akgentic.core.utils.deserializer import import_class
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TeamQuery
+    from akgentic.catalog.services.agent_catalog import AgentCatalog
 
 __all__ = ["TeamCatalog"]
 
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
 
-def _collect_agent_ids(members: _list[TeamMemberSpec]) -> _list[str]:
+def _collect_agent_ids(members: list[TeamMemberSpec]) -> list[str]:
     """Recursively collect all agent_ids from the members tree.
 
     Args:
@@ -31,7 +31,7 @@ def _collect_agent_ids(members: _list[TeamMemberSpec]) -> _list[str]:
     Returns:
         Flat list of all agent_ids found in the tree.
     """
-    ids: _list[str] = []
+    ids: list[str] = []
     for m in members:
         ids.append(m.agent_id)
         if m.members:

--- a/src/akgentic/catalog/services/team_catalog.py
+++ b/src/akgentic/catalog/services/team_catalog.py
@@ -22,8 +22,27 @@ logger = logging.getLogger(__name__)
 _list = builtins.list  # Alias: the service's list() method shadows the built-in
 
 
+def _collect_agent_ids(members: _list[TeamMemberSpec]) -> _list[str]:
+    """Recursively collect all agent_ids from the members tree.
+
+    Args:
+        members: The member tree to traverse.
+
+    Returns:
+        Flat list of all agent_ids found in the tree.
+    """
+    ids: _list[str] = []
+    for m in members:
+        ids.append(m.agent_id)
+        if m.members:
+            ids.extend(_collect_agent_ids(m.members))
+    return ids
+
+
 class TeamCatalog:
     """Service layer for team catalog entries with cross-validation."""
+
+    # --- Initialization ---
 
     def __init__(
         self,
@@ -39,22 +58,7 @@ class TeamCatalog:
         self.repository = repository
         self._agent_catalog = agent_catalog
 
-    @staticmethod
-    def _collect_agent_ids(members: _list[TeamMemberSpec]) -> _list[str]:
-        """Recursively collect all agent_ids from the members tree.
-
-        Args:
-            members: The member tree to traverse.
-
-        Returns:
-            Flat list of all agent_ids found in the tree.
-        """
-        ids: _list[str] = []
-        for m in members:
-            ids.append(m.agent_id)
-            if m.members:
-                ids.extend(TeamCatalog._collect_agent_ids(m.members))
-        return ids
+    # --- Validation ---
 
     def _validate_entry(
         self,
@@ -79,23 +83,17 @@ class TeamCatalog:
 
         # AC2: entry_point must be an agent_id in the members tree
         if not agent_in_members(entry.entry_point, entry.members):
-            errors.append(
-                f"Entry point '{entry.entry_point}' not found in members tree"
-            )
+            errors.append(f"Entry point '{entry.entry_point}' not found in members tree")
 
         # AC1/AC15: Every agent_id in members tree must exist in AgentCatalog
-        for agent_id in TeamCatalog._collect_agent_ids(entry.members):
+        for agent_id in _collect_agent_ids(entry.members):
             if self._agent_catalog.get(agent_id) is None:
-                errors.append(
-                    f"Agent '{agent_id}' not found in AgentCatalog"
-                )
+                errors.append(f"Agent '{agent_id}' not found in AgentCatalog")
 
         # AC3: Every agent_id in profiles must exist in AgentCatalog
         for agent_id in entry.profiles:
             if self._agent_catalog.get(agent_id) is None:
-                errors.append(
-                    f"Profile agent '{agent_id}' not found in AgentCatalog"
-                )
+                errors.append(f"Profile agent '{agent_id}' not found in AgentCatalog")
 
         # AC4: Every message_type must be resolvable
         for mt in entry.message_types:
@@ -116,6 +114,8 @@ class TeamCatalog:
             List of validation error strings (empty if valid).
         """
         return self._validate_entry(entry)
+
+    # --- CRUD Operations ---
 
     def create(self, entry: TeamSpec) -> str:
         """Persist a new team entry.
@@ -190,6 +190,8 @@ class TeamCatalog:
             raise CatalogValidationError(errors)
         self.repository.update(id, entry)
         logger.info("team updated: %s", id)
+
+    # --- Delete Protection ---
 
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence before delete. No downstream refs for teams (v1: D9).

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -26,6 +26,8 @@ _list = builtins.list  # Alias: the service's list() method shadows the built-in
 class TemplateCatalog:
     """Service layer for template catalog entries with delete protection."""
 
+    # --- Initialization ---
+
     def __init__(self, repository: TemplateCatalogRepository) -> None:
         """Initialize with repository for template entry storage.
 
@@ -44,6 +46,8 @@ class TemplateCatalog:
     def agent_catalog(self, value: AgentCatalog | None) -> None:
         """Set the downstream agent catalog for delete protection."""
         self._agent_catalog = value
+
+    # --- CRUD Operations ---
 
     def validate_create(self, entry: TemplateEntry) -> _list[str]:
         """Check for duplicate id.
@@ -130,6 +134,8 @@ class TemplateCatalog:
         self.repository.update(id, entry)
         logger.info("template updated: %s", id)
 
+    # --- Delete Protection ---
+
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence and downstream references before delete.
 
@@ -151,8 +157,7 @@ class TemplateCatalog:
                         ref_id = _resolve_ref(config.prompt.template)
                         if ref_id == id:
                             errors.append(
-                                f"Agent '{agent.id}' references template '@{id}'"
-                                f" — cannot delete"
+                                f"Agent '{agent.id}' references template '@{id}' — cannot delete"
                             )
         return errors
 

--- a/src/akgentic/catalog/services/tool_catalog.py
+++ b/src/akgentic/catalog/services/tool_catalog.py
@@ -24,6 +24,8 @@ _list = builtins.list  # Alias: the service's list() method shadows the built-in
 class ToolCatalog:
     """Service layer for tool catalog entries with delete protection."""
 
+    # --- Initialization ---
+
     def __init__(self, repository: ToolCatalogRepository) -> None:
         """Initialize with repository for tool entry storage.
 
@@ -42,6 +44,8 @@ class ToolCatalog:
     def agent_catalog(self, value: AgentCatalog | None) -> None:
         """Set the downstream agent catalog for delete protection."""
         self._agent_catalog = value
+
+    # --- CRUD Operations ---
 
     def validate_create(self, entry: ToolEntry) -> _list[str]:
         """Check for duplicate id.
@@ -128,6 +132,8 @@ class ToolCatalog:
         self.repository.update(id, entry)
         logger.info("tool updated: %s", id)
 
+    # --- Delete Protection ---
+
     def validate_delete(self, id: str) -> _list[str]:
         """Check existence and downstream references before delete.
 
@@ -145,8 +151,7 @@ class ToolCatalog:
             for agent in self._agent_catalog.repository.list():
                 if id in agent.tool_ids:
                     errors.append(
-                        f"Agent '{agent.id}' references tool '{id}'"
-                        f" in tool_ids — cannot delete"
+                        f"Agent '{agent.id}' references tool '{id}' in tool_ids — cannot delete"
                     )
         return errors
 


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to all 25 src files
- Add `if TYPE_CHECKING:` blocks for type-only imports (query classes in YAML repos, AgentCatalog in service layer)
- Add `[tool.ruff.format]` with `quote-style = "double"` and run `ruff format` on src/
- Convert `TeamCatalog._collect_agent_ids` from `@staticmethod` to module-level function
- Add `# --- Section Name ---` separators to classes exceeding 100 lines

## Quality Gates

- `ruff check`: 0 errors
- `ruff format --check`: 25 files clean
- `mypy`: 0 errors in 25 source files
- `pytest`: 350 passed, 98% coverage
- Zero test files modified

Closes #28