### PR TITLE
CLI Backend Selection (YAML and MongoDB)

### DIFF
--- a/src/akgentic/catalog/cli/_catalog.py
+++ b/src/akgentic/catalog/cli/_catalog.py
@@ -1,7 +1,8 @@
 """Catalog service wiring for the CLI.
 
-Provides ``build_catalogs()`` to create all four catalog services from a
-YAML base directory, replicating the wiring pattern from ``api/app.py``.
+Provides ``build_catalogs()`` for YAML backend, ``build_mongo_catalogs()``
+for MongoDB backend, and ``build_catalogs_from_state()`` to dispatch based
+on ``GlobalState.backend``.
 """
 
 from __future__ import annotations
@@ -12,19 +13,41 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from akgentic.catalog.cli.main import GlobalState
     from akgentic.catalog.services.agent_catalog import AgentCatalog
     from akgentic.catalog.services.team_catalog import TeamCatalog
     from akgentic.catalog.services.template_catalog import TemplateCatalog
     from akgentic.catalog.services.tool_catalog import ToolCatalog
 
-__all__ = ["build_catalogs"]
+# Type alias for the four-catalog tuple returned by all wiring functions
+CatalogTuple = tuple["TemplateCatalog", "ToolCatalog", "AgentCatalog", "TeamCatalog"]
+
+__all__ = ["build_catalogs", "build_catalogs_from_state", "build_mongo_catalogs"]
 
 logger = logging.getLogger(__name__)
 
 
+def build_catalogs_from_state(
+    state: GlobalState,
+) -> CatalogTuple:
+    """Dispatch to YAML or MongoDB backend based on global state.
+
+    Args:
+        state: The CLI global state containing backend selection and
+            connection parameters.
+
+    Returns:
+        Tuple of (TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog).
+    """
+    if state.backend == "mongodb":
+        # mongo_uri and mongo_db are validated before this point
+        return build_mongo_catalogs(state.mongo_uri, state.mongo_db)  # type: ignore[arg-type]
+    return build_catalogs(state.catalog_dir)
+
+
 def build_catalogs(
     catalog_dir: Path,
-) -> tuple[TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog]:
+) -> CatalogTuple:
     """Wire all four catalog services from a YAML base directory.
 
     Creates subdirectories (``templates/``, ``tools/``, ``agents/``,
@@ -69,4 +92,63 @@ def build_catalogs(
     agent_catalog.team_catalog = team_catalog
 
     logger.info("Wired catalog services from %s", catalog_dir)
+    return template_catalog, tool_catalog, agent_catalog, team_catalog
+
+
+def build_mongo_catalogs(
+    mongo_uri: str,
+    mongo_db: str,
+) -> CatalogTuple:
+    """Wire all four catalog services from a MongoDB backend.
+
+    Imports MongoDB dependencies lazily to avoid requiring pymongo when
+    using the YAML backend.
+
+    Args:
+        mongo_uri: MongoDB connection URI.
+        mongo_db: MongoDB database name.
+
+    Returns:
+        Tuple of (TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog).
+    """
+    from akgentic.catalog.repositories.mongo import (
+        MongoAgentCatalogRepository,
+        MongoCatalogConfig,
+        MongoTeamCatalogRepository,
+        MongoTemplateCatalogRepository,
+        MongoToolCatalogRepository,
+    )
+    from akgentic.catalog.services.agent_catalog import AgentCatalog
+    from akgentic.catalog.services.team_catalog import TeamCatalog
+    from akgentic.catalog.services.template_catalog import TemplateCatalog
+    from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+    config = MongoCatalogConfig(connection_string=mongo_uri, database=mongo_db)
+    client = config.create_client()
+
+    template_repo = MongoTemplateCatalogRepository(
+        config.get_collection(client, config.template_entries_collection)
+    )
+    tool_repo = MongoToolCatalogRepository(
+        config.get_collection(client, config.tool_entries_collection)
+    )
+    agent_repo = MongoAgentCatalogRepository(
+        config.get_collection(client, config.agent_entries_collection)
+    )
+    team_repo = MongoTeamCatalogRepository(
+        config.get_collection(client, config.team_specs_collection)
+    )
+
+    # Create services in dependency order
+    template_catalog = TemplateCatalog(template_repo)
+    tool_catalog = ToolCatalog(tool_repo)
+    agent_catalog = AgentCatalog(agent_repo, template_catalog, tool_catalog)
+    team_catalog = TeamCatalog(team_repo, agent_catalog)
+
+    # Wire downstream back-references for delete protection
+    template_catalog.agent_catalog = agent_catalog
+    tool_catalog.agent_catalog = agent_catalog
+    agent_catalog.team_catalog = team_catalog
+
+    logger.info("Wired catalog services from MongoDB %s", mongo_db)
     return template_catalog, tool_catalog, agent_catalog, team_catalog

--- a/src/akgentic/catalog/cli/_catalog.py
+++ b/src/akgentic/catalog/cli/_catalog.py
@@ -40,8 +40,9 @@ def build_catalogs_from_state(
         Tuple of (TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog).
     """
     if state.backend == "mongodb":
