### PR TITLE
MongoDB connection infrastructure and lazy import guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "mypy>=1.8.0",
     "ruff>=0.1.0",
     "types-PyYAML>=6.0",
+    "mongomock>=4.0.0",
 ]
 
 [build-system]

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -58,8 +58,11 @@ __all__ = [
 ]
 
 try:
-    from akgentic.catalog.repositories.mongo import MongoCatalogConfig
-    from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+    from akgentic.catalog.repositories.mongo import (
+        MongoCatalogConfig,
+        from_document,
+        to_document,
+    )
 
     __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
 except ImportError:

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -2,7 +2,8 @@
 
 Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamSpec),
 query models, error types, abstract and YAML repository interfaces,
-catalog services, and the resolve_env_vars utility.
+catalog services, and the resolve_env_vars utility. MongoDB backend exports
+are conditionally available when pymongo is installed.
 """
 
 from __future__ import annotations
@@ -55,3 +56,11 @@ __all__ = [
     "YamlToolCatalogRepository",
     "resolve_env_vars",
 ]
+
+try:
+    from akgentic.catalog.repositories.mongo import MongoCatalogConfig
+    from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+    __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
+except ImportError:
+    pass

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -2,8 +2,8 @@
 
 Re-exports abstract repository interfaces (TemplateCatalogRepository,
 ToolCatalogRepository, AgentCatalogRepository, TeamCatalogRepository)
-and their YAML-backed implementations. New backends (e.g. MongoDB) will
-add their concrete repositories here.
+and their YAML-backed implementations. MongoDB backend exports are
+conditionally available when pymongo is installed.
 """
 
 from __future__ import annotations
@@ -29,3 +29,11 @@ __all__ = [
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
 ]
+
+try:
+    from akgentic.catalog.repositories.mongo import MongoCatalogConfig
+    from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+    __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
+except ImportError:
+    pass

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -31,8 +31,11 @@ __all__ = [
 ]
 
 try:
-    from akgentic.catalog.repositories.mongo import MongoCatalogConfig
-    from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+    from akgentic.catalog.repositories.mongo import (
+        MongoCatalogConfig,
+        from_document,
+        to_document,
+    )
 
     __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
 except ImportError:

--- a/src/akgentic/catalog/repositories/mongo/__init__.py
+++ b/src/akgentic/catalog/repositories/mongo/__init__.py
@@ -1,0 +1,29 @@
+"""Public API surface for MongoDB-backed catalog repositories.
+
+Gates all MongoDB imports behind a pymongo availability check. When pymongo
+is not installed, importing this package raises ImportError with installation
+instructions. When pymongo IS available, re-exports MongoCatalogConfig and
+shared document helpers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pymongo  # noqa: F401 — side-effect import to verify availability
+except ImportError as exc:
+    logger.warning("pymongo is not installed; MongoDB backend is unavailable")
+    raise ImportError(
+        "pymongo is required for the MongoDB backend. "
+        "Install with: pip install akgentic-catalog[mongo]"
+    ) from exc
+
+# Only reached if pymongo is available
+from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig  # noqa: E402, I001
+from akgentic.catalog.repositories.mongo._helpers import from_document  # noqa: E402
+from akgentic.catalog.repositories.mongo._helpers import to_document  # noqa: E402
+
+__all__ = ["MongoCatalogConfig", "from_document", "to_document"]

--- a/src/akgentic/catalog/repositories/mongo/_config.py
+++ b/src/akgentic/catalog/repositories/mongo/_config.py
@@ -1,0 +1,99 @@
+"""MongoDB catalog configuration model.
+
+Provides validated configuration for MongoDB connection parameters and
+collection naming. The config is serializable and does not hold a MongoClient
+instance — callers use create_client() to obtain one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    import pymongo
+    import pymongo.collection
+    import pymongo.database
+
+logger = logging.getLogger(__name__)
+
+
+class MongoCatalogConfig(BaseModel):
+    """Validated configuration for MongoDB catalog backend.
+
+    Holds connection parameters and collection naming. Does not manage a live
+    MongoClient — use create_client() and get_database()/get_collection()
+    to obtain database objects.
+    """
+
+    connection_string: str = Field(description="MongoDB connection URI")
+    database: str = Field(description="Name of the MongoDB database")
+
+    template_entries_collection: str = Field(
+        default="template_entries",
+        description="Collection name for template catalog entries",
+    )
+    tool_entries_collection: str = Field(
+        default="tool_entries",
+        description="Collection name for tool catalog entries",
+    )
+    agent_entries_collection: str = Field(
+        default="agent_entries",
+        description="Collection name for agent catalog entries",
+    )
+    team_specs_collection: str = Field(
+        default="team_specs",
+        description="Collection name for team spec catalog entries",
+    )
+
+    @field_validator("connection_string")
+    @classmethod
+    def _validate_connection_string(cls, v: str) -> str:
+        """Ensure connection string uses a valid MongoDB URI scheme."""
+        if not v.startswith(("mongodb://", "mongodb+srv://")):
+            msg = f"connection_string must start with 'mongodb://' or 'mongodb+srv://'; got: {v!r}"
+            raise ValueError(msg)
+        return v
+
+    def create_client(self) -> pymongo.MongoClient:  # type: ignore[type-arg]
+        """Create a new MongoClient from the configured connection string.
+
+        Returns:
+            A pymongo.MongoClient instance connected to the configured URI.
+        """
+        import pymongo
+
+        logger.info("Creating MongoClient for database %s", self.database)
+        return pymongo.MongoClient(self.connection_string)
+
+    def get_database(self, client: pymongo.MongoClient) -> pymongo.database.Database:  # type: ignore[type-arg]
+        """Obtain the configured database from a MongoClient.
+
+        Args:
+            client: An active MongoClient instance.
+
+        Returns:
+            The pymongo Database object for the configured database name.
+        """
+        return client[self.database]
+
+    def get_collection(
+        self,
+        client: pymongo.MongoClient,  # type: ignore[type-arg]
+        collection_name: str,
+    ) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+        """Obtain a named collection from the configured database.
+
+        Args:
+            client: An active MongoClient instance.
+            collection_name: One of the configured collection name fields.
+
+        Returns:
+            The pymongo Collection object.
+        """
+        return self.get_database(client)[collection_name]
+
+
+__all__ = ["MongoCatalogConfig"]

