### PR TITLE
MongoDB Repository for Templates and Tools

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -60,10 +60,18 @@ __all__ = [
 try:
     from akgentic.catalog.repositories.mongo import (
         MongoCatalogConfig,
+        MongoTemplateCatalogRepository,
+        MongoToolCatalogRepository,
         from_document,
         to_document,
     )
 
-    __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
+    __all__ += [
+        "MongoCatalogConfig",
+        "MongoTemplateCatalogRepository",
+        "MongoToolCatalogRepository",
+        "from_document",
+        "to_document",
+    ]
 except ImportError:
     pass

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -33,10 +33,18 @@ __all__ = [
 try:
     from akgentic.catalog.repositories.mongo import (
         MongoCatalogConfig,
+        MongoTemplateCatalogRepository,
+        MongoToolCatalogRepository,
         from_document,
         to_document,
     )
 
-    __all__ += ["MongoCatalogConfig", "from_document", "to_document"]
+    __all__ += [
+        "MongoCatalogConfig",
+        "MongoTemplateCatalogRepository",
+        "MongoToolCatalogRepository",
+        "from_document",
+        "to_document",
+    ]
 except ImportError:
     pass

--- a/src/akgentic/catalog/repositories/mongo/__init__.py
+++ b/src/akgentic/catalog/repositories/mongo/__init__.py
@@ -25,5 +25,13 @@ except ImportError as exc:
 from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig  # noqa: E402, I001
 from akgentic.catalog.repositories.mongo._helpers import from_document  # noqa: E402
 from akgentic.catalog.repositories.mongo._helpers import to_document  # noqa: E402
+from akgentic.catalog.repositories.mongo.template_repo import MongoTemplateCatalogRepository  # noqa: E402
+from akgentic.catalog.repositories.mongo.tool_repo import MongoToolCatalogRepository  # noqa: E402
 
-__all__ = ["MongoCatalogConfig", "from_document", "to_document"]
+__all__ = [
+    "MongoCatalogConfig",
+    "MongoTemplateCatalogRepository",
+    "MongoToolCatalogRepository",
+    "from_document",
+    "to_document",
+]

--- a/src/akgentic/catalog/repositories/mongo/template_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/template_repo.py
@@ -6,6 +6,8 @@ import builtins
 import logging
 from typing import TYPE_CHECKING
 
+from pymongo.errors import DuplicateKeyError
+
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
@@ -50,10 +52,11 @@ class MongoTemplateCatalogRepository(TemplateCatalogRepository):
         Raises:
             CatalogValidationError: If an entry with the same id already exists.
         """
-        if self._collection.find_one({"_id": template_entry.id}) is not None:
-            raise CatalogValidationError([f"Entry with id '{template_entry.id}' already exists"])
         doc = to_document(template_entry)
-        self._collection.insert_one(doc)
+        try:
+            self._collection.insert_one(doc)
+        except DuplicateKeyError:
+            raise CatalogValidationError([f"Entry with id '{template_entry.id}' already exists"])
         logger.debug("Created template entry with id=%s", template_entry.id)
         return template_entry.id
 
@@ -74,7 +77,9 @@ class MongoTemplateCatalogRepository(TemplateCatalogRepository):
 
     def list(self) -> _list[TemplateEntry]:
         """Return all template entries."""
-        return [from_document(doc, TemplateEntry) for doc in self._collection.find()]
+        entries = [from_document(doc, TemplateEntry) for doc in self._collection.find()]
+        logger.debug("Listed %d template entries", len(entries))
+        return entries
 
     def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
         """Filter templates by AND-ing all non-None query fields.
@@ -100,6 +105,7 @@ class MongoTemplateCatalogRepository(TemplateCatalogRepository):
         if query.placeholder is not None:
             candidates = [entry for entry in candidates if query.placeholder in entry.placeholders]
 
+        logger.debug("Search returned %d template entries", len(candidates))
         return candidates
 
     def update(self, id: str, template_entry: TemplateEntry) -> None:
@@ -110,8 +116,13 @@ class MongoTemplateCatalogRepository(TemplateCatalogRepository):
             template_entry: The new entry data.
 
         Raises:
+            CatalogValidationError: If template_entry.id does not match id.
             EntryNotFoundError: If no entry with the given id exists.
         """
+        if template_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{template_entry.id}'"]
+            )
         doc = to_document(template_entry)
         result = self._collection.replace_one({"_id": id}, doc)
         if result.matched_count == 0:

--- a/src/akgentic/catalog/repositories/mongo/template_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/template_repo.py
@@ -1,0 +1,133 @@
+"""MongoDB-backed repository for template catalog entries."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import TYPE_CHECKING
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.base import TemplateCatalogRepository
+from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+    from akgentic.catalog.models.queries import TemplateQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+class MongoTemplateCatalogRepository(TemplateCatalogRepository):
+    """MongoDB-backed template catalog repository.
+
+    Args:
+        collection: A pymongo Collection for template entries.
+    """
+
+    def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
+        """Initialize with a pymongo Collection and ensure unique index on _id.
+
+        Args:
+            collection: The MongoDB collection for template entries.
+        """
+        self._collection = collection
+        self._collection.create_index("_id", unique=True)
+        logger.info("MongoTemplateCatalogRepository initialized with index on _id")
+
+    def create(self, template_entry: TemplateEntry) -> str:
+        """Persist a new template entry.
+
+        Args:
+            template_entry: The template entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        if self._collection.find_one({"_id": template_entry.id}) is not None:
+            raise CatalogValidationError([f"Entry with id '{template_entry.id}' already exists"])
+        doc = to_document(template_entry)
+        self._collection.insert_one(doc)
+        logger.debug("Created template entry with id=%s", template_entry.id)
+        return template_entry.id
+
+    def get(self, id: str) -> TemplateEntry | None:
+        """Retrieve a template entry by id.
+
+        Args:
+            id: The template entry id.
+
+        Returns:
+            The template entry, or None if not found.
+        """
+        doc = self._collection.find_one({"_id": id})
+        if doc is None:
+            logger.debug("Template entry not found: id=%s", id)
+            return None
+        return from_document(doc, TemplateEntry)
+
+    def list(self) -> _list[TemplateEntry]:
+        """Return all template entries."""
+        return [from_document(doc, TemplateEntry) for doc in self._collection.find()]
+
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
+        """Filter templates by AND-ing all non-None query fields.
+
+        For ``id``, uses server-side exact match. For ``placeholder``, uses
+        client-side filtering on the computed ``placeholders`` field after
+        hydration via ``from_document()``.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching template entries.
+        """
+        mongo_filter: dict[str, str] = {}
+        if query.id is not None:
+            mongo_filter["_id"] = query.id
+
+        candidates = [
+            from_document(doc, TemplateEntry) for doc in self._collection.find(mongo_filter)
+        ]
+
+        if query.placeholder is not None:
+            candidates = [entry for entry in candidates if query.placeholder in entry.placeholders]
+
+        return candidates
+
+    def update(self, id: str, template_entry: TemplateEntry) -> None:
+        """Update an existing template entry.
+
+        Args:
+            id: The id of the entry to update.
+            template_entry: The new entry data.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        doc = to_document(template_entry)
+        result = self._collection.replace_one({"_id": id}, doc)
+        if result.matched_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated template entry with id=%s", id)
+
+    def delete(self, id: str) -> None:
+        """Delete a template entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        result = self._collection.delete_one({"_id": id})
+        if result.deleted_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted template entry with id=%s", id)

--- a/src/akgentic/catalog/repositories/mongo/tool_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/tool_repo.py
@@ -7,6 +7,8 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+from pymongo.errors import DuplicateKeyError
+
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
@@ -51,10 +53,11 @@ class MongoToolCatalogRepository(ToolCatalogRepository):
         Raises:
             CatalogValidationError: If an entry with the same id already exists.
         """
-        if self._collection.find_one({"_id": tool_entry.id}) is not None:
-            raise CatalogValidationError([f"Entry with id '{tool_entry.id}' already exists"])
         doc = to_document(tool_entry)
-        self._collection.insert_one(doc)
+        try:
+            self._collection.insert_one(doc)
+        except DuplicateKeyError:
+            raise CatalogValidationError([f"Entry with id '{tool_entry.id}' already exists"])
         logger.debug("Created tool entry with id=%s", tool_entry.id)
         return tool_entry.id
 
@@ -75,7 +78,9 @@ class MongoToolCatalogRepository(ToolCatalogRepository):
 
     def list(self) -> _list[ToolEntry]:
         """Return all tool entries."""
-        return [from_document(doc, ToolEntry) for doc in self._collection.find()]
+        entries = [from_document(doc, ToolEntry) for doc in self._collection.find()]
+        logger.debug("Listed %d tool entries", len(entries))
+        return entries
 
     def search(self, query: ToolQuery) -> _list[ToolEntry]:
         """Filter tools by AND-ing all non-None query fields.
@@ -106,7 +111,9 @@ class MongoToolCatalogRepository(ToolCatalogRepository):
                 "$options": "i",
             }
 
-        return [from_document(doc, ToolEntry) for doc in self._collection.find(mongo_filter)]
+        results = [from_document(doc, ToolEntry) for doc in self._collection.find(mongo_filter)]
+        logger.debug("Search returned %d tool entries", len(results))
+        return results
 
     def update(self, id: str, tool_entry: ToolEntry) -> None:
         """Update an existing tool entry.
@@ -116,8 +123,13 @@ class MongoToolCatalogRepository(ToolCatalogRepository):
             tool_entry: The new entry data.
 
         Raises:
+            CatalogValidationError: If tool_entry.id does not match id.
             EntryNotFoundError: If no entry with the given id exists.
         """
+        if tool_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{tool_entry.id}'"]
+            )
         doc = to_document(tool_entry)
         result = self._collection.replace_one({"_id": id}, doc)
         if result.matched_count == 0:

--- a/src/akgentic/catalog/repositories/mongo/tool_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/tool_repo.py
@@ -1,0 +1,139 @@
+"""MongoDB-backed repository for tool catalog entries."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
+from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+    from akgentic.catalog.models.queries import ToolQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+class MongoToolCatalogRepository(ToolCatalogRepository):
+    """MongoDB-backed tool catalog repository.
+
+    Args:
+        collection: A pymongo Collection for tool entries.
+    """
+
+    def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
+        """Initialize with a pymongo Collection and ensure unique index on _id.
+
+        Args:
+            collection: The MongoDB collection for tool entries.
+        """
+        self._collection = collection
+        self._collection.create_index("_id", unique=True)
+        logger.info("MongoToolCatalogRepository initialized with index on _id")
+
+    def create(self, tool_entry: ToolEntry) -> str:
+        """Persist a new tool entry.
+
+        Args:
+            tool_entry: The tool entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        if self._collection.find_one({"_id": tool_entry.id}) is not None:
+            raise CatalogValidationError([f"Entry with id '{tool_entry.id}' already exists"])
+        doc = to_document(tool_entry)
+        self._collection.insert_one(doc)
+        logger.debug("Created tool entry with id=%s", tool_entry.id)
+        return tool_entry.id
+
+    def get(self, id: str) -> ToolEntry | None:
+        """Retrieve a tool entry by id.
+
+        Args:
+            id: The tool entry id.
+
+        Returns:
+            The tool entry, or None if not found.
+        """
+        doc = self._collection.find_one({"_id": id})
+        if doc is None:
+            logger.debug("Tool entry not found: id=%s", id)
+            return None
+        return from_document(doc, ToolEntry)
+
+    def list(self) -> _list[ToolEntry]:
+        """Return all tool entries."""
+        return [from_document(doc, ToolEntry) for doc in self._collection.find()]
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        """Filter tools by AND-ing all non-None query fields.
+
+        Uses server-side exact match for ``id`` and ``tool_class``. Uses
+        ``$regex`` with case-insensitive option for substring matching on
+        ``name`` and ``description`` (nested under ``tool`` key in document).
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching tool entries.
+        """
+        mongo_filter: dict[str, Any] = {}
+        if query.id is not None:
+            mongo_filter["_id"] = query.id
+        if query.tool_class is not None:
+            mongo_filter["tool_class"] = query.tool_class
+        if query.name is not None:
+            mongo_filter["tool.name"] = {
+                "$regex": re.escape(query.name),
+                "$options": "i",
+            }
+        if query.description is not None:
+            mongo_filter["tool.description"] = {
+                "$regex": re.escape(query.description),
+                "$options": "i",
+            }
+
+        return [from_document(doc, ToolEntry) for doc in self._collection.find(mongo_filter)]
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        """Update an existing tool entry.
+
+        Args:
+            id: The id of the entry to update.
+            tool_entry: The new entry data.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        doc = to_document(tool_entry)
+        result = self._collection.replace_one({"_id": id}, doc)
+        if result.matched_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated tool entry with id=%s", id)
+
+    def delete(self, id: str) -> None:
+        """Delete a tool entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        result = self._collection.delete_one({"_id": id})
+        if result.deleted_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted tool entry with id=%s", id)

--- a/tests/repositories/mongo/test_mongo_template_repo.py
+++ b/tests/repositories/mongo/test_mongo_template_repo.py
@@ -1,0 +1,159 @@
+"""Tests for MongoTemplateCatalogRepository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TemplateQuery
+from akgentic.catalog.repositories.mongo.template_repo import MongoTemplateCatalogRepository
+from tests.conftest import make_template
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+@pytest.fixture
+def repo(template_collection: pymongo.collection.Collection) -> MongoTemplateCatalogRepository:  # type: ignore[type-arg]
+    """Provide a MongoTemplateCatalogRepository backed by mongomock."""
+    return MongoTemplateCatalogRepository(template_collection)
+
+
+class TestCreateAndGet:
+    """Test create + get round-trip."""
+
+    def test_create_and_get_round_trip(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Create an entry and retrieve it by id."""
+        entry = make_template(id="tpl-1", template="Hello {name}, you are {role}.")
+        created_id = repo.create(entry)
+        assert created_id == "tpl-1"
+
+        retrieved = repo.get("tpl-1")
+        assert retrieved is not None
+        assert retrieved.id == "tpl-1"
+        assert retrieved.template == "Hello {name}, you are {role}."
+        assert set(retrieved.placeholders) == {"name", "role"}
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: MongoTemplateCatalogRepository
+    ) -> None:
+        """Creating an entry with an existing id raises CatalogValidationError."""
+        entry = make_template(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Getting a nonexistent id returns None."""
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """Test list returns all entries."""
+
+    def test_list_empty(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Empty collection returns empty list."""
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: MongoTemplateCatalogRepository) -> None:
+        """List returns all created entries."""
+        repo.create(make_template(id="tpl-a", template="Template {a}"))
+        repo.create(make_template(id="tpl-b", template="Template {b}"))
+        repo.create(make_template(id="tpl-c", template="Template {c}"))
+
+        results = repo.list()
+        assert len(results) == 3
+        ids = {e.id for e in results}
+        assert ids == {"tpl-a", "tpl-b", "tpl-c"}
+
+
+class TestSearch:
+    """Test search with various query combinations."""
+
+    def test_search_by_id_exact_match(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Search by id returns exact match only."""
+        repo.create(make_template(id="tpl-1", template="A {x}"))
+        repo.create(make_template(id="tpl-2", template="B {y}"))
+
+        results = repo.search(TemplateQuery(id="tpl-1"))
+        assert len(results) == 1
+        assert results[0].id == "tpl-1"
+
+    def test_search_by_placeholder_containment(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Search by placeholder returns entries containing that placeholder."""
+        repo.create(make_template(id="tpl-1", template="Hello {name}, welcome to {place}."))
+        repo.create(make_template(id="tpl-2", template="Dear {title} {name},"))
+        repo.create(make_template(id="tpl-3", template="System {role} prompt"))
+
+        results = repo.search(TemplateQuery(placeholder="name"))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"tpl-1", "tpl-2"}
+
+    def test_search_with_multiple_anded_fields(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Search with both id and placeholder AND-ed together."""
+        repo.create(make_template(id="tpl-1", template="Hello {name}, {role}."))
+        repo.create(make_template(id="tpl-2", template="Hey {name}!"))
+
+        # Both id and placeholder must match
+        results = repo.search(TemplateQuery(id="tpl-1", placeholder="name"))
+        assert len(results) == 1
+        assert results[0].id == "tpl-1"
+
+        # id matches but placeholder doesn't
+        results = repo.search(TemplateQuery(id="tpl-2", placeholder="role"))
+        assert len(results) == 0
+
+    def test_search_no_filters_returns_all(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Search with no filters returns all entries."""
+        repo.create(make_template(id="tpl-1"))
+        repo.create(make_template(id="tpl-2"))
+
+        results = repo.search(TemplateQuery())
+        assert len(results) == 2
+
+
+class TestUpdate:
+    """Test update operations."""
+
+    def test_update_existing_entry(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Update replaces the entry data."""
+        repo.create(make_template(id="tpl-1", template="Old {x}"))
+
+        updated_entry = make_template(id="tpl-1", template="New {y} template")
+        repo.update("tpl-1", updated_entry)
+
+        retrieved = repo.get("tpl-1")
+        assert retrieved is not None
+        assert retrieved.template == "New {y} template"
+        assert "y" in retrieved.placeholders
+
+    def test_update_nonexistent_raises_not_found(
+        self, repo: MongoTemplateCatalogRepository
+    ) -> None:
+        """Updating a nonexistent entry raises EntryNotFoundError."""
+        entry = make_template(id="ghost")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", entry)
+
+
+class TestDelete:
+    """Test delete operations."""
+
+    def test_delete_existing_entry(self, repo: MongoTemplateCatalogRepository) -> None:
+        """Delete removes the entry from the collection."""
+        repo.create(make_template(id="tpl-1"))
+        assert repo.get("tpl-1") is not None
+
+        repo.delete("tpl-1")
+        assert repo.get("tpl-1") is None
+
+    def test_delete_nonexistent_raises_not_found(
+        self, repo: MongoTemplateCatalogRepository
+    ) -> None:
+        """Deleting a nonexistent entry raises EntryNotFoundError."""
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")

--- a/tests/repositories/mongo/test_mongo_template_repo.py
+++ b/tests/repositories/mongo/test_mongo_template_repo.py
@@ -139,6 +139,15 @@ class TestUpdate:
         with pytest.raises(EntryNotFoundError, match="not found"):
             repo.update("ghost", entry)
 
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: MongoTemplateCatalogRepository
+    ) -> None:
+        """Updating with mismatched entry id raises CatalogValidationError."""
+        repo.create(make_template(id="tpl-1"))
+        mismatched = make_template(id="tpl-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("tpl-1", mismatched)
+
 
 class TestDelete:
     """Test delete operations."""

--- a/tests/repositories/mongo/test_mongo_tool_repo.py
+++ b/tests/repositories/mongo/test_mongo_tool_repo.py
@@ -73,6 +73,15 @@ class TestList:
 class TestSearch:
     """Test search with various query combinations."""
 
+    def test_search_by_id_exact_match(self, repo: MongoToolCatalogRepository) -> None:
+        """Search by id returns exact match only."""
+        repo.create(make_tool(id="t1", name="Alpha"))
+        repo.create(make_tool(id="t2", name="Beta"))
+
+        results = repo.search(ToolQuery(id="t1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
     def test_search_by_tool_class_exact_match(self, repo: MongoToolCatalogRepository) -> None:
         """Search by tool_class returns exact matches only."""
         repo.create(make_tool(id="t1", tool_class="akgentic.tool.search.search.SearchTool"))
@@ -122,6 +131,15 @@ class TestSearch:
 
         results = repo.search(ToolQuery())
         assert len(results) == 2
+
+    def test_search_name_with_regex_special_chars(self, repo: MongoToolCatalogRepository) -> None:
+        """Search with regex special characters in name treats them literally."""
+        repo.create(make_tool(id="t1", name="Search (v2)"))
+        repo.create(make_tool(id="t2", name="Search v2"))
+
+        results = repo.search(ToolQuery(name="(v2)"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
 
     def test_search_multiple_anded_fields(self, repo: MongoToolCatalogRepository) -> None:
         """Search with multiple fields AND-ed together."""
@@ -181,6 +199,15 @@ class TestUpdate:
         entry = make_tool(id="ghost")
         with pytest.raises(EntryNotFoundError, match="not found"):
             repo.update("ghost", entry)
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: MongoToolCatalogRepository
+    ) -> None:
+        """Updating with mismatched entry id raises CatalogValidationError."""
+        repo.create(make_tool(id="tool-1"))
+        mismatched = make_tool(id="tool-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("tool-1", mismatched)
 
 
 class TestDelete:

--- a/tests/repositories/mongo/test_mongo_tool_repo.py
+++ b/tests/repositories/mongo/test_mongo_tool_repo.py
@@ -1,0 +1,200 @@
+"""Tests for MongoToolCatalogRepository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.repositories.mongo.tool_repo import MongoToolCatalogRepository
+from tests.conftest import make_tool
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+@pytest.fixture
+def repo(tool_collection: pymongo.collection.Collection) -> MongoToolCatalogRepository:  # type: ignore[type-arg]
+    """Provide a MongoToolCatalogRepository backed by mongomock."""
+    return MongoToolCatalogRepository(tool_collection)
+
+
+class TestCreateAndGet:
+    """Test create + get round-trip."""
+
+    def test_create_and_get_round_trip(self, repo: MongoToolCatalogRepository) -> None:
+        """Create an entry and retrieve it by id."""
+        entry = make_tool(id="tool-1", name="Search", description="Web search tool")
+        created_id = repo.create(entry)
+        assert created_id == "tool-1"
+
+        retrieved = repo.get("tool-1")
+        assert retrieved is not None
+        assert retrieved.id == "tool-1"
+        assert retrieved.tool.name == "Search"
+        assert retrieved.tool.description == "Web search tool"
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: MongoToolCatalogRepository
+    ) -> None:
+        """Creating an entry with an existing id raises CatalogValidationError."""
+        entry = make_tool(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: MongoToolCatalogRepository) -> None:
+        """Getting a nonexistent id returns None."""
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """Test list returns all entries."""
+
+    def test_list_empty(self, repo: MongoToolCatalogRepository) -> None:
+        """Empty collection returns empty list."""
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: MongoToolCatalogRepository) -> None:
+        """List returns all created entries."""
+        repo.create(make_tool(id="tool-a", name="Alpha"))
+        repo.create(make_tool(id="tool-b", name="Beta"))
+        repo.create(make_tool(id="tool-c", name="Gamma"))
+
+        results = repo.list()
+        assert len(results) == 3
+        ids = {e.id for e in results}
+        assert ids == {"tool-a", "tool-b", "tool-c"}
+
+
+class TestSearch:
+    """Test search with various query combinations."""
+
+    def test_search_by_tool_class_exact_match(self, repo: MongoToolCatalogRepository) -> None:
+        """Search by tool_class returns exact matches only."""
+        repo.create(make_tool(id="t1", tool_class="akgentic.tool.search.search.SearchTool"))
+        repo.create(
+            make_tool(
+                id="t2",
+                tool_class="akgentic.tool.planning.planning.PlanningTool",
+                name="planner",
+                description="Planning tool",
+            )
+        )
+
+        results = repo.search(ToolQuery(tool_class="akgentic.tool.planning.planning.PlanningTool"))
+        assert len(results) == 1
+        assert results[0].id == "t2"
+
+    def test_search_by_name_case_insensitive_substring(
+        self, repo: MongoToolCatalogRepository
+    ) -> None:
+        """Search by name uses case-insensitive substring matching."""
+        repo.create(make_tool(id="t1", name="Web Search Tool"))
+        repo.create(make_tool(id="t2", name="Calculator"))
+        repo.create(make_tool(id="t3", name="Advanced SEARCH Engine"))
+
+        results = repo.search(ToolQuery(name="search"))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"t1", "t3"}
+
+    def test_search_by_description_case_insensitive_substring(
+        self, repo: MongoToolCatalogRepository
+    ) -> None:
+        """Search by description uses case-insensitive substring matching."""
+        repo.create(make_tool(id="t1", description="Search the web for information"))
+        repo.create(make_tool(id="t2", description="Perform calculations"))
+        repo.create(make_tool(id="t3", description="Deep WEB crawler"))
+
+        results = repo.search(ToolQuery(description="web"))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"t1", "t3"}
+
+    def test_search_no_filters_returns_all(self, repo: MongoToolCatalogRepository) -> None:
+        """Search with no filters returns all entries."""
+        repo.create(make_tool(id="t1"))
+        repo.create(make_tool(id="t2"))
+
+        results = repo.search(ToolQuery())
+        assert len(results) == 2
+
+    def test_search_multiple_anded_fields(self, repo: MongoToolCatalogRepository) -> None:
+        """Search with multiple fields AND-ed together."""
+        repo.create(
+            make_tool(
+                id="t1",
+                tool_class="akgentic.tool.planning.planning.PlanningTool",
+                name="Plan Search",
+                description="Search via planning",
+            )
+        )
+        repo.create(
+            make_tool(
+                id="t2",
+                tool_class="akgentic.tool.planning.planning.PlanningTool",
+                name="Plan Calculator",
+                description="Calculate via planning",
+            )
+        )
+        repo.create(
+            make_tool(
+                id="t3",
+                tool_class="akgentic.tool.search.search.SearchTool",
+                name="Tavily Search",
+                description="Search the web",
+            )
+        )
+
+        # tool_class AND name
+        results = repo.search(
+            ToolQuery(
+                tool_class="akgentic.tool.planning.planning.PlanningTool",
+                name="search",
+            )
+        )
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+
+class TestUpdate:
+    """Test update operations."""
+
+    def test_update_existing_entry(self, repo: MongoToolCatalogRepository) -> None:
+        """Update replaces the entry data."""
+        repo.create(make_tool(id="tool-1", name="Old Name", description="Old desc"))
+
+        updated = make_tool(id="tool-1", name="New Name", description="New desc")
+        repo.update("tool-1", updated)
+
+        retrieved = repo.get("tool-1")
+        assert retrieved is not None
+        assert retrieved.tool.name == "New Name"
+        assert retrieved.tool.description == "New desc"
+
+    def test_update_nonexistent_raises_not_found(self, repo: MongoToolCatalogRepository) -> None:
+        """Updating a nonexistent entry raises EntryNotFoundError."""
+        entry = make_tool(id="ghost")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", entry)
+
+
+class TestDelete:
+    """Test delete operations."""
+
+    def test_delete_existing_entry(self, repo: MongoToolCatalogRepository) -> None:
+        """Delete removes the entry from the collection."""
+        repo.create(make_tool(id="tool-1"))
+        assert repo.get("tool-1") is not None
+
+        repo.delete("tool-1")
+        assert repo.get("tool-1") is None
+
+    def test_delete_nonexistent_raises_not_found(self, repo: MongoToolCatalogRepository) -> None:
+        """Deleting a nonexistent entry raises EntryNotFoundError."""
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")


### PR DESCRIPTION
## Summary

- Implement `MongoTemplateCatalogRepository` with full CRUD + search (placeholder filtering via client-side hydration)
- Implement `MongoToolCatalogRepository` with full CRUD + search (case-insensitive `$regex` for name/description)
- Update public API exports with conditional pymongo imports across 3 `__init__.py` files
- Code review fixes: atomic `DuplicateKeyError` handling in `create()`, id-mismatch guard in `update()`, CRUD logging consistency, 4 additional tests

31 tests (up from 27 after review), 406 total suite. All quality gates pass (ruff, mypy --strict).

Closes #34