### PR TITLE
FastAPI Routers for All Four Catalogs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "ruff>=0.1.0",
     "types-PyYAML>=6.0",
     "mongomock>=4.0.0",
+    "httpx>=0.24.0",
 ]
 
 [build-system]

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -79,3 +79,24 @@ try:
     ]
 except ImportError:
     pass
+
+try:
+    from akgentic.catalog.api import (
+        ErrorResponse,
+        add_exception_handlers,
+        agent_router,
+        team_router,
+        template_router,
+        tool_router,
+    )
+
+    __all__ += [
+        "ErrorResponse",
+        "add_exception_handlers",
+        "agent_router",
+        "team_router",
+        "template_router",
+        "tool_router",
+    ]
+except ImportError:
+    pass

--- a/src/akgentic/catalog/api/__init__.py
+++ b/src/akgentic/catalog/api/__init__.py
@@ -1,0 +1,31 @@
+"""FastAPI REST API for the Akgentic catalog.
+
+Provides routers for all four catalog types (templates, tools, agents, teams)
+with CRUD and search endpoints.
+
+Requires the ``api`` extra: ``pip install akgentic-catalog[api]``.
+"""
+
+from __future__ import annotations
+
+try:
+    import fastapi as _fastapi  # noqa: F401
+except ImportError as exc:
+    raise ImportError(
+        "FastAPI is required. Install with: pip install akgentic-catalog[api]"
+    ) from exc
+
+from akgentic.catalog.api._errors import ErrorResponse, add_exception_handlers
+from akgentic.catalog.api.agent_router import router as agent_router
+from akgentic.catalog.api.team_router import router as team_router
+from akgentic.catalog.api.template_router import router as template_router
+from akgentic.catalog.api.tool_router import router as tool_router
+
+__all__ = [
+    "ErrorResponse",
+    "add_exception_handlers",
+    "agent_router",
+    "team_router",
+    "template_router",
+    "tool_router",
+]

--- a/src/akgentic/catalog/api/_errors.py
+++ b/src/akgentic/catalog/api/_errors.py
@@ -1,0 +1,56 @@
+"""Shared error response model and exception handlers for the catalog API."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+__all__ = ["ErrorResponse", "add_exception_handlers"]
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorResponse(BaseModel):
+    """Structured error response returned by catalog API endpoints."""
+
+    detail: str
+    errors: list[str] = []
+
+
+async def _handle_entry_not_found(
+    request: Request,
+    exc: EntryNotFoundError,
+) -> JSONResponse:
+    """Convert EntryNotFoundError to a 404 JSON response."""
+    logger.debug("entry not found: %s", exc)
+    return JSONResponse(
+        status_code=404,
+        content=ErrorResponse(detail=str(exc)).model_dump(),
+    )
+
+
+async def _handle_catalog_validation_error(
+    request: Request,
+    exc: CatalogValidationError,
+) -> JSONResponse:
+    """Convert CatalogValidationError to a 409 JSON response."""
+    logger.debug("catalog validation error: %s", exc)
+    return JSONResponse(
+        status_code=409,
+        content=ErrorResponse(detail=str(exc), errors=exc.errors).model_dump(),
+    )
+
+
+def add_exception_handlers(app: FastAPI) -> None:
+    """Register catalog exception handlers on a FastAPI application.
+
+    Args:
+        app: The FastAPI application to add handlers to.
+    """
+    app.add_exception_handler(EntryNotFoundError, _handle_entry_not_found)  # type: ignore[arg-type]
+    app.add_exception_handler(CatalogValidationError, _handle_catalog_validation_error)  # type: ignore[arg-type]

--- a/src/akgentic/catalog/api/agent_router.py
+++ b/src/akgentic/catalog/api/agent_router.py
@@ -1,0 +1,88 @@
+"""FastAPI router for agent catalog CRUD and search operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Response
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery
+
+if TYPE_CHECKING:
+    from akgentic.catalog.services.agent_catalog import AgentCatalog
+
+__all__ = ["router", "set_catalog"]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/agents", tags=["agents"])
+
+_catalog: AgentCatalog | None = None
+
+
+def set_catalog(catalog: AgentCatalog) -> None:
+    """Inject the agent catalog service instance.
+
+    Args:
+        catalog: The AgentCatalog service to use for all operations.
+    """
+    global _catalog  # noqa: PLW0603
+    _catalog = catalog
+
+
+def _get_catalog() -> AgentCatalog:
+    """Return the injected catalog or raise if not configured."""
+    if _catalog is None:
+        raise RuntimeError("AgentCatalog not configured — call set_catalog() first")
+    return _catalog
+
+
+@router.post("/", response_model=AgentEntry, status_code=201)
+async def create_agent(entry: AgentEntry) -> AgentEntry:
+    """Create a new agent entry."""
+    logger.debug("POST /api/agents — creating %s", entry.id)
+    _get_catalog().create(entry)
+    return entry
+
+
+@router.get("/", response_model=list[AgentEntry])
+async def list_agents() -> list[AgentEntry]:
+    """List all agent entries."""
+    logger.debug("GET /api/agents — listing all")
+    return _get_catalog().list()
+
+
+@router.get("/{id}", response_model=AgentEntry)
+async def get_agent(id: str) -> AgentEntry:
+    """Get an agent entry by id."""
+    logger.debug("GET /api/agents/%s", id)
+    entry = _get_catalog().get(id)
+    if entry is None:
+        raise EntryNotFoundError(f"Agent '{id}' not found")
+    return entry
+
+
+@router.post("/search", response_model=list[AgentEntry])
+async def search_agents(query: AgentQuery) -> list[AgentEntry]:
+    """Search agent entries by query."""
+    logger.debug("POST /api/agents/search")
+    return _get_catalog().search(query)
+
+
+@router.put("/{id}", response_model=AgentEntry)
+async def update_agent(id: str, entry: AgentEntry) -> AgentEntry:
+    """Update an existing agent entry."""
+    logger.debug("PUT /api/agents/%s", id)
+    _get_catalog().update(id, entry)
+    return entry
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_agent(id: str) -> Response:
+    """Delete an agent entry."""
+    logger.debug("DELETE /api/agents/%s", id)
+    _get_catalog().delete(id)
+    return Response(status_code=204)