-        # mongo_uri and mongo_db are validated before this point
-        return build_mongo_catalogs(state.mongo_uri, state.mongo_db)  # type: ignore[arg-type]
+        assert state.mongo_uri is not None, "mongo_uri must be set for mongodb backend"
+        assert state.mongo_db is not None, "mongo_db must be set for mongodb backend"
+        return build_mongo_catalogs(state.mongo_uri, state.mongo_db)
     return build_catalogs(state.catalog_dir)
 
 

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -66,12 +66,23 @@ def main(
     ),
 ) -> None:
     """Akgentic catalog CLI -- manage templates, tools, agents, and teams."""
+    valid_backends = ("yaml", "mongodb")
+    if backend not in valid_backends:
+        err_console = Console(stderr=True)
+        err_console.print(
+            f"[red]Error:[/red] Invalid backend '{backend}'. "
+            f"Must be one of: {', '.join(valid_backends)}"
+        )
+        logger.warning("Invalid backend value: %s", backend)
+        raise typer.Exit(code=1)
+
     if backend == "mongodb":
         errors = _validate_mongodb_options(mongo_uri, mongo_db)
         if errors:
             err_console = Console(stderr=True)
             for err in errors:
                 err_console.print(f"[red]Error:[/red] {err}")
+            logger.warning("MongoDB validation failed: %s", errors)
             raise typer.Exit(code=1)
 
     ctx.ensure_object(dict)

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
+from rich.console import Console
 
 from akgentic.catalog.cli._output import OutputFormat
 
@@ -25,6 +26,9 @@ class GlobalState:
 
     catalog_dir: Path = field(default_factory=lambda: Path("catalog"))
     format: OutputFormat = OutputFormat.table
+    backend: str = "yaml"
+    mongo_uri: str | None = None
+    mongo_db: str | None = None
 
 
 app = typer.Typer(name="ak-catalog", help="Manage Akgentic catalog entries.")
@@ -43,10 +47,64 @@ def main(
         "--format",
         help="Output format: table, json, or yaml.",
     ),
+    backend: str = typer.Option(
+        "yaml",
+        "--backend",
+        help="Storage backend: yaml or mongodb.",
+    ),
+    mongo_uri: str | None = typer.Option(
+        None,
+        "--mongo-uri",
+        envvar="MONGO_URI",
+        help="MongoDB connection URI (required when --backend=mongodb).",
+    ),
+    mongo_db: str | None = typer.Option(
+        None,
+        "--mongo-db",
+        envvar="MONGO_DB",
+        help="MongoDB database name (required when --backend=mongodb).",
+    ),
 ) -> None:
     """Akgentic catalog CLI -- manage templates, tools, agents, and teams."""
+    if backend == "mongodb":
+        errors = _validate_mongodb_options(mongo_uri, mongo_db)
+        if errors:
+            err_console = Console(stderr=True)
+            for err in errors:
+                err_console.print(f"[red]Error:[/red] {err}")
+            raise typer.Exit(code=1)
+
     ctx.ensure_object(dict)
