### PR TITLE
feat: MongoDB repositories for agents and teams

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -59,7 +59,9 @@ __all__ = [
 
 try:
     from akgentic.catalog.repositories.mongo import (
+        MongoAgentCatalogRepository,
         MongoCatalogConfig,
+        MongoTeamCatalogRepository,
         MongoTemplateCatalogRepository,
         MongoToolCatalogRepository,
         from_document,
@@ -67,7 +69,9 @@ try:
     )
 
     __all__ += [
+        "MongoAgentCatalogRepository",
         "MongoCatalogConfig",
+        "MongoTeamCatalogRepository",
         "MongoTemplateCatalogRepository",
         "MongoToolCatalogRepository",
         "from_document",

--- a/src/akgentic/catalog/repositories/__init__.py
+++ b/src/akgentic/catalog/repositories/__init__.py
@@ -32,7 +32,9 @@ __all__ = [
 
 try:
     from akgentic.catalog.repositories.mongo import (
+        MongoAgentCatalogRepository,
         MongoCatalogConfig,
+        MongoTeamCatalogRepository,
         MongoTemplateCatalogRepository,
         MongoToolCatalogRepository,
         from_document,
@@ -40,7 +42,9 @@ try:
     )
 
     __all__ += [
+        "MongoAgentCatalogRepository",
         "MongoCatalogConfig",
+        "MongoTeamCatalogRepository",
         "MongoTemplateCatalogRepository",
         "MongoToolCatalogRepository",
         "from_document",

--- a/src/akgentic/catalog/repositories/mongo/__init__.py
+++ b/src/akgentic/catalog/repositories/mongo/__init__.py
@@ -25,11 +25,15 @@ except ImportError as exc:
 from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig  # noqa: E402, I001
 from akgentic.catalog.repositories.mongo._helpers import from_document  # noqa: E402
 from akgentic.catalog.repositories.mongo._helpers import to_document  # noqa: E402
+from akgentic.catalog.repositories.mongo.agent_repo import MongoAgentCatalogRepository  # noqa: E402
+from akgentic.catalog.repositories.mongo.team_repo import MongoTeamCatalogRepository  # noqa: E402
 from akgentic.catalog.repositories.mongo.template_repo import MongoTemplateCatalogRepository  # noqa: E402
 from akgentic.catalog.repositories.mongo.tool_repo import MongoToolCatalogRepository  # noqa: E402
 
 __all__ = [
+    "MongoAgentCatalogRepository",
     "MongoCatalogConfig",
+    "MongoTeamCatalogRepository",
     "MongoTemplateCatalogRepository",
     "MongoToolCatalogRepository",
     "from_document",

--- a/src/akgentic/catalog/repositories/mongo/agent_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/agent_repo.py
@@ -1,0 +1,155 @@
+"""MongoDB-backed repository for agent catalog entries."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from pymongo.errors import DuplicateKeyError
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.repositories.base import AgentCatalogRepository
+from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+    from akgentic.catalog.models.queries import AgentQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+class MongoAgentCatalogRepository(AgentCatalogRepository):
+    """MongoDB-backed agent catalog repository.
+
+    Args:
+        collection: A pymongo Collection for agent entries.
+    """
+
+    def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
+        """Initialize with a pymongo Collection and ensure indexes.
+
+        Creates indexes on ``_id`` (unique), ``card.role`` (secondary),
+        and ``card.skills`` (multikey for ``$in`` queries).
+
+        Args:
+            collection: The MongoDB collection for agent entries.
+        """
+        self._collection = collection
+        self._collection.create_index("_id", unique=True)
+        self._collection.create_index("card.role")
+        self._collection.create_index("card.skills")
+        logger.info(
+            "MongoAgentCatalogRepository initialized with indexes on _id, card.role, card.skills"
+        )
+
+    def create(self, agent_entry: AgentEntry) -> str:
+        """Persist a new agent entry.
+
+        Args:
+            agent_entry: The agent entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        doc = to_document(agent_entry)
+        try:
+            self._collection.insert_one(doc)
+        except DuplicateKeyError:
+            raise CatalogValidationError([f"Entry with id '{agent_entry.id}' already exists"])
+        logger.debug("Created agent entry with id=%s", agent_entry.id)
+        return agent_entry.id
+
+    def get(self, id: str) -> AgentEntry | None:
+        """Retrieve an agent entry by id.
+
+        Args:
+            id: The agent entry id.
+
+        Returns:
+            The agent entry, or None if not found.
+        """
+        doc = self._collection.find_one({"_id": id})
+        if doc is None:
+            logger.debug("Agent entry not found: id=%s", id)
+            return None
+        return from_document(doc, AgentEntry)
+
+    def list(self) -> _list[AgentEntry]:
+        """Return all agent entries."""
+        entries = [from_document(doc, AgentEntry) for doc in self._collection.find()]
+        logger.debug("Listed %d agent entries", len(entries))
+        return entries
+
+    def search(self, query: AgentQuery) -> _list[AgentEntry]:
+        """Filter agents by AND-ing all non-None query fields.
+
+        Uses server-side exact match for ``id`` and ``card.role``. Uses
+        ``$in`` for ``card.skills`` (ANY overlap semantics). Uses ``$regex``
+        with case-insensitive option for substring matching on ``card.description``.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching agent entries.
+        """
+        mongo_filter: dict[str, Any] = {}
+        if query.id is not None:
+            mongo_filter["_id"] = query.id
+        if query.role is not None:
+            mongo_filter["card.role"] = query.role
+        if query.skills is not None:
+            mongo_filter["card.skills"] = {"$in": query.skills}
+        if query.description is not None:
+            mongo_filter["card.description"] = {
+                "$regex": re.escape(query.description),
+                "$options": "i",
+            }
+
+        results = [from_document(doc, AgentEntry) for doc in self._collection.find(mongo_filter)]
+        logger.debug("Search returned %d agent entries", len(results))
+        return results
+
+    def update(self, id: str, agent_entry: AgentEntry) -> None:
+        """Update an existing agent entry.
+
+        Args:
+            id: The id of the entry to update.
+            agent_entry: The new entry data.
+
+        Raises:
+            CatalogValidationError: If agent_entry.id does not match id.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if agent_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{agent_entry.id}'"]
+            )
+        doc = to_document(agent_entry)
+        result = self._collection.replace_one({"_id": id}, doc)
+        if result.matched_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated agent entry with id=%s", id)
+
+    def delete(self, id: str) -> None:
+        """Delete an agent entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        result = self._collection.delete_one({"_id": id})
+        if result.deleted_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted agent entry with id=%s", id)

--- a/src/akgentic/catalog/repositories/mongo/agent_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/agent_repo.py
@@ -63,8 +63,10 @@ class MongoAgentCatalogRepository(AgentCatalogRepository):
         doc = to_document(agent_entry)
         try:
             self._collection.insert_one(doc)
-        except DuplicateKeyError:
-            raise CatalogValidationError([f"Entry with id '{agent_entry.id}' already exists"])
+        except DuplicateKeyError as e:
+            raise CatalogValidationError(
+                [f"Entry with id '{agent_entry.id}' already exists"]
+            ) from e
         logger.debug("Created agent entry with id=%s", agent_entry.id)
         return agent_entry.id
 

--- a/src/akgentic/catalog/repositories/mongo/team_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/team_repo.py
@@ -1,0 +1,154 @@
+"""MongoDB-backed repository for team catalog entries."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from pymongo.errors import DuplicateKeyError
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.team import TeamSpec, agent_in_members
+from akgentic.catalog.repositories.base import TeamCatalogRepository
+from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+    from akgentic.catalog.models.queries import TeamQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+class MongoTeamCatalogRepository(TeamCatalogRepository):
+    """MongoDB-backed team catalog repository.
+
+    Args:
+        collection: A pymongo Collection for team specs.
+    """
+
+    def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
+        """Initialize with a pymongo Collection and ensure unique index on _id.
+
+        Args:
+            collection: The MongoDB collection for team specs.
+        """
+        self._collection = collection
+        self._collection.create_index("_id", unique=True)
+        logger.info("MongoTeamCatalogRepository initialized with index on _id")
+
+    def create(self, team_spec: TeamSpec) -> str:
+        """Persist a new team spec.
+
+        Args:
+            team_spec: The team spec to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        doc = to_document(team_spec)
+        try:
+            self._collection.insert_one(doc)
+        except DuplicateKeyError:
+            raise CatalogValidationError([f"Entry with id '{team_spec.id}' already exists"])
+        logger.debug("Created team spec with id=%s", team_spec.id)
+        return team_spec.id
+
+    def get(self, id: str) -> TeamSpec | None:
+        """Retrieve a team spec by id.
+
+        Args:
+            id: The team spec id.
+
+        Returns:
+            The team spec, or None if not found.
+        """
+        doc = self._collection.find_one({"_id": id})
+        if doc is None:
+            logger.debug("Team spec not found: id=%s", id)
+            return None
+        return from_document(doc, TeamSpec)
+
+    def list(self) -> _list[TeamSpec]:
+        """Return all team specs."""
+        entries = [from_document(doc, TeamSpec) for doc in self._collection.find()]
+        logger.debug("Listed %d team specs", len(entries))
+        return entries
+
+    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+        """Filter teams by AND-ing all non-None query fields.
+
+        Applies server-side filters for ``id``, ``name``, and ``description``
+        first, then applies client-side recursive ``agent_id`` filtering on
+        hydrated results.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching team specs.
+        """
+        mongo_filter: dict[str, Any] = {}
+        if query.id is not None:
+            mongo_filter["_id"] = query.id
+        if query.name is not None:
+            mongo_filter["name"] = {
+                "$regex": re.escape(query.name),
+                "$options": "i",
+            }
+        if query.description is not None:
+            mongo_filter["description"] = {
+                "$regex": re.escape(query.description),
+                "$options": "i",
+            }
+
+        results = [from_document(doc, TeamSpec) for doc in self._collection.find(mongo_filter)]
+
+        # Client-side recursive filter for agent_id in member tree
+        if query.agent_id is not None:
+            results = [t for t in results if agent_in_members(query.agent_id, t.members)]
+
+        logger.debug("Search returned %d team specs", len(results))
+        return results
+
+    def update(self, id: str, team_spec: TeamSpec) -> None:
+        """Update an existing team spec.
+
+        Args:
+            id: The id of the entry to update.
+            team_spec: The new entry data.
+
+        Raises:
+            CatalogValidationError: If team_spec.id does not match id.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if team_spec.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{team_spec.id}'"]
+            )
+        doc = to_document(team_spec)
+        result = self._collection.replace_one({"_id": id}, doc)
+        if result.matched_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated team spec with id=%s", id)
+
+    def delete(self, id: str) -> None:
+        """Delete a team spec by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        result = self._collection.delete_one({"_id": id})
+        if result.deleted_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted team spec with id=%s", id)

--- a/src/akgentic/catalog/repositories/mongo/team_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/team_repo.py
@@ -56,8 +56,8 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
         doc = to_document(team_spec)
         try:
             self._collection.insert_one(doc)
-        except DuplicateKeyError:
-            raise CatalogValidationError([f"Entry with id '{team_spec.id}' already exists"])
+        except DuplicateKeyError as e:
+            raise CatalogValidationError([f"Entry with id '{team_spec.id}' already exists"]) from e
         logger.debug("Created team spec with id=%s", team_spec.id)
         return team_spec.id
 

--- a/tests/repositories/mongo/test_mongo_agent_repo.py
+++ b/tests/repositories/mongo/test_mongo_agent_repo.py
@@ -1,0 +1,351 @@
+"""Tests for MongoAgentCatalogRepository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery
+from akgentic.catalog.repositories.mongo.agent_repo import MongoAgentCatalogRepository
+from tests.conftest import make_agent
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+@pytest.fixture
+def repo(agent_collection: pymongo.collection.Collection) -> MongoAgentCatalogRepository:  # type: ignore[type-arg]
+    """Provide a MongoAgentCatalogRepository backed by mongomock."""
+    return MongoAgentCatalogRepository(agent_collection)
+
+
+class TestCreateAndGet:
+    """Test create + get round-trip."""
+
+    def test_create_and_get_round_trip(self, repo: MongoAgentCatalogRepository) -> None:
+        """Create an entry and retrieve it by id."""
+        entry = make_agent(id="agent-1", name="test-agent")
+        created_id = repo.create(entry)
+        assert created_id == "agent-1"
+
+        retrieved = repo.get("agent-1")
+        assert retrieved is not None
+        assert retrieved.id == "agent-1"
+        assert retrieved.card.role == "engineer"
+        assert retrieved.card.skills == ["coding"]
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: MongoAgentCatalogRepository
+    ) -> None:
+        """Creating an entry with an existing id raises CatalogValidationError."""
+        entry = make_agent(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: MongoAgentCatalogRepository) -> None:
+        """Getting a nonexistent id returns None."""
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """Test list returns all entries."""
+
+    def test_list_empty(self, repo: MongoAgentCatalogRepository) -> None:
+        """Empty collection returns empty list."""
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: MongoAgentCatalogRepository) -> None:
+        """List returns all created entries."""
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+        repo.create(make_agent(id="a3"))
+
+        results = repo.list()
+        assert len(results) == 3
+        ids = {e.id for e in results}
+        assert ids == {"a1", "a2", "a3"}
+
+
+class TestSearch:
+    """Test search with various query combinations."""
+
+    def test_search_by_id_exact_match(self, repo: MongoAgentCatalogRepository) -> None:
+        """Search by id returns exact match only."""
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+
+        results = repo.search(AgentQuery(id="a1"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_search_by_role_exact_match(self, repo: MongoAgentCatalogRepository) -> None:
+        """Search by role returns exact matches on card.role."""
+        # make_agent defaults to role="engineer"
+        repo.create(make_agent(id="a1"))
+        repo.create(
+            make_agent(id="a2"),
+        )
+
+        # Override role by creating with different card data
+        from akgentic.catalog.models.agent import AgentEntry
+
+        manager = AgentEntry(
+            id="a3",
+            tool_ids=[],
+            card={
+                "role": "manager",
+                "description": "team lead",
+                "skills": ["leadership"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "mgr-agent"},
+                "routes_to": [],
+            },
+        )
+        repo.create(manager)
+
+        results = repo.search(AgentQuery(role="manager"))
+        assert len(results) == 1
+        assert results[0].id == "a3"
+
+    def test_search_by_skills_any_overlap(self, repo: MongoAgentCatalogRepository) -> None:
+        """Search by skills returns agents with ANY of the listed skills."""
+        from akgentic.catalog.models.agent import AgentEntry
+
+        a1 = AgentEntry(
+            id="a1",
+            tool_ids=[],
+            card={
+                "role": "researcher",
+                "description": "researches topics",
+                "skills": ["research", "coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "researcher"},
+                "routes_to": [],
+            },
+        )
+        a2 = AgentEntry(
+            id="a2",
+            tool_ids=[],
+            card={
+                "role": "writer",
+                "description": "writes content",
+                "skills": ["writing"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "writer"},
+                "routes_to": [],
+            },
+        )
+        a3 = AgentEntry(
+            id="a3",
+            tool_ids=[],
+            card={
+                "role": "coder",
+                "description": "writes code",
+                "skills": ["coding", "testing"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "coder"},
+                "routes_to": [],
+            },
+        )
+        repo.create(a1)
+        repo.create(a2)
+        repo.create(a3)
+
+        # Query for "research" — matches a1 only
+        results = repo.search(AgentQuery(skills=["research"]))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+        # Query for "coding" — matches a1 and a3
+        results = repo.search(AgentQuery(skills=["coding"]))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"a1", "a3"}
+
+        # Query for ANY of ["writing", "testing"] — matches a2 and a3
+        results = repo.search(AgentQuery(skills=["writing", "testing"]))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"a2", "a3"}
+
+    def test_search_by_description_case_insensitive(
+        self, repo: MongoAgentCatalogRepository
+    ) -> None:
+        """Search by description uses case-insensitive substring matching."""
+        from akgentic.catalog.models.agent import AgentEntry
+
+        a1 = AgentEntry(
+            id="a1",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "Builds REST APIs",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "api-builder"},
+                "routes_to": [],
+            },
+        )
+        a2 = AgentEntry(
+            id="a2",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "Builds CLI tools",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "cli-builder"},
+                "routes_to": [],
+            },
+        )
+        repo.create(a1)
+        repo.create(a2)
+
+        results = repo.search(AgentQuery(description="rest"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_search_multiple_anded_fields(self, repo: MongoAgentCatalogRepository) -> None:
+        """Search with multiple fields AND-ed together."""
+        from akgentic.catalog.models.agent import AgentEntry
+
+        a1 = AgentEntry(
+            id="a1",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "builds APIs",
+                "skills": ["coding", "research"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "a1"},
+                "routes_to": [],
+            },
+        )
+        a2 = AgentEntry(
+            id="a2",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "builds UIs",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "a2"},
+                "routes_to": [],
+            },
+        )
+        a3 = AgentEntry(
+            id="a3",
+            tool_ids=[],
+            card={
+                "role": "manager",
+                "description": "manages APIs team",
+                "skills": ["leadership"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "a3"},
+                "routes_to": [],
+            },
+        )
+        repo.create(a1)
+        repo.create(a2)
+        repo.create(a3)
+
+        # role=engineer AND description contains "api" → only a1
+        results = repo.search(AgentQuery(role="engineer", description="api"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_search_no_filters_returns_all(self, repo: MongoAgentCatalogRepository) -> None:
+        """Search with no filters returns all entries."""
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+
+        results = repo.search(AgentQuery())
+        assert len(results) == 2
+
+    def test_search_description_with_regex_special_chars(
+        self, repo: MongoAgentCatalogRepository
+    ) -> None:
+        """Search with regex special characters in description treats them literally."""
+        from akgentic.catalog.models.agent import AgentEntry
+
+        a1 = AgentEntry(
+            id="a1",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "builds APIs (v2)",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "a1"},
+                "routes_to": [],
+            },
+        )
+        a2 = AgentEntry(
+            id="a2",
+            tool_ids=[],
+            card={
+                "role": "engineer",
+                "description": "builds APIs v2",
+                "skills": ["coding"],
+                "agent_class": "akgentic.agent.BaseAgent",
+                "config": {"name": "a2"},
+                "routes_to": [],
+            },
+        )
+        repo.create(a1)
+        repo.create(a2)
+
+        results = repo.search(AgentQuery(description="(v2)"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+
+class TestUpdate:
+    """Test update operations."""
+
+    def test_update_existing_entry(self, repo: MongoAgentCatalogRepository) -> None:
+        """Update replaces the entry data."""
+        repo.create(make_agent(id="agent-1", name="old-name"))
+
+        updated = make_agent(id="agent-1", name="new-name")
+        repo.update("agent-1", updated)
+
+        retrieved = repo.get("agent-1")
+        assert retrieved is not None
+        assert retrieved.card.config.name == "new-name"
+
+    def test_update_nonexistent_raises_not_found(self, repo: MongoAgentCatalogRepository) -> None:
+        """Updating a nonexistent entry raises EntryNotFoundError."""
+        entry = make_agent(id="ghost")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", entry)
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: MongoAgentCatalogRepository
+    ) -> None:
+        """Updating with mismatched entry id raises CatalogValidationError."""
+        repo.create(make_agent(id="agent-1"))
+        mismatched = make_agent(id="agent-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("agent-1", mismatched)
+
+
+class TestDelete:
+    """Test delete operations."""
+
+    def test_delete_existing_entry(self, repo: MongoAgentCatalogRepository) -> None:
+        """Delete removes the entry from the collection."""
+        repo.create(make_agent(id="agent-1"))
+        assert repo.get("agent-1") is not None
+
+        repo.delete("agent-1")
+        assert repo.get("agent-1") is None
+
+    def test_delete_nonexistent_raises_not_found(self, repo: MongoAgentCatalogRepository) -> None:
+        """Deleting a nonexistent entry raises EntryNotFoundError."""
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")

--- a/tests/repositories/mongo/test_mongo_agent_repo.py
+++ b/tests/repositories/mongo/test_mongo_agent_repo.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import AgentQuery
 from akgentic.catalog.repositories.mongo.agent_repo import MongoAgentCatalogRepository
@@ -22,7 +23,7 @@ def repo(agent_collection: pymongo.collection.Collection) -> MongoAgentCatalogRe
 
 
 class TestCreateAndGet:
-    """Test create + get round-trip."""
+    """AC-1: MongoAgentCatalogRepository CRUD — create and get round-trip."""
 
     def test_create_and_get_round_trip(self, repo: MongoAgentCatalogRepository) -> None:
         """Create an entry and retrieve it by id."""
@@ -52,7 +53,7 @@ class TestCreateAndGet:
 
 
 class TestList:
-    """Test list returns all entries."""
+    """AC-1: MongoAgentCatalogRepository list operation."""
 
     def test_list_empty(self, repo: MongoAgentCatalogRepository) -> None:
         """Empty collection returns empty list."""
@@ -71,7 +72,7 @@ class TestList:
 
 
 class TestSearch:
-    """Test search with various query combinations."""
+    """AC-2/3/4: Agent search by role, skills, and description."""
 
     def test_search_by_id_exact_match(self, repo: MongoAgentCatalogRepository) -> None:
         """Search by id returns exact match only."""
@@ -91,8 +92,6 @@ class TestSearch:
         )
 
         # Override role by creating with different card data
-        from akgentic.catalog.models.agent import AgentEntry
-
         manager = AgentEntry(
             id="a3",
             tool_ids=[],
@@ -113,8 +112,6 @@ class TestSearch:
 
     def test_search_by_skills_any_overlap(self, repo: MongoAgentCatalogRepository) -> None:
         """Search by skills returns agents with ANY of the listed skills."""
-        from akgentic.catalog.models.agent import AgentEntry
-
         a1 = AgentEntry(
             id="a1",
             tool_ids=[],
@@ -176,8 +173,6 @@ class TestSearch:
         self, repo: MongoAgentCatalogRepository
     ) -> None:
         """Search by description uses case-insensitive substring matching."""
-        from akgentic.catalog.models.agent import AgentEntry
-
         a1 = AgentEntry(
             id="a1",
             tool_ids=[],
@@ -211,8 +206,6 @@ class TestSearch:
 
     def test_search_multiple_anded_fields(self, repo: MongoAgentCatalogRepository) -> None:
         """Search with multiple fields AND-ed together."""
-        from akgentic.catalog.models.agent import AgentEntry
-
         a1 = AgentEntry(
             id="a1",
             tool_ids=[],
@@ -270,8 +263,6 @@ class TestSearch:
         self, repo: MongoAgentCatalogRepository
     ) -> None:
         """Search with regex special characters in description treats them literally."""
-        from akgentic.catalog.models.agent import AgentEntry
-
         a1 = AgentEntry(
             id="a1",
             tool_ids=[],
@@ -305,7 +296,7 @@ class TestSearch:
 
 
 class TestUpdate:
-    """Test update operations."""
+    """AC-1: MongoAgentCatalogRepository update with id-mismatch guard."""
 
     def test_update_existing_entry(self, repo: MongoAgentCatalogRepository) -> None:
         """Update replaces the entry data."""
@@ -335,7 +326,7 @@ class TestUpdate:
 
 
 class TestDelete:
-    """Test delete operations."""
+    """AC-1: MongoAgentCatalogRepository delete operation."""
 
     def test_delete_existing_entry(self, repo: MongoAgentCatalogRepository) -> None:
         """Delete removes the entry from the collection."""

--- a/tests/repositories/mongo/test_mongo_team_repo.py
+++ b/tests/repositories/mongo/test_mongo_team_repo.py
@@ -23,7 +23,7 @@ def repo(team_collection: pymongo.collection.Collection) -> MongoTeamCatalogRepo
 
 
 class TestCreateAndGet:
-    """Test create + get round-trip."""
+    """AC-5: MongoTeamCatalogRepository CRUD — create and get round-trip."""
 
     def test_create_and_get_round_trip(self, repo: MongoTeamCatalogRepository) -> None:
         """Create a team spec and retrieve it by id."""
@@ -53,7 +53,7 @@ class TestCreateAndGet:
 
 
 class TestList:
-    """Test list returns all entries."""
+    """AC-5: MongoTeamCatalogRepository list operation."""
 
     def test_list_empty(self, repo: MongoTeamCatalogRepository) -> None:
         """Empty collection returns empty list."""
@@ -72,7 +72,7 @@ class TestList:
 
 
 class TestSearch:
-    """Test search with various query combinations."""
+    """AC-6/7: Team search by agent_id, name, and description."""
 
     def test_search_by_id_exact_match(self, repo: MongoTeamCatalogRepository) -> None:
         """Search by id returns exact match only."""
@@ -193,6 +193,15 @@ class TestSearch:
         assert len(results) == 1
         assert results[0].id == "t1"
 
+    def test_search_name_with_regex_special_chars(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search with regex special characters in name treats them literally."""
+        repo.create(make_team(id="t1", name="Team (Alpha)"))
+        repo.create(make_team(id="t2", name="Team Alpha"))
+
+        results = repo.search(TeamQuery(name="(Alpha)"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
     def test_search_no_filters_returns_all(self, repo: MongoTeamCatalogRepository) -> None:
         """Search with no filters returns all entries."""
         repo.create(make_team(id="t1", name="Alpha"))
@@ -203,7 +212,7 @@ class TestSearch:
 
 
 class TestUpdate:
-    """Test update operations."""
+    """AC-5: MongoTeamCatalogRepository update with id-mismatch guard."""
 
     def test_update_existing_entry(self, repo: MongoTeamCatalogRepository) -> None:
         """Update replaces the team spec data."""
@@ -233,7 +242,7 @@ class TestUpdate:
 
 
 class TestDelete:
-    """Test delete operations."""
+    """AC-5: MongoTeamCatalogRepository delete operation."""
 
     def test_delete_existing_entry(self, repo: MongoTeamCatalogRepository) -> None:
         """Delete removes the team from the collection."""

--- a/tests/repositories/mongo/test_mongo_team_repo.py
+++ b/tests/repositories/mongo/test_mongo_team_repo.py
@@ -1,0 +1,249 @@
+"""Tests for MongoTeamCatalogRepository."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TeamQuery
+from akgentic.catalog.models.team import TeamMemberSpec
+from akgentic.catalog.repositories.mongo.team_repo import MongoTeamCatalogRepository
+from tests.conftest import make_team
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+@pytest.fixture
+def repo(team_collection: pymongo.collection.Collection) -> MongoTeamCatalogRepository:  # type: ignore[type-arg]
+    """Provide a MongoTeamCatalogRepository backed by mongomock."""
+    return MongoTeamCatalogRepository(team_collection)
+
+
+class TestCreateAndGet:
+    """Test create + get round-trip."""
+
+    def test_create_and_get_round_trip(self, repo: MongoTeamCatalogRepository) -> None:
+        """Create a team spec and retrieve it by id."""
+        entry = make_team(id="team-1", name="Engineering")
+        created_id = repo.create(entry)
+        assert created_id == "team-1"
+
+        retrieved = repo.get("team-1")
+        assert retrieved is not None
+        assert retrieved.id == "team-1"
+        assert retrieved.name == "Engineering"
+        assert len(retrieved.members) == 1
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: MongoTeamCatalogRepository
+    ) -> None:
+        """Creating a team with an existing id raises CatalogValidationError."""
+        entry = make_team(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: MongoTeamCatalogRepository) -> None:
+        """Getting a nonexistent id returns None."""
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """Test list returns all entries."""
+
+    def test_list_empty(self, repo: MongoTeamCatalogRepository) -> None:
+        """Empty collection returns empty list."""
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: MongoTeamCatalogRepository) -> None:
+        """List returns all created team specs."""
+        repo.create(make_team(id="t1", name="Alpha"))
+        repo.create(make_team(id="t2", name="Beta"))
+        repo.create(make_team(id="t3", name="Gamma"))
+
+        results = repo.list()
+        assert len(results) == 3
+        ids = {e.id for e in results}
+        assert ids == {"t1", "t2", "t3"}
+
+
+class TestSearch:
+    """Test search with various query combinations."""
+
+    def test_search_by_id_exact_match(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by id returns exact match only."""
+        repo.create(make_team(id="t1", name="Alpha"))
+        repo.create(make_team(id="t2", name="Beta"))
+
+        results = repo.search(TeamQuery(id="t1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_name_case_insensitive(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by name uses case-insensitive substring matching."""
+        repo.create(make_team(id="t1", name="Engineering Team"))
+        repo.create(make_team(id="t2", name="Marketing Team"))
+        repo.create(make_team(id="t3", name="ENGINEERING Core"))
+
+        results = repo.search(TeamQuery(name="engineering"))
+        assert len(results) == 2
+        ids = {e.id for e in results}
+        assert ids == {"t1", "t3"}
+
+    def test_search_by_description_case_insensitive(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by description uses case-insensitive substring matching."""
+        t1 = make_team(id="t1", name="Alpha")
+        t1.description = "Handles backend APIs"
+        t2 = make_team(id="t2", name="Beta")
+        t2.description = "Handles frontend UI"
+        repo.create(t1)
+        repo.create(t2)
+
+        results = repo.search(TeamQuery(description="backend"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_agent_id_flat_members(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by agent_id finds agent at top level of members."""
+        repo.create(
+            make_team(
+                id="t1",
+                name="Team A",
+                members=[
+                    TeamMemberSpec(agent_id="eng-lead"),
+                    TeamMemberSpec(agent_id="dev-1"),
+                ],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t2",
+                name="Team B",
+                members=[TeamMemberSpec(agent_id="pm-lead")],
+            )
+        )
+
+        results = repo.search(TeamQuery(agent_id="dev-1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_agent_id_nested_members(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by agent_id finds agent buried 2+ levels deep in member tree."""
+        nested_team = make_team(
+            id="t1",
+            name="Deep Team",
+            members=[
+                TeamMemberSpec(
+                    agent_id="director",
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="manager",
+                            members=[
+                                TeamMemberSpec(agent_id="deep-worker"),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        repo.create(nested_team)
+        repo.create(make_team(id="t2", name="Flat Team"))
+
+        results = repo.search(TeamQuery(agent_id="deep-worker"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_agent_id_no_match(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search by agent_id returns empty when no team contains the agent."""
+        repo.create(make_team(id="t1", name="Team A"))
+
+        results = repo.search(TeamQuery(agent_id="nonexistent-agent"))
+        assert results == []
+
+    def test_search_multiple_anded_fields(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search with multiple fields AND-ed together."""
+        repo.create(
+            make_team(
+                id="t1",
+                name="Engineering Alpha",
+                members=[TeamMemberSpec(agent_id="eng-1")],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t2",
+                name="Engineering Beta",
+                members=[TeamMemberSpec(agent_id="eng-2")],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t3",
+                name="Marketing Alpha",
+                members=[TeamMemberSpec(agent_id="mkt-1")],
+            )
+        )
+
+        # name contains "engineering" AND agent_id = "eng-1"
+        results = repo.search(TeamQuery(name="engineering", agent_id="eng-1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_no_filters_returns_all(self, repo: MongoTeamCatalogRepository) -> None:
+        """Search with no filters returns all entries."""
+        repo.create(make_team(id="t1", name="Alpha"))
+        repo.create(make_team(id="t2", name="Beta"))
+
+        results = repo.search(TeamQuery())
+        assert len(results) == 2
+
+
+class TestUpdate:
+    """Test update operations."""
+
+    def test_update_existing_entry(self, repo: MongoTeamCatalogRepository) -> None:
+        """Update replaces the team spec data."""
+        repo.create(make_team(id="team-1", name="Old Name"))
+
+        updated = make_team(id="team-1", name="New Name")
+        repo.update("team-1", updated)
+
+        retrieved = repo.get("team-1")
+        assert retrieved is not None
+        assert retrieved.name == "New Name"
+
+    def test_update_nonexistent_raises_not_found(self, repo: MongoTeamCatalogRepository) -> None:
+        """Updating a nonexistent team raises EntryNotFoundError."""
+        entry = make_team(id="ghost")
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", entry)
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: MongoTeamCatalogRepository
+    ) -> None:
+        """Updating with mismatched team id raises CatalogValidationError."""
+        repo.create(make_team(id="team-1"))
+        mismatched = make_team(id="team-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("team-1", mismatched)
+
+
+class TestDelete:
+    """Test delete operations."""
+
+    def test_delete_existing_entry(self, repo: MongoTeamCatalogRepository) -> None:
+        """Delete removes the team from the collection."""
+        repo.create(make_team(id="team-1"))
+        assert repo.get("team-1") is not None
+
+        repo.delete("team-1")
+        assert repo.get("team-1") is None
+
+    def test_delete_nonexistent_raises_not_found(self, repo: MongoTeamCatalogRepository) -> None:
+        """Deleting a nonexistent team raises EntryNotFoundError."""
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")


### PR DESCRIPTION
## Summary

- Add `MongoAgentCatalogRepository` with indexes on `_id`, `card.role`, `card.skills` and search via exact match, `$in` array overlap, `$regex` substring
- Add `MongoTeamCatalogRepository` with `$regex` for name/description and client-side recursive `agent_in_members()` for agent_id search
- Update `__init__.py` exports at mongo, repositories, and catalog levels
- 35 new tests (17 agent + 18 team) — full suite: 441 tests passing

Closes #36

## Checklist

- [x] All 441 tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy --strict` clean on new files
- [x] Follows 4-2 code review patterns (DuplicateKeyError, id-mismatch guard, re.escape, logging)