--- a/src/akgentic/catalog/api/team_router.py
+++ b/src/akgentic/catalog/api/team_router.py
@@ -1,0 +1,88 @@
+"""FastAPI router for team catalog CRUD and search operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Response
+
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.models.queries import TeamQuery
+from akgentic.catalog.models.team import TeamSpec
+
+if TYPE_CHECKING:
+    from akgentic.catalog.services.team_catalog import TeamCatalog
+
+__all__ = ["router", "set_catalog"]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/teams", tags=["teams"])
+
+_catalog: TeamCatalog | None = None
+
+
+def set_catalog(catalog: TeamCatalog) -> None:
+    """Inject the team catalog service instance.
+
+    Args:
+        catalog: The TeamCatalog service to use for all operations.
+    """
+    global _catalog  # noqa: PLW0603
+    _catalog = catalog
+
+
+def _get_catalog() -> TeamCatalog:
+    """Return the injected catalog or raise if not configured."""
+    if _catalog is None:
+        raise RuntimeError("TeamCatalog not configured — call set_catalog() first")
+    return _catalog
+
+
+@router.post("/", response_model=TeamSpec, status_code=201)
+async def create_team(entry: TeamSpec) -> TeamSpec:
+    """Create a new team spec."""
+    logger.debug("POST /api/teams — creating %s", entry.id)
+    _get_catalog().create(entry)
+    return entry
+
+
+@router.get("/", response_model=list[TeamSpec])
+async def list_teams() -> list[TeamSpec]:
+    """List all team specs."""
+    logger.debug("GET /api/teams — listing all")
+    return _get_catalog().list()
+
+
+@router.get("/{id}", response_model=TeamSpec)
+async def get_team(id: str) -> TeamSpec:
+    """Get a team spec by id."""
+    logger.debug("GET /api/teams/%s", id)
+    entry = _get_catalog().get(id)
+    if entry is None:
+        raise EntryNotFoundError(f"Team '{id}' not found")
+    return entry
+
+
+@router.post("/search", response_model=list[TeamSpec])
+async def search_teams(query: TeamQuery) -> list[TeamSpec]:
+    """Search team specs by query."""
+    logger.debug("POST /api/teams/search")
+    return _get_catalog().search(query)
+
+
+@router.put("/{id}", response_model=TeamSpec)
+async def update_team(id: str, entry: TeamSpec) -> TeamSpec:
+    """Update an existing team spec."""
+    logger.debug("PUT /api/teams/%s", id)
+    _get_catalog().update(id, entry)
+    return entry
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_team(id: str) -> Response:
+    """Delete a team spec."""
+    logger.debug("DELETE /api/teams/%s", id)
+    _get_catalog().delete(id)
+    return Response(status_code=204)

--- a/src/akgentic/catalog/api/template_router.py
+++ b/src/akgentic/catalog/api/template_router.py
@@ -1,0 +1,88 @@
+"""FastAPI router for template catalog CRUD and search operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Response
+
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.models.queries import TemplateQuery
+from akgentic.catalog.models.template import TemplateEntry
+
+if TYPE_CHECKING:
+    from akgentic.catalog.services.template_catalog import TemplateCatalog
+
+__all__ = ["router", "set_catalog"]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/templates", tags=["templates"])
+
+_catalog: TemplateCatalog | None = None
+
+
+def set_catalog(catalog: TemplateCatalog) -> None:
+    """Inject the template catalog service instance.
+
+    Args:
+        catalog: The TemplateCatalog service to use for all operations.
+    """
+    global _catalog  # noqa: PLW0603
+    _catalog = catalog
+
+
+def _get_catalog() -> TemplateCatalog:
+    """Return the injected catalog or raise if not configured."""
+    if _catalog is None:
+        raise RuntimeError("TemplateCatalog not configured — call set_catalog() first")
+    return _catalog
+
+
+@router.post("/", response_model=TemplateEntry, status_code=201)
+async def create_template(entry: TemplateEntry) -> TemplateEntry:
+    """Create a new template entry."""
+    logger.debug("POST /api/templates — creating %s", entry.id)
+    _get_catalog().create(entry)
+    return entry
+
+
+@router.get("/", response_model=list[TemplateEntry])
+async def list_templates() -> list[TemplateEntry]:
+    """List all template entries."""
+    logger.debug("GET /api/templates — listing all")
+    return _get_catalog().list()
+
+
+@router.get("/{id}", response_model=TemplateEntry)
+async def get_template(id: str) -> TemplateEntry:
+    """Get a template entry by id."""
+    logger.debug("GET /api/templates/%s", id)
+    entry = _get_catalog().get(id)
+    if entry is None:
+        raise EntryNotFoundError(f"Template '{id}' not found")
+    return entry
+
+
+@router.post("/search", response_model=list[TemplateEntry])
+async def search_templates(query: TemplateQuery) -> list[TemplateEntry]:
+    """Search template entries by query."""
+    logger.debug("POST /api/templates/search")
+    return _get_catalog().search(query)
+
+
+@router.put("/{id}", response_model=TemplateEntry)
+async def update_template(id: str, entry: TemplateEntry) -> TemplateEntry:
+    """Update an existing template entry."""
+    logger.debug("PUT /api/templates/%s", id)
+    _get_catalog().update(id, entry)
+    return entry
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_template(id: str) -> Response:
+    """Delete a template entry."""
+    logger.debug("DELETE /api/templates/%s", id)
+    _get_catalog().delete(id)
+    return Response(status_code=204)