-    ctx.obj = GlobalState(catalog_dir=catalog_dir, format=fmt)
+    ctx.obj = GlobalState(
+        catalog_dir=catalog_dir,
+        format=fmt,
+        backend=backend,
+        mongo_uri=mongo_uri,
+        mongo_db=mongo_db,
+    )
+
+
+def _validate_mongodb_options(
+    mongo_uri: str | None,
+    mongo_db: str | None,
+) -> list[str]:
+    """Validate MongoDB connection options and return error messages.
+
+    Args:
+        mongo_uri: MongoDB connection URI, or None if not provided.
+        mongo_db: MongoDB database name, or None if not provided.
+
+    Returns:
+        List of error message strings (empty if valid).
+    """
+    errors: list[str] = []
+    if not mongo_uri:
+        errors.append("--mongo-uri (or MONGO_URI env var) is required when --backend=mongodb")
+    elif not mongo_uri.startswith(("mongodb://", "mongodb+srv://")):
+        errors.append("--mongo-uri must start with 'mongodb://' or 'mongodb+srv://'")
+    if not mongo_db:
+        errors.append("--mongo-db (or MONGO_DB env var) is required when --backend=mongodb")
+    return errors
 
 
 @app.command("import")

--- a/src/akgentic/catalog/cli/template_cmd.py
+++ b/src/akgentic/catalog/cli/template_cmd.py
@@ -11,7 +11,7 @@ import yaml
 from pydantic import ValidationError
 from rich.console import Console
 
-from akgentic.catalog.cli._catalog import build_catalogs
+from akgentic.catalog.cli._catalog import build_catalogs_from_state
 from akgentic.catalog.cli._output import render
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import TemplateQuery
@@ -64,7 +64,7 @@ def _load_entry_from_yaml(file: Path) -> TemplateEntry:
 def list_templates(ctx: typer.Context) -> None:
     """List all template entries."""
     state = _state(ctx)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     entries = template_catalog.list()
     render(entries, state.format)
 
@@ -73,7 +73,7 @@ def list_templates(ctx: typer.Context) -> None:
 def get_template(ctx: typer.Context, template_id: str = typer.Argument(help="Template ID")) -> None:
     """Display a single template entry."""
     state = _state(ctx)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     entry = template_catalog.get(template_id)
     if entry is None:
         err_console.print(f"[red]Not found:[/red] Template '{template_id}' not found")