--- a/src/akgentic/catalog/repositories/mongo/_helpers.py
+++ b/src/akgentic/catalog/repositories/mongo/_helpers.py
@@ -1,0 +1,58 @@
+"""Shared helpers for MongoDB document ↔ Pydantic model mapping.
+
+Converts between MongoDB's _id convention and the model's id field so that
+all four catalog repositories can share the same round-trip logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+def to_document(entry: BaseModel) -> dict[str, Any]:
+    """Convert a Pydantic model to a MongoDB document.
+
+    Calls model_dump(), removes the ``id`` key, and stores its value as
+    ``_id`` so MongoDB uses the catalog id as the primary key.
+
+    Args:
+        entry: A Pydantic model instance with an ``id`` field.
+
+    Returns:
+        A dict suitable for MongoDB insert/replace operations.
+    """
+    doc = entry.model_dump()
+    id_value = doc.pop("id", None)
+    if id_value is not None:
+        doc["_id"] = id_value
+    logger.debug("to_document: mapped id=%s to _id", id_value)
+    return doc
+
+
+def from_document[T: BaseModel](doc: dict[str, Any], entry_type: type[T]) -> T:
+    """Reconstruct a Pydantic model from a MongoDB document.
+
+    Pops ``_id`` from the document and sets it as ``id``, then validates
+    through the model constructor.
+
+    Args:
+        doc: A MongoDB document dict (may contain ``_id``).
+        entry_type: The Pydantic model class to validate into.
+
+    Returns:
+        A validated instance of entry_type.
+    """
+    data = dict(doc)  # shallow copy to avoid mutating the original
+    id_value = data.pop("_id", None)
+    if id_value is not None and "id" not in data:
+        data["id"] = id_value
+    logger.debug("from_document: mapped _id=%s to id", id_value)
+    return entry_type.model_validate(data)
+
+
+__all__ = ["from_document", "to_document"]

--- a/tests/repositories/mongo/__init__.py
+++ b/tests/repositories/mongo/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for MongoDB-backed catalog repositories."""