--- a/src/akgentic/catalog/api/tool_router.py
+++ b/src/akgentic/catalog/api/tool_router.py
@@ -1,0 +1,88 @@
+"""FastAPI router for tool catalog CRUD and search operations."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Response
+
+from akgentic.catalog.models.errors import EntryNotFoundError
+from akgentic.catalog.models.queries import ToolQuery
+from akgentic.catalog.models.tool import ToolEntry
+
+if TYPE_CHECKING:
+    from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+__all__ = ["router", "set_catalog"]
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/tools", tags=["tools"])
+
+_catalog: ToolCatalog | None = None
+
+
+def set_catalog(catalog: ToolCatalog) -> None:
+    """Inject the tool catalog service instance.
+
+    Args:
+        catalog: The ToolCatalog service to use for all operations.
+    """
+    global _catalog  # noqa: PLW0603
+    _catalog = catalog
+
+
+def _get_catalog() -> ToolCatalog:
+    """Return the injected catalog or raise if not configured."""
+    if _catalog is None:
+        raise RuntimeError("ToolCatalog not configured — call set_catalog() first")
+    return _catalog
+
+
+@router.post("/", response_model=ToolEntry, status_code=201)
+async def create_tool(entry: ToolEntry) -> ToolEntry:
+    """Create a new tool entry."""
+    logger.debug("POST /api/tools — creating %s", entry.id)
+    _get_catalog().create(entry)
+    return entry
+
+
+@router.get("/", response_model=list[ToolEntry])
+async def list_tools() -> list[ToolEntry]:
+    """List all tool entries."""
+    logger.debug("GET /api/tools — listing all")
+    return _get_catalog().list()
+
+
+@router.get("/{id}", response_model=ToolEntry)
+async def get_tool(id: str) -> ToolEntry:
+    """Get a tool entry by id."""
+    logger.debug("GET /api/tools/%s", id)
+    entry = _get_catalog().get(id)
+    if entry is None:
+        raise EntryNotFoundError(f"Tool '{id}' not found")
+    return entry
+
+
+@router.post("/search", response_model=list[ToolEntry])
+async def search_tools(query: ToolQuery) -> list[ToolEntry]:
+    """Search tool entries by query."""
+    logger.debug("POST /api/tools/search")
+    return _get_catalog().search(query)
+
+
+@router.put("/{id}", response_model=ToolEntry)
+async def update_tool(id: str, entry: ToolEntry) -> ToolEntry:
+    """Update an existing tool entry."""
+    logger.debug("PUT /api/tools/%s", id)
+    _get_catalog().update(id, entry)
+    return entry
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_tool(id: str) -> Response:
+    """Delete a tool entry."""
+    logger.debug("DELETE /api/tools/%s", id)
+    _get_catalog().delete(id)
+    return Response(status_code=204)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,97 @@
+"""Shared fixtures for API router tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from akgentic.catalog.api._errors import add_exception_handlers
+from akgentic.catalog.api.agent_router import router as agent_router
+from akgentic.catalog.api.agent_router import set_catalog as set_agent_catalog
+from akgentic.catalog.api.team_router import router as team_router
+from akgentic.catalog.api.team_router import set_catalog as set_team_catalog
+from akgentic.catalog.api.template_router import router as template_router
+from akgentic.catalog.api.template_router import set_catalog as set_template_catalog
+from akgentic.catalog.api.tool_router import router as tool_router
+from akgentic.catalog.api.tool_router import set_catalog as set_tool_catalog
+from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogRepository
+from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
+from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
+from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+from akgentic.catalog.services.agent_catalog import AgentCatalog
+from akgentic.catalog.services.team_catalog import TeamCatalog
+from akgentic.catalog.services.template_catalog import TemplateCatalog
+from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+
+@pytest.fixture()
+def catalog_dirs(tmp_path: Path) -> dict[str, Path]:
+    """Create temporary directories for each catalog type."""
+    dirs = {}
+    for name in ("templates", "tools", "agents", "teams"):
+        d = tmp_path / name
+        d.mkdir()
+        dirs[name] = d
+    return dirs
+
+
+@pytest.fixture()
+def catalogs(catalog_dirs: dict[str, Path]) -> dict[str, object]:
+    """Wire all four catalog services with YAML repos in dependency order."""
+    template_catalog = TemplateCatalog(YamlTemplateCatalogRepository(catalog_dirs["templates"]))
+    tool_catalog = ToolCatalog(YamlToolCatalogRepository(catalog_dirs["tools"]))
+    agent_catalog = AgentCatalog(
+        YamlAgentCatalogRepository(catalog_dirs["agents"]),
+        template_catalog,
+        tool_catalog,
+    )
+    team_catalog = TeamCatalog(
+        YamlTeamCatalogRepository(catalog_dirs["teams"]),
+        agent_catalog,
+    )
+    # Wire downstream references for delete protection
+    template_catalog.agent_catalog = agent_catalog
+    tool_catalog.agent_catalog = agent_catalog
+    return {
+        "template": template_catalog,
+        "tool": tool_catalog,
+        "agent": agent_catalog,
+        "team": team_catalog,
+    }
+
+
+@pytest.fixture()
+def test_app(catalogs: dict[str, object]) -> Generator[FastAPI, None, None]:
+    """Create a FastAPI app wired with catalog services for testing."""
+    app = FastAPI(title="Test Catalog API")
+
+    # Inject catalogs into router modules
+    set_template_catalog(catalogs["template"])  # type: ignore[arg-type]
+    set_tool_catalog(catalogs["tool"])  # type: ignore[arg-type]
+    set_agent_catalog(catalogs["agent"])  # type: ignore[arg-type]
+    set_team_catalog(catalogs["team"])  # type: ignore[arg-type]
+
+    # Register routers and exception handlers
+    app.include_router(template_router)
+    app.include_router(tool_router)
+    app.include_router(agent_router)
+    app.include_router(team_router)
+    add_exception_handlers(app)
+
+    yield app
+
+    # Clean up module-level state
+    set_template_catalog(None)  # type: ignore[arg-type]
+    set_tool_catalog(None)  # type: ignore[arg-type]
+    set_agent_catalog(None)  # type: ignore[arg-type]
+    set_team_catalog(None)  # type: ignore[arg-type]
+
+
+@pytest.fixture()
+def client(test_app: FastAPI) -> TestClient:
+    """Create a test client for the wired FastAPI app."""
+    return TestClient(test_app)