@@ -89,7 +89,7 @@ def create_template(
     """Create a new template entry from a YAML file."""
     state = _state(ctx)
     entry = _load_entry_from_yaml(yaml_file)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     try:
         created_id = template_catalog.create(entry)
     except CatalogValidationError as exc:
@@ -109,7 +109,7 @@ def update_template(
     """Update an existing template entry from a YAML file."""
     state = _state(ctx)
     entry = _load_entry_from_yaml(yaml_file)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     try:
         template_catalog.update(template_id, entry)
     except EntryNotFoundError as exc:
@@ -130,7 +130,7 @@ def delete_template(
 ) -> None:
     """Delete a template entry."""
     state = _state(ctx)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     try:
         template_catalog.delete(template_id)
     except EntryNotFoundError as exc:
@@ -151,7 +151,7 @@ def search_templates(
 ) -> None:
     """Search template entries by placeholder name."""
     state = _state(ctx)
-    template_catalog, _, _, _ = build_catalogs(state.catalog_dir)
+    template_catalog, _, _, _ = build_catalogs_from_state(state)
     query = TemplateQuery(placeholder=placeholder)
     entries = template_catalog.search(query)
     render(entries, state.format)

--- a/src/akgentic/catalog/cli/tool_cmd.py
+++ b/src/akgentic/catalog/cli/tool_cmd.py
@@ -11,7 +11,7 @@ import yaml
 from pydantic import ValidationError
 from rich.console import Console
 
-from akgentic.catalog.cli._catalog import build_catalogs
+from akgentic.catalog.cli._catalog import build_catalogs_from_state
 from akgentic.catalog.cli._output import render
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import ToolQuery
@@ -64,7 +64,7 @@ def _load_entry_from_yaml(file: Path) -> ToolEntry:
 def list_tools(ctx: typer.Context) -> None:
     """List all tool entries."""
     state = _state(ctx)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     entries = tool_catalog.list()
     render(entries, state.format)
 
@@ -73,7 +73,7 @@ def list_tools(ctx: typer.Context) -> None:
 def get_tool(ctx: typer.Context, tool_id: str = typer.Argument(help="Tool ID")) -> None:
     """Display a single tool entry."""
     state = _state(ctx)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     entry = tool_catalog.get(tool_id)
     if entry is None:
         err_console.print(f"[red]Not found:[/red] Tool '{tool_id}' not found")
@@ -89,7 +89,7 @@ def create_tool(
     """Create a new tool entry from a YAML file."""
     state = _state(ctx)
     entry = _load_entry_from_yaml(yaml_file)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     try:
         created_id = tool_catalog.create(entry)
     except CatalogValidationError as exc:
@@ -109,7 +109,7 @@ def update_tool(
     """Update an existing tool entry from a YAML file."""
     state = _state(ctx)
     entry = _load_entry_from_yaml(yaml_file)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     try:
         tool_catalog.update(tool_id, entry)
     except EntryNotFoundError as exc:
@@ -130,7 +130,7 @@ def delete_tool(
 ) -> None:
     """Delete a tool entry."""
     state = _state(ctx)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     try:
         tool_catalog.delete(tool_id)
     except EntryNotFoundError as exc:
@@ -154,7 +154,7 @@ def search_tools(
 ) -> None:
     """Search tool entries by class or name."""
     state = _state(ctx)
-    _, tool_catalog, _, _ = build_catalogs(state.catalog_dir)
+    _, tool_catalog, _, _ = build_catalogs_from_state(state)
     query = ToolQuery(tool_class=tool_class, name=name)
     entries = tool_catalog.search(query)
     render(entries, state.format)

--- a/tests/cli/test_backend_selection.py
+++ b/tests/cli/test_backend_selection.py
@@ -1,0 +1,495 @@
+"""Tests for CLI backend selection (YAML and MongoDB)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import mongomock
+import pytest
+from typer.testing import CliRunner
+
+from akgentic.catalog.cli.main import GlobalState, app
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.mongo._helpers import to_document
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+runner = CliRunner()
+
+MONGO_URI = "mongodb://localhost:27017"
+MONGO_DB = "test_catalog"
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def mongo_client() -> mongomock.MongoClient:  # type: ignore[type-arg]
+    """Provide a fresh mongomock MongoClient per test."""
+    return mongomock.MongoClient()
+
+
+@pytest.fixture
+def _patch_mongo_client(
+    monkeypatch: pytest.MonkeyPatch,
+    mongo_client: mongomock.MongoClient,  # type: ignore[type-arg]
+) -> None:
+    """Patch MongoCatalogConfig.create_client to return the mongomock client."""
+    monkeypatch.setattr(
+        "akgentic.catalog.repositories.mongo._config.MongoCatalogConfig.create_client",
+        lambda self: mongo_client,
+    )
+
+
+@pytest.fixture
+def template_collection(
+    mongo_client: mongomock.MongoClient,  # type: ignore[type-arg]
+) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the template_entries collection for seeding data."""
+    return mongo_client[MONGO_DB]["template_entries"]
+
+
+@pytest.fixture
+def tool_collection(
+    mongo_client: mongomock.MongoClient,  # type: ignore[type-arg]
+) -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide the tool_entries collection for seeding data."""
+    return mongo_client[MONGO_DB]["tool_entries"]
+
+
+def _seed_template(
+    collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    template_id: str,
+    template: str,
+) -> None:
+    """Insert a template entry document into the MongoDB collection."""
+    entry = TemplateEntry(id=template_id, template=template)
+    collection.insert_one(to_document(entry))
+
+
+TOOL_CLASS = "akgentic.tool.search.search.SearchTool"
+
+
+def _seed_tool(
+    collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    tool_id: str,
+    name: str = "search",
+    description: str = "Search tool",
+    tool_class: str = TOOL_CLASS,
+) -> None:
+    """Insert a tool entry document directly into the MongoDB collection."""
+    doc = {
+        "_id": tool_id,
+        "tool_class": tool_class,
+        "tool": {"name": name, "description": description},
+    }
+    collection.insert_one(doc)
+
+
+# --- Task 1 tests: GlobalState backend fields ---
+
+
+class TestGlobalStateBackendFields:
+    """Verify GlobalState includes backend, mongo_uri, and mongo_db fields."""
+
+    def test_default_backend_is_yaml(self) -> None:
+        state = GlobalState()
+        assert state.backend == "yaml"
+
+    def test_default_mongo_uri_is_none(self) -> None:
+        state = GlobalState()
+        assert state.mongo_uri is None
+
+    def test_default_mongo_db_is_none(self) -> None:
+        state = GlobalState()
+        assert state.mongo_db is None
+
+    def test_backend_can_be_set(self) -> None:
+        state = GlobalState(backend="mongodb", mongo_uri="mongodb://localhost", mongo_db="mydb")
+        assert state.backend == "mongodb"
+        assert state.mongo_uri == "mongodb://localhost"
+        assert state.mongo_db == "mydb"
+
+
+# --- AC-4: YAML default (backward compatible) ---
+
+
+class TestYamlBackendDefault:
+    """AC-4: YAML is default when no --backend specified."""
+
+    def test_no_backend_flag_uses_yaml(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "template", "list"])
+        assert result.exit_code == 0
+
+    def test_explicit_yaml_backend(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["--backend", "yaml", "--catalog-dir", str(tmp_path), "template", "list"]
+        )
+        assert result.exit_code == 0
+
+
+class TestBackendHelpOutput:
+    """Verify --help shows backend options."""
+
+    def test_help_lists_backend_option(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "--backend" in result.output
+
+    def test_help_lists_mongo_uri_option(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "--mongo-uri" in result.output
+
+    def test_help_lists_mongo_db_option(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "--mongo-db" in result.output
+
+
+# --- AC-2: Missing MongoDB options error ---
+
+
+class TestMongoMissingOptions:
+    """AC-2: Clear error when MongoDB options missing."""
+
+    def test_missing_mongo_uri(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-db",
+                "test_db",
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--mongo-uri" in result.output or "MONGO_URI" in result.output
+
+    def test_missing_mongo_db(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--mongo-db" in result.output or "MONGO_DB" in result.output
+
+    def test_missing_both_mongo_options(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--mongo-uri" in result.output or "MONGO_URI" in result.output
+        assert "--mongo-db" in result.output or "MONGO_DB" in result.output
+
+    def test_invalid_mongo_uri_scheme(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                "http://localhost:27017",
+                "--mongo-db",
+                "test_db",
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "mongodb://" in result.output or "mongodb+srv://" in result.output
+
+    def test_no_python_traceback_on_error(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+
+
+# --- AC-1: MongoDB backend selection ---
+
+
+@pytest.mark.usefixtures("_patch_mongo_client")
+class TestMongoBackendSelection:
+    """AC-1: MongoDB backend selection works."""
+
+    def test_template_list_empty_from_mongodb(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "No entries found" in result.output
+
+    def test_template_list_from_mongodb(
+        self,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_template(template_collection, "greet-v1", "Hello {name}")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "greet-v1" in result.output
+
+    def test_template_get_from_mongodb(
+        self,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_template(template_collection, "greet-v1", "Hello {name}")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "get",
+                "greet-v1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "greet-v1" in result.output
+
+    def test_tool_list_from_mongodb(
+        self,
+        tool_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_tool(tool_collection, "tavily-search", name="Tavily Search")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "tool",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "tavily-search" in result.output
+
+
+# --- AC-3: Environment variable fallback ---
+
+
+@pytest.mark.usefixtures("_patch_mongo_client")
+class TestMongoEnvVarFallback:
+    """AC-3: Environment variable fallback for MongoDB options."""
+
+    def test_env_var_used_when_no_flags(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("MONGO_URI", MONGO_URI)
+        monkeypatch.setenv("MONGO_DB", MONGO_DB)
+        result = runner.invoke(app, ["--backend", "mongodb", "template", "list"])
+        assert result.exit_code == 0
+
+    def test_env_var_mongo_uri_only(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("MONGO_URI", MONGO_URI)
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_env_var_mongo_db_only(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("MONGO_DB", MONGO_DB)
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_cli_flags_override_env_vars(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """CLI flags should take precedence over env vars."""
+        monkeypatch.setenv("MONGO_URI", "mongodb://wrong-host:27017")
+        monkeypatch.setenv("MONGO_DB", "wrong_db")
+        _seed_template(template_collection, "t1", "Hello {name}")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "t1" in result.output
+
+
+# --- AC-5: MongoDB search ---
+
+
+@pytest.mark.usefixtures("_patch_mongo_client")
+class TestMongoSearch:
+    """AC-5: Search commands work with MongoDB backend."""
+
+    def test_template_search_by_placeholder(
+        self,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_template(template_collection, "t1", "Hello {name}")
+        _seed_template(template_collection, "t2", "You are {role}. Do {task}")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "search",
+                "--placeholder",
+                "name",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "t1" in result.output
+        # t2 does not have {name}, so it should not appear
+        assert "t2" not in result.output
+
+    def test_tool_search_by_class(
+        self,
+        tool_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_tool(tool_collection, "tavily-search", name="Tavily", tool_class=TOOL_CLASS)
+        _seed_tool(tool_collection, "calc", name="Calculator", tool_class="math.Calculator")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "tool",
+                "search",
+                "--class",
+                TOOL_CLASS,
+            ],
+        )
+        assert result.exit_code == 0
+        assert "tavily-search" in result.output
+
+    def test_template_search_no_results(
+        self,
+        template_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        _seed_template(template_collection, "t1", "Hello {name}")
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                MONGO_URI,
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "search",
+                "--placeholder",
+                "nonexistent",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "t1" not in result.output
+
+
+# --- Subtask 5.4: pymongo import error handling ---
+
+
+class TestMongoPymongoImportError:
+    """Verify clear error when pymongo is not installed."""
+
+    def test_import_guard_message_exists_in_mongo_package(self) -> None:
+        """Verify the import guard provides clear installation instructions."""
+        import akgentic.catalog.repositories.mongo as mongo_pkg
+
+        source_file = mongo_pkg.__file__
+        assert source_file is not None
+        with open(source_file) as f:
+            source = f.read()
+        assert "pip install akgentic-catalog[mongo]" in source

--- a/tests/cli/test_backend_selection.py
+++ b/tests/cli/test_backend_selection.py
@@ -79,7 +79,12 @@ def _seed_tool(
     description: str = "Search tool",
     tool_class: str = TOOL_CLASS,
 ) -> None:
-    """Insert a tool entry document directly into the MongoDB collection."""
+    """Insert a tool entry document into the MongoDB collection.
+
+    Uses raw dict in to_document format (``_id`` instead of ``id``) because
+    ToolEntry's validator resolves ``tool_class`` imports, preventing use of
+    arbitrary class paths needed for search-filter tests.
+    """
     doc = {
         "_id": tool_id,
         "tool_class": tool_class,
@@ -216,6 +221,15 @@ class TestMongoMissingOptions:
         assert result.exit_code == 1
         assert "mongodb://" in result.output or "mongodb+srv://" in result.output
 
+    def test_invalid_backend_value_rejected(self) -> None:
+        result = runner.invoke(
+            app,
+            ["--backend", "postgres", "template", "list"],
+        )
+        assert result.exit_code == 1
+        assert "Invalid backend" in result.output
+        assert "postgres" in result.output
+
     def test_no_python_traceback_on_error(self) -> None:
         result = runner.invoke(
             app,
@@ -296,6 +310,23 @@ class TestMongoBackendSelection:
         )
         assert result.exit_code == 0
         assert "greet-v1" in result.output
+
+    def test_mongodb_srv_uri_accepted(self) -> None:
+        """Verify mongodb+srv:// scheme passes validation."""
+        result = runner.invoke(
+            app,
+            [
+                "--backend",
+                "mongodb",
+                "--mongo-uri",
+                "mongodb+srv://cluster.example.com",
+                "--mongo-db",
+                MONGO_DB,
+                "template",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
 
     def test_tool_list_from_mongodb(
         self,


### PR DESCRIPTION
## Summary

- Extends `ak-catalog` CLI with `--backend`, `--mongo-uri`, `--mongo-db` global options for dual YAML/MongoDB backend support
- Adds `build_mongo_catalogs()` and `build_catalogs_from_state()` dispatcher in `_catalog.py` following the API's `_wire_mongodb_backend` pattern
- Validates MongoDB options (presence, URI scheme) with Rich error output — no Python tracebacks
- Environment variable fallback via Typer's `envvar` parameter (`MONGO_URI`, `MONGO_DB`)
- Code review fixes: invalid backend rejection, assert guards, `mongodb+srv://` test coverage
- 28 tests covering all 5 acceptance criteria, 577 total tests passing

Closes #44