--- a/tests/repositories/mongo/conftest.py
+++ b/tests/repositories/mongo/conftest.py
@@ -1,0 +1,52 @@
+"""Shared test fixtures for MongoDB repository tests.
+
+Provides mongomock-backed client, database, and per-collection fixtures
+that mirror the production MongoCatalogConfig collection naming.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import mongomock
+import pytest
+
+if TYPE_CHECKING:
+    import pymongo.collection
+    import pymongo.database
+
+
+@pytest.fixture
+def mongo_client() -> mongomock.MongoClient:  # type: ignore[type-arg]
+    """Provide a mongomock in-memory MongoClient."""
+    return mongomock.MongoClient()
+
+
+@pytest.fixture
+def mongo_db(mongo_client: mongomock.MongoClient) -> pymongo.database.Database:  # type: ignore[type-arg]
+    """Provide the test catalog database."""
+    return mongo_client["test_catalog"]
+
+
+@pytest.fixture
+def template_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the template_entries collection."""
+    return mongo_db["template_entries"]
+
+
+@pytest.fixture
+def tool_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the tool_entries collection."""
+    return mongo_db["tool_entries"]
+
+
+@pytest.fixture
+def agent_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the agent_entries collection."""
+    return mongo_db["agent_entries"]
+
+
+@pytest.fixture
+def team_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the team_specs collection."""
+    return mongo_db["team_specs"]

--- a/tests/repositories/mongo/test_config.py
+++ b/tests/repositories/mongo/test_config.py
@@ -1,0 +1,109 @@
+"""Tests for MongoCatalogConfig (AC-2).
+
+Verifies connection string validation, default collection names, and
+database/collection accessor methods.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import mongomock
+import pytest
+
+from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestMongoCatalogConfigValidation:
+    """AC-2: MongoCatalogConfig validates connection string and collection names."""
+
+    def test_valid_mongodb_connection_string(self) -> None:
+        """Standard mongodb:// URI is accepted."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="catalog",
+        )
+        assert config.connection_string == "mongodb://localhost:27017"
+        assert config.database == "catalog"
+
+    def test_valid_mongodb_srv_connection_string(self) -> None:
+        """SRV mongodb+srv:// URI is accepted."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb+srv://user:pass@cluster.example.com",
+            database="catalog",
+        )
+        assert config.connection_string.startswith("mongodb+srv://")
+
+    def test_invalid_connection_string_raises(self) -> None:
+        """Non-MongoDB URI scheme is rejected."""
+        with pytest.raises(ValueError, match="must start with 'mongodb://'"):
+            MongoCatalogConfig(
+                connection_string="postgres://localhost:5432",
+                database="catalog",
+            )
+
+    def test_empty_connection_string_raises(self) -> None:
+        """Empty string does not pass validation."""
+        with pytest.raises(ValueError, match="must start with 'mongodb://'"):
+            MongoCatalogConfig(connection_string="", database="catalog")
+
+    def test_default_collection_names(self) -> None:
+        """Default collection names match architecture spec."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="catalog",
+        )
+        assert config.template_entries_collection == "template_entries"
+        assert config.tool_entries_collection == "tool_entries"
+        assert config.agent_entries_collection == "agent_entries"
+        assert config.team_specs_collection == "team_specs"
+
+    def test_custom_collection_names(self) -> None:
+        """Collection names can be overridden."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="catalog",
+            template_entries_collection="my_templates",
+            tool_entries_collection="my_tools",
+        )
+        assert config.template_entries_collection == "my_templates"
+        assert config.tool_entries_collection == "my_tools"
+
+
+class TestMongoCatalogConfigAccessors:
+    """AC-2: MongoCatalogConfig provides database and collection accessors."""
+
+    def test_get_database_returns_named_database(self) -> None:
+        """get_database() returns the correct database by name."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="test_db",
+        )
+        client = mongomock.MongoClient()
+        db = config.get_database(client)
+        assert db.name == "test_db"
+
+    def test_get_collection_returns_named_collection(self) -> None:
+        """get_collection() returns the correct collection from the database."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="test_db",
+        )
+        client = mongomock.MongoClient()
+        coll = config.get_collection(client, config.template_entries_collection)
+        assert coll.name == "template_entries"
+
+    def test_create_client_returns_mongo_client(self) -> None:
+        """create_client() returns a MongoClient instance."""
+        config = MongoCatalogConfig(
+            connection_string="mongodb://localhost:27017",
+            database="test_db",
+        )
+        # mongomock patches MongoClient so this works in tests
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("pymongo.MongoClient", mongomock.MongoClient)
+            client = config.create_client()
+            assert client is not None

--- a/tests/repositories/mongo/test_config.py
+++ b/tests/repositories/mongo/test_config.py
@@ -6,15 +6,10 @@ database/collection accessor methods.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import mongomock
 import pytest
 
 from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig
-
-if TYPE_CHECKING:
-    pass
 
 
 class TestMongoCatalogConfigValidation:
@@ -97,7 +92,7 @@ class TestMongoCatalogConfigAccessors:
         assert coll.name == "template_entries"
 
     def test_create_client_returns_mongo_client(self) -> None:
-        """create_client() returns a MongoClient instance."""
+        """create_client() returns a functional MongoClient instance."""
         config = MongoCatalogConfig(
             connection_string="mongodb://localhost:27017",
             database="test_db",
@@ -106,4 +101,4 @@ class TestMongoCatalogConfigAccessors:
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr("pymongo.MongoClient", mongomock.MongoClient)
             client = config.create_client()
-            assert client is not None
+            assert isinstance(client, mongomock.MongoClient)

--- a/tests/repositories/mongo/test_helpers.py
+++ b/tests/repositories/mongo/test_helpers.py
@@ -1,0 +1,121 @@
+"""Tests for _id ↔ id round-trip mapping helpers (AC-3).
+
+Verifies that to_document() and from_document() correctly map between
+MongoDB's _id convention and the model's id field for all four entry types.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+# Import factory functions from root conftest
+from tests.conftest import make_agent, make_team, make_template, make_tool
+
+
+class TestToDocument:
+    """AC-3: to_document() converts model id to MongoDB _id."""
+
+    def test_template_entry_id_becomes_underscore_id(self) -> None:
+        """TemplateEntry.id is stored as _id in the document."""
+        entry = make_template(id="tpl-1")
+        doc = to_document(entry)
+        assert "_id" in doc
+        assert doc["_id"] == "tpl-1"
+        assert "id" not in doc
+
+    def test_tool_entry_id_becomes_underscore_id(self) -> None:
+        """ToolEntry.id is stored as _id in the document."""
+        entry = make_tool(id="tool-1")
+        doc = to_document(entry)
+        assert doc["_id"] == "tool-1"
+        assert "id" not in doc
+
+    def test_agent_entry_id_becomes_underscore_id(self) -> None:
+        """AgentEntry.id is stored as _id in the document."""
+        entry = make_agent(id="agent-1")
+        doc = to_document(entry)
+        assert doc["_id"] == "agent-1"
+        assert "id" not in doc
+
+    def test_team_spec_id_becomes_underscore_id(self) -> None:
+        """TeamSpec.id is stored as _id in the document."""
+        entry = make_team(id="team-1")
+        doc = to_document(entry)
+        assert doc["_id"] == "team-1"
+        assert "id" not in doc
+
+
+class TestFromDocument:
+    """AC-3: from_document() converts MongoDB _id back to model id."""
+
+    def test_template_entry_round_trip(self) -> None:
+        """TemplateEntry survives to_document → from_document round-trip."""
+        from akgentic.catalog.models.template import TemplateEntry
+
+        original = make_template(id="tpl-rt", template="Hello {name}")
+        doc = to_document(original)
+        restored = from_document(doc, TemplateEntry)
+        assert restored.id == original.id
+        assert restored.template == original.template
+
+    def test_team_spec_round_trip(self) -> None:
+        """TeamSpec survives to_document → from_document round-trip."""
+        from akgentic.catalog.models.team import TeamSpec
+
+        original = make_team(id="team-rt", name="Round Trip Team")
+        doc = to_document(original)
+        restored = from_document(doc, TeamSpec)
+        assert restored.id == original.id
+        assert restored.name == original.name
+        assert len(restored.members) == len(original.members)
+
+
+class TestEdgeCases:
+    """AC-3: Edge cases for _id / id mapping."""
+
+    def test_from_document_with_no_underscore_id(self) -> None:
+        """Document without _id but with id is handled gracefully."""
+        from akgentic.catalog.models.template import TemplateEntry
+
+        doc = {"id": "direct-id", "template": "Hello {world}"}
+        entry = from_document(doc, TemplateEntry)
+        assert entry.id == "direct-id"
+
+    def test_from_document_with_both_id_and_underscore_id(self) -> None:
+        """When both _id and id exist, id takes precedence (no overwrite)."""
+        from akgentic.catalog.models.template import TemplateEntry
+
+        doc = {"_id": "from-mongo", "id": "from-model", "template": "Hello {world}"}
+        entry = from_document(doc, TemplateEntry)
+        assert entry.id == "from-model"
+
+    def test_to_document_preserves_other_fields(self) -> None:
+        """to_document() keeps all non-id fields intact."""
+        entry = make_template(id="tpl-fields", template="You are {role}")
+        doc = to_document(entry)
+        assert doc["template"] == "You are {role}"
+        assert doc["_id"] == "tpl-fields"
+
+    def test_round_trip_via_mongomock(
+        self,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """Full round-trip through mongomock insert and find."""
+        from akgentic.catalog.models.template import TemplateEntry
+
+        original = make_template(id="mongomock-rt", template="Test {placeholder}")
+        doc = to_document(original)
+        template_collection.insert_one(doc)
+
+        found = template_collection.find_one({"_id": "mongomock-rt"})
+        assert found is not None
+        restored = from_document(found, TemplateEntry)
+        assert restored.id == original.id
+        assert restored.template == original.template

--- a/tests/repositories/mongo/test_helpers.py
+++ b/tests/repositories/mongo/test_helpers.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
 
 if TYPE_CHECKING:
@@ -64,6 +62,26 @@ class TestFromDocument:
         restored = from_document(doc, TemplateEntry)
         assert restored.id == original.id
         assert restored.template == original.template
+
+    def test_tool_entry_round_trip(self) -> None:
+        """ToolEntry survives to_document → from_document round-trip."""
+        from akgentic.catalog.models.tool import ToolEntry
+
+        original = make_tool(id="tool-rt")
+        doc = to_document(original)
+        restored = from_document(doc, ToolEntry)
+        assert restored.id == original.id
+        assert restored.tool_class == original.tool_class
+
+    def test_agent_entry_round_trip(self) -> None:
+        """AgentEntry survives to_document → from_document round-trip."""
+        from akgentic.catalog.models.agent import AgentEntry
+
+        original = make_agent(id="agent-rt")
+        doc = to_document(original)
+        restored = from_document(doc, AgentEntry)
+        assert restored.id == original.id
+        assert restored.card == original.card
 
     def test_team_spec_round_trip(self) -> None:
         """TeamSpec survives to_document → from_document round-trip."""

--- a/tests/repositories/mongo/test_import_guard.py
+++ b/tests/repositories/mongo/test_import_guard.py
@@ -1,0 +1,60 @@
+"""Tests for the MongoDB lazy import guard (AC-1).
+
+Verifies that importing the mongo package raises ImportError with a helpful
+message when pymongo is not installed, and succeeds when it is.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+
+class TestLazyImportGuard:
+    """AC-1: Lazy import guard raises ImportError when pymongo is missing."""
+
+    def test_import_raises_when_pymongo_unavailable(self) -> None:
+        """Simulating missing pymongo triggers ImportError with install instructions."""
+        # Remove cached module to force re-import
+        mod_name = "akgentic.catalog.repositories.mongo"
+        saved = {}
+        for key in list(sys.modules):
+            if key.startswith(mod_name):
+                saved[key] = sys.modules.pop(key)
+        # Also remove pymongo itself if cached
+        pymongo_saved = {}
+        for key in list(sys.modules):
+            if key.startswith("pymongo"):
+                pymongo_saved[key] = sys.modules.pop(key)
+
+        try:
+            with patch.dict(sys.modules, {"pymongo": None}):
+                try:
+                    importlib.import_module(mod_name)
+                    msg = "Expected ImportError was not raised"
+                    raise AssertionError(msg)
+                except ImportError as exc:
+                    assert "pymongo is required" in str(exc)
+                    assert "akgentic-catalog[mongo]" in str(exc)
+        finally:
+            # Restore original modules
+            sys.modules.update(saved)
+            sys.modules.update(pymongo_saved)
+
+    def test_import_succeeds_when_pymongo_available(self) -> None:
+        """When pymongo is installed, the mongo package imports without error."""
+        import akgentic.catalog.repositories.mongo  # noqa: F401
+
+    def test_import_exports_mongo_catalog_config(self) -> None:
+        """Successful import exposes MongoCatalogConfig."""
+        from akgentic.catalog.repositories.mongo import MongoCatalogConfig
+
+        assert MongoCatalogConfig is not None
+
+    def test_import_exports_document_helpers(self) -> None:
+        """Successful import exposes to_document and from_document."""
+        from akgentic.catalog.repositories.mongo import from_document, to_document
+
+        assert callable(to_document)
+        assert callable(from_document)


### PR DESCRIPTION
## Summary

- Add MongoDB connection infrastructure with lazy import guard, `MongoCatalogConfig` Pydantic model, and `_id` ↔ `id` mapping helpers
- Create mongomock-based test fixtures and 25 tests covering all 4 acceptance criteria
- Conditional public API exports for mongo backend (graceful when pymongo absent)

Closes #32

## Fixes Applied During Code Review

- Removed unused `pytest` import in `test_helpers.py` (ruff F401)
- Added missing `AgentEntry` and `ToolEntry` `from_document` round-trip tests (Task 5.3 completion)
- Fixed private module `_helpers` imports in `repositories/__init__.py` and `catalog/__init__.py` to use public `mongo` package API
- Removed dead `if TYPE_CHECKING: pass` block in `test_config.py`
- Strengthened `create_client` test assertion to verify `MongoClient` type