--- a/tests/api/test_agent_router.py
+++ b/tests/api/test_agent_router.py
@@ -1,0 +1,93 @@
+"""Tests for the agent catalog API router."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_agent
+
+
+class TestAgentRouter:
+    """AC-3: Agent router CRUD and search endpoints."""
+
+    def test_create_returns_201(self, client: TestClient) -> None:
+        """POST /api/agents creates entry and returns 201."""
+        entry = make_agent(id="a1", name="alpha")
+        resp = client.post("/api/agents/", json=entry.model_dump())
+        assert resp.status_code == 201
+        assert resp.json()["id"] == "a1"
+
+    def test_list_returns_entries(self, client: TestClient) -> None:
+        """GET /api/agents lists all entries."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        client.post("/api/agents/", json=make_agent(id="a2", name="beta").model_dump())
+        resp = client.get("/api/agents/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_get_by_id(self, client: TestClient) -> None:
+        """GET /api/agents/{id} returns entry."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        resp = client.get("/api/agents/a1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "a1"
+
+    def test_get_nonexistent_returns_404(self, client: TestClient) -> None:
+        """GET /api/agents/{id} returns 404 for missing entry."""
+        resp = client.get("/api/agents/missing")
+        assert resp.status_code == 404
+
+    def test_search_with_query(self, client: TestClient) -> None:
+        """POST /api/agents/search returns filtered results."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        client.post("/api/agents/", json=make_agent(id="a2", name="beta").model_dump())
+        resp = client.post("/api/agents/search", json={"id": "a1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "a1"
+
+    def test_search_empty_results(self, client: TestClient) -> None:
+        """POST /api/agents/search returns empty array when no matches."""
+        resp = client.post("/api/agents/search", json={"id": "nonexistent"})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_update_entry(self, client: TestClient) -> None:
+        """PUT /api/agents/{id} updates and returns updated entry."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        updated = make_agent(id="a1", name="alpha-v2")
+        resp = client.put("/api/agents/a1", json=updated.model_dump())
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "a1"
+
+    def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
+        """PUT /api/agents/{id} returns 404 for missing entry."""
+        entry = make_agent(id="missing", name="ghost")
+        resp = client.put("/api/agents/missing", json=entry.model_dump())
+        assert resp.status_code == 404
+
+    def test_delete_returns_204(self, client: TestClient) -> None:
+        """DELETE /api/agents/{id} returns 204."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        resp = client.delete("/api/agents/a1")
+        assert resp.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        """DELETE /api/agents/{id} returns 404 for missing entry."""
+        resp = client.delete("/api/agents/missing")
+        assert resp.status_code == 404
+
+    def test_create_duplicate_returns_409(self, client: TestClient) -> None:
+        """POST /api/agents with duplicate id returns 409."""
+        entry = make_agent(id="a1", name="alpha")
+        client.post("/api/agents/", json=entry.model_dump())
+        resp = client.post("/api/agents/", json=entry.model_dump())
+        assert resp.status_code == 409
+        assert "errors" in resp.json()
+
+    def test_create_with_invalid_routes_to_returns_409(self, client: TestClient) -> None:
+        """POST /api/agents with invalid routes_to returns 409."""
+        entry = make_agent(id="a1", name="alpha", routes_to=["nonexistent-agent"])
+        resp = client.post("/api/agents/", json=entry.model_dump())
+        assert resp.status_code == 409

--- a/tests/api/test_agent_router.py
+++ b/tests/api/test_agent_router.py
@@ -59,7 +59,14 @@ class TestAgentRouter:
         updated = make_agent(id="a1", name="alpha-v2")
         resp = client.put("/api/agents/a1", json=updated.model_dump())
         assert resp.status_code == 200
-        assert resp.json()["id"] == "a1"
+        assert resp.json()["card"]["config"]["name"] == "alpha-v2"
+
+    def test_update_id_mismatch_returns_409(self, client: TestClient) -> None:
+        """PUT /api/agents/{id} with mismatched body id returns 409."""
+        client.post("/api/agents/", json=make_agent(id="a1", name="alpha").model_dump())
+        mismatched = make_agent(id="a2", name="alpha")
+        resp = client.put("/api/agents/a1", json=mismatched.model_dump())
+        assert resp.status_code == 409
 
     def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
         """PUT /api/agents/{id} returns 404 for missing entry."""
@@ -85,6 +92,12 @@ class TestAgentRouter:
         resp = client.post("/api/agents/", json=entry.model_dump())
         assert resp.status_code == 409
         assert "errors" in resp.json()
+
+    def test_create_with_invalid_tool_ids_returns_409(self, client: TestClient) -> None:
+        """POST /api/agents with invalid tool_ids returns 409."""
+        entry = make_agent(id="a1", name="alpha", tool_ids=["nonexistent-tool"])
+        resp = client.post("/api/agents/", json=entry.model_dump())
+        assert resp.status_code == 409
 
     def test_create_with_invalid_routes_to_returns_409(self, client: TestClient) -> None:
         """POST /api/agents with invalid routes_to returns 409."""

--- a/tests/api/test_team_router.py
+++ b/tests/api/test_team_router.py
@@ -1,0 +1,121 @@
+"""Tests for the team catalog API router."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from akgentic.catalog.models.team import TeamMemberSpec
+from tests.conftest import make_agent, make_team
+
+
+class TestTeamRouter:
+    """AC-4: Team router CRUD and search endpoints."""
+
+    def _seed_agent(self, client: TestClient, id: str = "agent-1") -> None:
+        """Create a prerequisite agent so team references resolve."""
+        agent = make_agent(id=id, name=id)
+        client.post("/api/agents/", json=agent.model_dump())
+
+    def test_create_returns_201(self, client: TestClient) -> None:
+        """POST /api/teams creates entry and returns 201."""
+        self._seed_agent(client)
+        entry = make_team(id="team-1")
+        resp = client.post("/api/teams/", json=entry.model_dump())
+        assert resp.status_code == 201
+        assert resp.json()["id"] == "team-1"
+
+    def test_list_returns_entries(self, client: TestClient) -> None:
+        """GET /api/teams lists all entries."""
+        self._seed_agent(client, "a1")
+        self._seed_agent(client, "a2")
+        t1 = make_team(
+            id="t1",
+            entry_point="a1",
+            members=[TeamMemberSpec(agent_id="a1")],
+        )
+        t2 = make_team(
+            id="t2",
+            entry_point="a2",
+            members=[TeamMemberSpec(agent_id="a2")],
+        )
+        client.post("/api/teams/", json=t1.model_dump())
+        client.post("/api/teams/", json=t2.model_dump())
+        resp = client.get("/api/teams/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_get_by_id(self, client: TestClient) -> None:
+        """GET /api/teams/{id} returns entry."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1").model_dump())
+        resp = client.get("/api/teams/t1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "t1"
+
+    def test_get_nonexistent_returns_404(self, client: TestClient) -> None:
+        """GET /api/teams/{id} returns 404 for missing entry."""
+        resp = client.get("/api/teams/missing")
+        assert resp.status_code == 404
+
+    def test_search_with_query(self, client: TestClient) -> None:
+        """POST /api/teams/search returns filtered results."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1", name="Alpha Team").model_dump())
+        resp = client.post("/api/teams/search", json={"id": "t1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "t1"
+
+    def test_search_empty_results(self, client: TestClient) -> None:
+        """POST /api/teams/search returns empty array when no matches."""
+        resp = client.post("/api/teams/search", json={"id": "nonexistent"})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_update_entry(self, client: TestClient) -> None:
+        """PUT /api/teams/{id} updates and returns updated entry."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1", name="Old Name").model_dump())
+        updated = make_team(id="t1", name="New Name")
+        resp = client.put("/api/teams/t1", json=updated.model_dump())
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "New Name"
+
+    def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
+        """PUT /api/teams/{id} returns 404 for missing entry."""
+        self._seed_agent(client)
+        entry = make_team(id="missing")
+        resp = client.put("/api/teams/missing", json=entry.model_dump())
+        assert resp.status_code == 404
+
+    def test_delete_returns_204(self, client: TestClient) -> None:
+        """DELETE /api/teams/{id} returns 204."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1").model_dump())
+        resp = client.delete("/api/teams/t1")
+        assert resp.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        """DELETE /api/teams/{id} returns 404 for missing entry."""
+        resp = client.delete("/api/teams/missing")
+        assert resp.status_code == 404
+
+    def test_create_duplicate_returns_409(self, client: TestClient) -> None:
+        """POST /api/teams with duplicate id returns 409."""
+        self._seed_agent(client)
+        entry = make_team(id="t1")
+        client.post("/api/teams/", json=entry.model_dump())
+        resp = client.post("/api/teams/", json=entry.model_dump())
+        assert resp.status_code == 409
+        assert "errors" in resp.json()
+
+    def test_search_by_agent_id(self, client: TestClient) -> None:
+        """POST /api/teams/search by agent_id returns matching teams."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1").model_dump())
+        resp = client.post("/api/teams/search", json={"agent_id": "agent-1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "t1"

--- a/tests/api/test_team_router.py
+++ b/tests/api/test_team_router.py
@@ -82,6 +82,14 @@ class TestTeamRouter:
         assert resp.status_code == 200
         assert resp.json()["name"] == "New Name"
 
+    def test_update_id_mismatch_returns_409(self, client: TestClient) -> None:
+        """PUT /api/teams/{id} with mismatched body id returns 409."""
+        self._seed_agent(client)
+        client.post("/api/teams/", json=make_team(id="t1").model_dump())
+        mismatched = make_team(id="t2")
+        resp = client.put("/api/teams/t1", json=mismatched.model_dump())
+        assert resp.status_code == 409
+
     def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
         """PUT /api/teams/{id} returns 404 for missing entry."""
         self._seed_agent(client)

--- a/tests/api/test_template_router.py
+++ b/tests/api/test_template_router.py
@@ -1,0 +1,88 @@
+"""Tests for the template catalog API router."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_template
+
+
+class TestTemplateRouter:
+    """AC-1: Template router CRUD and search endpoints."""
+
+    def test_create_returns_201(self, client: TestClient) -> None:
+        """POST /api/templates creates entry and returns 201."""
+        entry = make_template()
+        resp = client.post("/api/templates/", json=entry.model_dump())
+        assert resp.status_code == 201
+        assert resp.json()["id"] == entry.id
+
+    def test_list_returns_entries(self, client: TestClient) -> None:
+        """GET /api/templates lists all entries."""
+        client.post("/api/templates/", json=make_template(id="t1").model_dump())
+        client.post("/api/templates/", json=make_template(id="t2").model_dump())
+        resp = client.get("/api/templates/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_get_by_id(self, client: TestClient) -> None:
+        """GET /api/templates/{id} returns entry."""
+        entry = make_template(id="t1")
+        client.post("/api/templates/", json=entry.model_dump())
+        resp = client.get("/api/templates/t1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "t1"
+
+    def test_get_nonexistent_returns_404(self, client: TestClient) -> None:
+        """GET /api/templates/{id} returns 404 for missing entry."""
+        resp = client.get("/api/templates/missing")
+        assert resp.status_code == 404
+
+    def test_search_with_query(self, client: TestClient) -> None:
+        """POST /api/templates/search returns filtered results."""
+        client.post("/api/templates/", json=make_template(id="t1").model_dump())
+        client.post("/api/templates/", json=make_template(id="t2").model_dump())
+        resp = client.post("/api/templates/search", json={"id": "t1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "t1"
+
+    def test_search_empty_results(self, client: TestClient) -> None:
+        """POST /api/templates/search returns empty array when no matches."""
+        resp = client.post("/api/templates/search", json={"id": "nonexistent"})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_update_entry(self, client: TestClient) -> None:
+        """PUT /api/templates/{id} updates and returns updated entry."""
+        client.post("/api/templates/", json=make_template(id="t1", template="old").model_dump())
+        updated = make_template(id="t1", template="new {role}")
+        resp = client.put("/api/templates/t1", json=updated.model_dump())
+        assert resp.status_code == 200
+        assert resp.json()["template"] == "new {role}"
+
+    def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
+        """PUT /api/templates/{id} returns 404 for missing entry."""
+        entry = make_template(id="missing")
+        resp = client.put("/api/templates/missing", json=entry.model_dump())
+        assert resp.status_code == 404
+
+    def test_delete_returns_204(self, client: TestClient) -> None:
+        """DELETE /api/templates/{id} returns 204."""
+        client.post("/api/templates/", json=make_template(id="t1").model_dump())
+        resp = client.delete("/api/templates/t1")
+        assert resp.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        """DELETE /api/templates/{id} returns 404 for missing entry."""
+        resp = client.delete("/api/templates/missing")
+        assert resp.status_code == 404
+
+    def test_create_duplicate_returns_409(self, client: TestClient) -> None:
+        """POST /api/templates with duplicate id returns 409."""
+        entry = make_template(id="t1")
+        client.post("/api/templates/", json=entry.model_dump())
+        resp = client.post("/api/templates/", json=entry.model_dump())
+        assert resp.status_code == 409
+        assert "errors" in resp.json()

--- a/tests/api/test_template_router.py
+++ b/tests/api/test_template_router.py
@@ -62,6 +62,13 @@ class TestTemplateRouter:
         assert resp.status_code == 200
         assert resp.json()["template"] == "new {role}"
 
+    def test_update_id_mismatch_returns_409(self, client: TestClient) -> None:
+        """PUT /api/templates/{id} with mismatched body id returns 409."""
+        client.post("/api/templates/", json=make_template(id="t1").model_dump())
+        mismatched = make_template(id="t2")
+        resp = client.put("/api/templates/t1", json=mismatched.model_dump())
+        assert resp.status_code == 409
+
     def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
         """PUT /api/templates/{id} returns 404 for missing entry."""
         entry = make_template(id="missing")

--- a/tests/api/test_tool_router.py
+++ b/tests/api/test_tool_router.py
@@ -1,0 +1,88 @@
+"""Tests for the tool catalog API router."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.conftest import make_tool
+
+
+class TestToolRouter:
+    """AC-2: Tool router CRUD and search endpoints."""
+
+    def test_create_returns_201(self, client: TestClient) -> None:
+        """POST /api/tools creates entry and returns 201."""
+        entry = make_tool()
+        resp = client.post("/api/tools/", json=entry.model_dump())
+        assert resp.status_code == 201
+        assert resp.json()["id"] == entry.id
+
+    def test_list_returns_entries(self, client: TestClient) -> None:
+        """GET /api/tools lists all entries."""
+        client.post("/api/tools/", json=make_tool(id="s1").model_dump())
+        client.post("/api/tools/", json=make_tool(id="s2").model_dump())
+        resp = client.get("/api/tools/")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+    def test_get_by_id(self, client: TestClient) -> None:
+        """GET /api/tools/{id} returns entry."""
+        entry = make_tool(id="s1")
+        client.post("/api/tools/", json=entry.model_dump())
+        resp = client.get("/api/tools/s1")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "s1"
+
+    def test_get_nonexistent_returns_404(self, client: TestClient) -> None:
+        """GET /api/tools/{id} returns 404 for missing entry."""
+        resp = client.get("/api/tools/missing")
+        assert resp.status_code == 404
+
+    def test_search_with_query(self, client: TestClient) -> None:
+        """POST /api/tools/search returns filtered results."""
+        client.post("/api/tools/", json=make_tool(id="s1").model_dump())
+        client.post("/api/tools/", json=make_tool(id="s2").model_dump())
+        resp = client.post("/api/tools/search", json={"id": "s1"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "s1"
+
+    def test_search_empty_results(self, client: TestClient) -> None:
+        """POST /api/tools/search returns empty array when no matches."""
+        resp = client.post("/api/tools/search", json={"id": "nonexistent"})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_update_entry(self, client: TestClient) -> None:
+        """PUT /api/tools/{id} updates and returns updated entry."""
+        client.post("/api/tools/", json=make_tool(id="s1").model_dump())
+        updated = make_tool(id="s1", description="Updated description")
+        resp = client.put("/api/tools/s1", json=updated.model_dump())
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "s1"
+
+    def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
+        """PUT /api/tools/{id} returns 404 for missing entry."""
+        entry = make_tool(id="missing")
+        resp = client.put("/api/tools/missing", json=entry.model_dump())
+        assert resp.status_code == 404
+
+    def test_delete_returns_204(self, client: TestClient) -> None:
+        """DELETE /api/tools/{id} returns 204."""
+        client.post("/api/tools/", json=make_tool(id="s1").model_dump())
+        resp = client.delete("/api/tools/s1")
+        assert resp.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self, client: TestClient) -> None:
+        """DELETE /api/tools/{id} returns 404 for missing entry."""
+        resp = client.delete("/api/tools/missing")
+        assert resp.status_code == 404
+
+    def test_create_duplicate_returns_409(self, client: TestClient) -> None:
+        """POST /api/tools with duplicate id returns 409."""
+        entry = make_tool(id="s1")
+        client.post("/api/tools/", json=entry.model_dump())
+        resp = client.post("/api/tools/", json=entry.model_dump())
+        assert resp.status_code == 409
+        assert "errors" in resp.json()

--- a/tests/api/test_tool_router.py
+++ b/tests/api/test_tool_router.py
@@ -60,7 +60,14 @@ class TestToolRouter:
         updated = make_tool(id="s1", description="Updated description")
         resp = client.put("/api/tools/s1", json=updated.model_dump())
         assert resp.status_code == 200
-        assert resp.json()["id"] == "s1"
+        assert resp.json()["tool"]["description"] == "Updated description"
+
+    def test_update_id_mismatch_returns_409(self, client: TestClient) -> None:
+        """PUT /api/tools/{id} with mismatched body id returns 409."""
+        client.post("/api/tools/", json=make_tool(id="s1").model_dump())
+        mismatched = make_tool(id="s2")
+        resp = client.put("/api/tools/s1", json=mismatched.model_dump())
+        assert resp.status_code == 409
 
     def test_update_nonexistent_returns_404(self, client: TestClient) -> None:
         """PUT /api/tools/{id} returns 404 for missing entry."""


### PR DESCRIPTION
## Summary

- Four FastAPI routers (templates, tools, agents, teams) with full CRUD + search endpoints
- ErrorResponse model and shared exception handler utility (EntryNotFoundError→404, CatalogValidationError→409)
- Import guard for optional FastAPI dependency (`akgentic-catalog[api]`)
- Conditional public API exports in `catalog/__init__.py`
- 51 comprehensive API tests with 96% branch coverage

## Review Fixes Applied

- Added `httpx` to dev dependencies (required by FastAPI TestClient)
- Added id-mismatch PUT tests for all 4 routers (409 on path/body id mismatch)
- Added invalid `tool_ids` validation test for agent create
- Strengthened update assertions in tool and agent router tests

Closes #38