### PR TITLE
CLI Commands for Agents and Teams

### DIFF
--- a/src/akgentic/catalog/cli/agent_cmd.py
+++ b/src/akgentic/catalog/cli/agent_cmd.py
@@ -1,0 +1,165 @@
+"""Agent CRUD subcommands for the catalog CLI."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+import yaml
+from pydantic import ValidationError
+from rich.console import Console
+
+from akgentic.catalog.cli._catalog import build_catalogs_from_state
+from akgentic.catalog.cli._output import render
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import AgentQuery
+
+if TYPE_CHECKING:
+    from akgentic.catalog.cli.main import GlobalState
+
+__all__ = ["agent_app"]
+
+logger = logging.getLogger(__name__)
+
+err_console = Console(stderr=True)
+
+agent_app = typer.Typer(name="agent", help="Manage agent catalog entries.")
+
+
+def _state(ctx: typer.Context) -> GlobalState:
+    """Retrieve global state from context."""
+    from akgentic.catalog.cli.main import get_state
+
+    return get_state(ctx)
+
+
+def _load_entry_from_yaml(file: Path) -> AgentEntry:
+    """Load an AgentEntry from a YAML file.
+
+    Args:
+        file: Path to the YAML file.
+
+    Returns:
+        A validated AgentEntry instance.
+
+    Raises:
+        typer.Exit: If the file cannot be read or parsed.
+    """
+    try:
+        data = yaml.safe_load(file.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        err_console.print(f"[red]Error reading file:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    try:
+        return AgentEntry.model_validate(data)
+    except (ValidationError, ValueError) as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@agent_app.command("list")
+def list_agents(ctx: typer.Context) -> None:
+    """List all agent entries."""
+    state = _state(ctx)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    entries = agent_catalog.list()
+    render(entries, state.format)
+
+
+@agent_app.command("get")
+def get_agent(ctx: typer.Context, agent_id: str = typer.Argument(help="Agent ID")) -> None:
+    """Display a single agent entry."""
+    state = _state(ctx)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    entry = agent_catalog.get(agent_id)
+    if entry is None:
+        err_console.print(f"[red]Not found:[/red] Agent '{agent_id}' not found")
+        raise typer.Exit(code=1)
+    render(entry, state.format)
+
+
+@agent_app.command("create")
+def create_agent(
+    ctx: typer.Context,
+    yaml_file: Path = typer.Argument(help="Path to YAML file with agent data"),
+) -> None:
+    """Create a new agent entry from a YAML file."""
+    state = _state(ctx)
+    entry = _load_entry_from_yaml(yaml_file)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    try:
+        created_id = agent_catalog.create(entry)
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Created agent:[/green] {created_id}")
+
+
+@agent_app.command("update")
+def update_agent(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(help="Agent ID to update"),
+    yaml_file: Path = typer.Argument(help="Path to YAML file with updated agent data"),
+) -> None:
+    """Update an existing agent entry from a YAML file."""
+    state = _state(ctx)
+    entry = _load_entry_from_yaml(yaml_file)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    try:
+        agent_catalog.update(agent_id, entry)
+    except EntryNotFoundError as exc:
+        err_console.print(f"[red]Not found:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Updated agent:[/green] {agent_id}")
+
+
+@agent_app.command("delete")
+def delete_agent(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(help="Agent ID to delete"),
+) -> None:
+    """Delete an agent entry."""
+    state = _state(ctx)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    try:
+        agent_catalog.delete(agent_id)
+    except EntryNotFoundError as exc:
+        err_console.print(f"[red]Not found:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Deleted agent:[/green] {agent_id}")
+
+
+@agent_app.command("search")
+def search_agents(
+    ctx: typer.Context,
+    role: str | None = typer.Option(None, "--role", help="Filter by agent role"),
+    skill: str | None = typer.Option(None, "--skill", help="Filter by agent skill"),
+    description: str | None = typer.Option(
+        None, "--description", help="Filter by description substring"
+    ),
+) -> None:
+    """Search agent entries by role, skill, or description."""
+    state = _state(ctx)
+    _, _, agent_catalog, _ = build_catalogs_from_state(state)
+    query = AgentQuery(
+        role=role,
+        skills=[skill] if skill else None,
+        description=description,
+    )
+    entries = agent_catalog.search(query)
+    render(entries, state.format)

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -153,15 +153,13 @@ def _register_subcommands() -> None:
     Called at module load time. Deferred to a function to keep imports
     after all module-level definitions, avoiding E402.
     """
+    from akgentic.catalog.cli.agent_cmd import agent_app
+    from akgentic.catalog.cli.team_cmd import team_app
     from akgentic.catalog.cli.template_cmd import template_app
     from akgentic.catalog.cli.tool_cmd import tool_app
 
     app.add_typer(template_app, name="template")
     app.add_typer(tool_app, name="tool")
-
-    # Stub subcommand groups (placeholders for stories 6-2 and 6-3)
-    agent_app = typer.Typer(name="agent", help="Manage agent catalog entries.")
-    team_app = typer.Typer(name="team", help="Manage team catalog entries.")
     app.add_typer(agent_app, name="agent")
     app.add_typer(team_app, name="team")
 

--- a/src/akgentic/catalog/cli/team_cmd.py
+++ b/src/akgentic/catalog/cli/team_cmd.py
@@ -55,7 +55,7 @@ def _load_entry_from_yaml(file: Path) -> TeamSpec:
         raise typer.Exit(code=1) from exc
     try:
         return TeamSpec.model_validate(data)
-    except (ValidationError, ValueError) as exc:
+    except ValidationError as exc:
         err_console.print(f"[red]Validation error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
 

--- a/src/akgentic/catalog/cli/team_cmd.py
+++ b/src/akgentic/catalog/cli/team_cmd.py
@@ -1,0 +1,163 @@
+"""Team CRUD subcommands for the catalog CLI."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+import yaml
+from pydantic import ValidationError
+from rich.console import Console
+
+from akgentic.catalog.cli._catalog import build_catalogs_from_state
+from akgentic.catalog.cli._output import render
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import TeamQuery
+from akgentic.catalog.models.team import TeamSpec
+
+if TYPE_CHECKING:
+    from akgentic.catalog.cli.main import GlobalState
+
+__all__ = ["team_app"]
+
+logger = logging.getLogger(__name__)
+
+err_console = Console(stderr=True)
+
+team_app = typer.Typer(name="team", help="Manage team catalog entries.")
+
+
+def _state(ctx: typer.Context) -> GlobalState:
+    """Retrieve global state from context."""
+    from akgentic.catalog.cli.main import get_state
+
+    return get_state(ctx)
+
+
+def _load_entry_from_yaml(file: Path) -> TeamSpec:
+    """Load a TeamSpec from a YAML file.
+
+    Args:
+        file: Path to the YAML file.
+
+    Returns:
+        A validated TeamSpec instance.
+
+    Raises:
+        typer.Exit: If the file cannot be read or parsed.
+    """
+    try:
+        data = yaml.safe_load(file.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        err_console.print(f"[red]Error reading file:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    try:
+        return TeamSpec.model_validate(data)
+    except (ValidationError, ValueError) as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
+@team_app.command("list")
+def list_teams(ctx: typer.Context) -> None:
+    """List all team entries."""
+    state = _state(ctx)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    entries = team_catalog.list()
+    render(entries, state.format)
+
+
+@team_app.command("get")
+def get_team(ctx: typer.Context, team_id: str = typer.Argument(help="Team ID")) -> None:
+    """Display a single team entry."""
+    state = _state(ctx)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    entry = team_catalog.get(team_id)
+    if entry is None:
+        err_console.print(f"[red]Not found:[/red] Team '{team_id}' not found")
+        raise typer.Exit(code=1)
+    render(entry, state.format)
+
+
+@team_app.command("create")
+def create_team(
+    ctx: typer.Context,
+    yaml_file: Path = typer.Argument(help="Path to YAML file with team data"),
+) -> None:
+    """Create a new team entry from a YAML file."""
+    state = _state(ctx)
+    entry = _load_entry_from_yaml(yaml_file)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    try:
+        created_id = team_catalog.create(entry)
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Created team:[/green] {created_id}")
+
+
+@team_app.command("update")
+def update_team(
+    ctx: typer.Context,
+    team_id: str = typer.Argument(help="Team ID to update"),
+    yaml_file: Path = typer.Argument(help="Path to YAML file with updated team data"),
+) -> None:
+    """Update an existing team entry from a YAML file."""
+    state = _state(ctx)
+    entry = _load_entry_from_yaml(yaml_file)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    try:
+        team_catalog.update(team_id, entry)
+    except EntryNotFoundError as exc:
+        err_console.print(f"[red]Not found:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Updated team:[/green] {team_id}")
+
+
+@team_app.command("delete")
+def delete_team(
+    ctx: typer.Context,
+    team_id: str = typer.Argument(help="Team ID to delete"),
+) -> None:
+    """Delete a team entry."""
+    state = _state(ctx)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    try:
+        team_catalog.delete(team_id)
+    except EntryNotFoundError as exc:
+        err_console.print(f"[red]Not found:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except CatalogValidationError as exc:
+        err_console.print(f"[red]Validation error:[/red] {exc}")
+        for err in exc.errors:
+            err_console.print(f"  - {err}")
+        raise typer.Exit(code=1) from exc
+    err_console.print(f"[green]Deleted team:[/green] {team_id}")
+
+
+@team_app.command("search")
+def search_teams(
+    ctx: typer.Context,
+    name: str | None = typer.Option(None, "--name", help="Filter by team name"),
+    description: str | None = typer.Option(
+        None, "--description", help="Filter by description substring"
+    ),
+    agent_id: str | None = typer.Option(
+        None, "--agent-id", help="Filter by agent ID in team members"
+    ),
+) -> None:
+    """Search team entries by name, description, or agent membership."""
+    state = _state(ctx)
+    _, _, _, team_catalog = build_catalogs_from_state(state)
+    query = TeamQuery(name=name, description=description, agent_id=agent_id)
+    entries = team_catalog.search(query)
+    render(entries, state.format)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,1 +1,72 @@
-"""Shared fixtures for CLI tests."""
+"""Shared fixtures and helpers for CLI tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+AGENT_CLASS = "akgentic.agent.BaseAgent"
+
+
+def make_dirs(tmp_path: Path) -> None:
+    """Create standard catalog subdirectories."""
+    for name in ("templates", "tools", "agents", "teams"):
+        (tmp_path / name).mkdir(exist_ok=True)
+
+
+def agent_data(
+    agent_id: str,
+    role: str = "engineer",
+    description: str = "Test agent",
+    skills: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build an agent entry dict suitable for YAML serialization."""
+    return {
+        "id": agent_id,
+        "tool_ids": [],
+        "card": {
+            "role": role,
+            "description": description,
+            "skills": skills or ["coding"],
+            "agent_class": AGENT_CLASS,
+            "config": {"name": f"@{role}", "role": role},
+            "routes_to": [],
+        },
+    }
+
+
+def team_data(
+    team_id: str,
+    name: str = "Test Team",
+    entry_point: str = "eng-mgr",
+    members: list[dict[str, Any]] | None = None,
+    description: str = "A test team",
+) -> dict[str, Any]:
+    """Build a team spec dict suitable for YAML serialization."""
+    return {
+        "id": team_id,
+        "name": name,
+        "entry_point": entry_point,
+        "message_types": ["akgentic.core.messages.UserMessage"],
+        "members": members or [{"agent_id": entry_point, "headcount": 1}],
+        "profiles": [],
+        "description": description,
+    }
+
+
+def seed_agent(catalog_dir: Path, agent_id: str, **kwargs: Any) -> None:
+    """Seed an agent entry directly in the catalog directory."""
+    data = agent_data(agent_id, **kwargs)
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def seed_team(catalog_dir: Path, team_id: str, **kwargs: Any) -> None:
+    """Seed a team entry directly in the catalog directory."""
+    data = team_data(team_id, **kwargs)
+    (catalog_dir / "teams" / f"{team_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )

--- a/tests/cli/test_agent_cmd.py
+++ b/tests/cli/test_agent_cmd.py
@@ -3,97 +3,38 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 from typer.testing import CliRunner
 
 from akgentic.catalog.cli.main import app
+from tests.cli.conftest import agent_data, make_dirs, seed_agent, seed_team
 
 runner = CliRunner()
 
-AGENT_CLASS = "akgentic.agent.BaseAgent"
 
-
-def _agent_data(
-    agent_id: str,
-    role: str = "engineer",
-    description: str = "Test agent",
-    skills: list[str] | None = None,
-) -> dict:
-    """Build an agent entry dict suitable for YAML serialization."""
-    return {
-        "id": agent_id,
-        "tool_ids": [],
-        "card": {
-            "role": role,
-            "description": description,
-            "skills": skills or ["coding"],
-            "agent_class": AGENT_CLASS,
-            "config": {"name": f"@{role}", "role": role},
-            "routes_to": [],
-        },
-    }
-
-
-def _write_agent_yaml(path: Path, agent_id: str, **kwargs: str | list[str]) -> Path:
+def _write_agent_yaml(path: Path, agent_id: str, **kwargs: Any) -> Path:
     """Write an agent YAML file and return its path."""
-    data = _agent_data(agent_id, **kwargs)  # type: ignore[arg-type]
+    data = agent_data(agent_id, **kwargs)
     file = path / f"{agent_id}.yaml"
     file.write_text(yaml.dump(data, default_flow_style=False))
     return file
-
-
-def _seed_agent(
-    catalog_dir: Path,
-    agent_id: str,
-    **kwargs: str | list[str],
-) -> None:
-    """Seed an agent entry directly in the catalog directory."""
-    data = _agent_data(agent_id, **kwargs)  # type: ignore[arg-type]
-    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
-        yaml.dump(data, default_flow_style=False)
-    )
-
-
-def _seed_team(
-    catalog_dir: Path,
-    team_id: str,
-    entry_point: str,
-    members: list[dict[str, str | int]] | None = None,
-) -> None:
-    """Seed a team entry directly in the catalog directory."""
-    data = {
-        "id": team_id,
-        "name": f"Team {team_id}",
-        "entry_point": entry_point,
-        "message_types": ["akgentic.core.messages.UserMessage"],
-        "members": members or [{"agent_id": entry_point, "headcount": 1}],
-        "profiles": [],
-        "description": f"Test team {team_id}",
-    }
-    (catalog_dir / "teams" / f"{team_id}.yaml").write_text(
-        yaml.dump(data, default_flow_style=False)
-    )
-
-
-def _make_dirs(tmp_path: Path) -> None:
-    for name in ("templates", "tools", "agents", "teams"):
-        (tmp_path / name).mkdir(exist_ok=True)
 
 
 class TestAgentList:
     """agent list command."""
 
     def test_list_empty(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "list"])
         assert result.exit_code == 0
         assert "No entries found" in result.output
 
     def test_list_with_entries(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
-        _seed_agent(tmp_path, "a2", role="Engineer")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
+        seed_agent(tmp_path, "a2", role="Engineer")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "list"])
         assert result.exit_code == 0
         assert "a1" in result.output
@@ -104,14 +45,14 @@ class TestAgentGet:
     """agent get command."""
 
     def test_get_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "get", "a1"])
         assert result.exit_code == 0
         assert "a1" in result.output
 
     def test_get_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "get", "nope"])
         assert result.exit_code == 1
         assert "Not found" in result.output
@@ -121,7 +62,7 @@ class TestAgentCreate:
     """agent create command."""
 
     def test_create_from_yaml(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         yaml_file = _write_agent_yaml(tmp_path, "new-agent", role="Researcher")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "create", str(yaml_file)]
@@ -135,8 +76,8 @@ class TestAgentCreate:
         assert "new-agent" in get_result.output
 
     def test_create_duplicate(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "dup", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "dup", role="Manager")
         yaml_file = _write_agent_yaml(tmp_path, "dup", role="Manager")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "create", str(yaml_file)]
@@ -144,7 +85,7 @@ class TestAgentCreate:
         assert result.exit_code == 1
 
     def test_create_with_invalid_yaml(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         bad_file = tmp_path / "bad.yaml"
         bad_file.write_text("id: bad\n")  # Missing required card field
         result = runner.invoke(
@@ -153,13 +94,25 @@ class TestAgentCreate:
         assert result.exit_code == 1
         assert "Validation error" in result.output
 
+    def test_create_with_cross_validation_error(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        data = agent_data("bad-refs")
+        data["tool_ids"] = ["nonexistent-tool"]
+        yaml_file = tmp_path / "bad-refs.yaml"
+        yaml_file.write_text(yaml.dump(data, default_flow_style=False))
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+        assert "nonexistent-tool" in result.output
+
 
 class TestAgentUpdate:
     """agent update command."""
 
     def test_update_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
         input_dir = tmp_path / "input"
         input_dir.mkdir()
         yaml_file = _write_agent_yaml(input_dir, "a1", role="Senior Manager")
@@ -169,7 +122,7 @@ class TestAgentUpdate:
         assert result.exit_code == 0
 
     def test_update_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         yaml_file = _write_agent_yaml(tmp_path, "nope", role="Ghost")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "update", "nope", str(yaml_file)]
@@ -181,21 +134,21 @@ class TestAgentDelete:
     """agent delete command."""
 
     def test_delete_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "delete", "a1"])
         assert result.exit_code == 0
 
     def test_delete_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "delete", "nope"])
         assert result.exit_code == 1
         assert "Not found" in result.output
 
     def test_delete_protected_by_team(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(
             tmp_path,
             "eng-team",
             entry_point="eng-mgr",
@@ -210,9 +163,9 @@ class TestAgentSearch:
     """agent search command."""
 
     def test_search_by_role(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
-        _seed_agent(tmp_path, "a2", role="Engineer")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
+        seed_agent(tmp_path, "a2", role="Engineer")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "search", "--role", "Manager"]
         )
@@ -220,18 +173,29 @@ class TestAgentSearch:
         assert "a1" in result.output
 
     def test_search_by_skill(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Researcher", skills=["research", "analysis"])
-        _seed_agent(tmp_path, "a2", role="Engineer", skills=["coding"])
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Researcher", skills=["research", "analysis"])
+        seed_agent(tmp_path, "a2", role="Engineer", skills=["coding"])
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "search", "--skill", "research"]
         )
         assert result.exit_code == 0
         assert "a1" in result.output
 
+    def test_search_by_description(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager", description="Coordinates engineering")
+        seed_agent(tmp_path, "a2", role="Engineer", description="Writes code")
+        result = runner.invoke(
+            app,
+            ["--catalog-dir", str(tmp_path), "agent", "search", "--description", "engineering"],
+        )
+        assert result.exit_code == 0
+        assert "a1" in result.output
+
     def test_search_no_results(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "a1", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "a1", role="Manager")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "agent", "search", "--role", "Ghost"]
         )

--- a/tests/cli/test_agent_cmd.py
+++ b/tests/cli/test_agent_cmd.py
@@ -1,0 +1,239 @@
+"""Tests for the agent CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.catalog.cli.main import app
+
+runner = CliRunner()
+
+AGENT_CLASS = "akgentic.agent.BaseAgent"
+
+
+def _agent_data(
+    agent_id: str,
+    role: str = "engineer",
+    description: str = "Test agent",
+    skills: list[str] | None = None,
+) -> dict:
+    """Build an agent entry dict suitable for YAML serialization."""
+    return {
+        "id": agent_id,
+        "tool_ids": [],
+        "card": {
+            "role": role,
+            "description": description,
+            "skills": skills or ["coding"],
+            "agent_class": AGENT_CLASS,
+            "config": {"name": f"@{role}", "role": role},
+            "routes_to": [],
+        },
+    }
+
+
+def _write_agent_yaml(path: Path, agent_id: str, **kwargs: str | list[str]) -> Path:
+    """Write an agent YAML file and return its path."""
+    data = _agent_data(agent_id, **kwargs)  # type: ignore[arg-type]
+    file = path / f"{agent_id}.yaml"
+    file.write_text(yaml.dump(data, default_flow_style=False))
+    return file
+
+
+def _seed_agent(
+    catalog_dir: Path,
+    agent_id: str,
+    **kwargs: str | list[str],
+) -> None:
+    """Seed an agent entry directly in the catalog directory."""
+    data = _agent_data(agent_id, **kwargs)  # type: ignore[arg-type]
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _seed_team(
+    catalog_dir: Path,
+    team_id: str,
+    entry_point: str,
+    members: list[dict[str, str | int]] | None = None,
+) -> None:
+    """Seed a team entry directly in the catalog directory."""
+    data = {
+        "id": team_id,
+        "name": f"Team {team_id}",
+        "entry_point": entry_point,
+        "message_types": ["akgentic.core.messages.UserMessage"],
+        "members": members or [{"agent_id": entry_point, "headcount": 1}],
+        "profiles": [],
+        "description": f"Test team {team_id}",
+    }
+    (catalog_dir / "teams" / f"{team_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _make_dirs(tmp_path: Path) -> None:
+    for name in ("templates", "tools", "agents", "teams"):
+        (tmp_path / name).mkdir(exist_ok=True)
+
+
+class TestAgentList:
+    """agent list command."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "list"])
+        assert result.exit_code == 0
+        assert "No entries found" in result.output
+
+    def test_list_with_entries(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        _seed_agent(tmp_path, "a2", role="Engineer")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "list"])
+        assert result.exit_code == 0
+        assert "a1" in result.output
+        assert "a2" in result.output
+
+
+class TestAgentGet:
+    """agent get command."""
+
+    def test_get_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "get", "a1"])
+        assert result.exit_code == 0
+        assert "a1" in result.output
+
+    def test_get_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "get", "nope"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+
+class TestAgentCreate:
+    """agent create command."""
+
+    def test_create_from_yaml(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        yaml_file = _write_agent_yaml(tmp_path, "new-agent", role="Researcher")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 0
+        # Verify it was actually created
+        get_result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "get", "new-agent"]
+        )
+        assert get_result.exit_code == 0
+        assert "new-agent" in get_result.output
+
+    def test_create_duplicate(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "dup", role="Manager")
+        yaml_file = _write_agent_yaml(tmp_path, "dup", role="Manager")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+
+    def test_create_with_invalid_yaml(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        bad_file = tmp_path / "bad.yaml"
+        bad_file.write_text("id: bad\n")  # Missing required card field
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "create", str(bad_file)]
+        )
+        assert result.exit_code == 1
+        assert "Validation error" in result.output
+
+
+class TestAgentUpdate:
+    """agent update command."""
+
+    def test_update_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        yaml_file = _write_agent_yaml(input_dir, "a1", role="Senior Manager")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "update", "a1", str(yaml_file)]
+        )
+        assert result.exit_code == 0
+
+    def test_update_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        yaml_file = _write_agent_yaml(tmp_path, "nope", role="Ghost")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "update", "nope", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+
+
+class TestAgentDelete:
+    """agent delete command."""
+
+    def test_delete_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "delete", "a1"])
+        assert result.exit_code == 0
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "delete", "nope"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+    def test_delete_protected_by_team(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(
+            tmp_path,
+            "eng-team",
+            entry_point="eng-mgr",
+            members=[{"agent_id": "eng-mgr", "headcount": 1}],
+        )
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "agent", "delete", "eng-mgr"])
+        assert result.exit_code == 1
+        assert "eng-team" in result.output
+
+
+class TestAgentSearch:
+    """agent search command."""
+
+    def test_search_by_role(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        _seed_agent(tmp_path, "a2", role="Engineer")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "search", "--role", "Manager"]
+        )
+        assert result.exit_code == 0
+        assert "a1" in result.output
+
+    def test_search_by_skill(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Researcher", skills=["research", "analysis"])
+        _seed_agent(tmp_path, "a2", role="Engineer", skills=["coding"])
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "search", "--skill", "research"]
+        )
+        assert result.exit_code == 0
+        assert "a1" in result.output
+
+    def test_search_no_results(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "a1", role="Manager")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "agent", "search", "--role", "Ghost"]
+        )
+        assert result.exit_code == 0
+        assert "No entries found" in result.output

--- a/tests/cli/test_team_cmd.py
+++ b/tests/cli/test_team_cmd.py
@@ -9,91 +9,34 @@ import yaml
 from typer.testing import CliRunner
 
 from akgentic.catalog.cli.main import app
+from tests.cli.conftest import make_dirs, seed_agent, seed_team, team_data
 
 runner = CliRunner()
-
-AGENT_CLASS = "akgentic.agent.BaseAgent"
-
-
-def _agent_data(agent_id: str, role: str = "engineer") -> dict[str, Any]:
-    """Build an agent entry dict suitable for YAML serialization."""
-    return {
-        "id": agent_id,
-        "tool_ids": [],
-        "card": {
-            "role": role,
-            "description": f"Test {role} agent",
-            "skills": ["coding"],
-            "agent_class": AGENT_CLASS,
-            "config": {"name": f"@{role}", "role": role},
-            "routes_to": [],
-        },
-    }
-
-
-def _team_data(
-    team_id: str,
-    name: str = "Test Team",
-    entry_point: str = "eng-mgr",
-    members: list[dict[str, Any]] | None = None,
-    description: str = "A test team",
-) -> dict[str, Any]:
-    """Build a team spec dict suitable for YAML serialization."""
-    return {
-        "id": team_id,
-        "name": name,
-        "entry_point": entry_point,
-        "message_types": ["akgentic.core.messages.UserMessage"],
-        "members": members or [{"agent_id": entry_point, "headcount": 1}],
-        "profiles": [],
-        "description": description,
-    }
-
-
-def _seed_agent(catalog_dir: Path, agent_id: str, role: str = "engineer") -> None:
-    """Seed an agent entry directly in the catalog directory."""
-    data = _agent_data(agent_id, role=role)
-    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
-        yaml.dump(data, default_flow_style=False)
-    )
 
 
 def _write_team_yaml(path: Path, team_id: str, **kwargs: Any) -> Path:
     """Write a team YAML file and return its path."""
-    data = _team_data(team_id, **kwargs)
+    data = team_data(team_id, **kwargs)
     file = path / f"{team_id}.yaml"
     file.write_text(yaml.dump(data, default_flow_style=False))
     return file
-
-
-def _seed_team(catalog_dir: Path, team_id: str, **kwargs: Any) -> None:
-    """Seed a team entry directly in the catalog directory."""
-    data = _team_data(team_id, **kwargs)
-    (catalog_dir / "teams" / f"{team_id}.yaml").write_text(
-        yaml.dump(data, default_flow_style=False)
-    )
-
-
-def _make_dirs(tmp_path: Path) -> None:
-    for name in ("templates", "tools", "agents", "teams"):
-        (tmp_path / name).mkdir(exist_ok=True)
 
 
 class TestTeamList:
     """team list command."""
 
     def test_list_empty(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "list"])
         assert result.exit_code == 0
         assert "No entries found" in result.output
 
     def test_list_with_entries(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_agent(tmp_path, "dev-lead", role="Lead")
-        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
-        _seed_team(tmp_path, "team2", name="Dev", entry_point="dev-lead")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_agent(tmp_path, "dev-lead", role="Lead")
+        seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        seed_team(tmp_path, "team2", name="Dev", entry_point="dev-lead")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "list"])
         assert result.exit_code == 0
         assert "team1" in result.output
@@ -104,15 +47,15 @@ class TestTeamGet:
     """team get command."""
 
     def test_get_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "get", "team1"])
         assert result.exit_code == 0
         assert "team1" in result.output
 
     def test_get_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "get", "nope"])
         assert result.exit_code == 1
         assert "Not found" in result.output
@@ -122,8 +65,8 @@ class TestTeamCreate:
     """team create command."""
 
     def test_create_from_yaml(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
         yaml_file = _write_team_yaml(tmp_path, "new-team", name="New Team", entry_point="eng-mgr")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "create", str(yaml_file)]
@@ -135,9 +78,9 @@ class TestTeamCreate:
         assert "new-team" in get_result.output
 
     def test_create_duplicate(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "dup", name="Dup Team", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "dup", name="Dup Team", entry_point="eng-mgr")
         yaml_file = _write_team_yaml(tmp_path, "dup", name="Dup Team", entry_point="eng-mgr")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "create", str(yaml_file)]
@@ -145,7 +88,7 @@ class TestTeamCreate:
         assert result.exit_code == 1
 
     def test_create_with_missing_agent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         yaml_file = _write_team_yaml(
             tmp_path,
             "bad-team",
@@ -159,14 +102,24 @@ class TestTeamCreate:
         assert result.exit_code == 1
         assert "ghost-agent" in result.output
 
+    def test_create_with_invalid_yaml(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        bad_file = tmp_path / "bad.yaml"
+        bad_file.write_text("id: bad\n")  # Missing required fields
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "create", str(bad_file)]
+        )
+        assert result.exit_code == 1
+        assert "Validation error" in result.output
+
 
 class TestTeamUpdate:
     """team update command."""
 
     def test_update_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "team1", name="Old Name", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "team1", name="Old Name", entry_point="eng-mgr")
         input_dir = tmp_path / "input"
         input_dir.mkdir()
         yaml_file = _write_team_yaml(input_dir, "team1", name="New Name", entry_point="eng-mgr")
@@ -176,8 +129,8 @@ class TestTeamUpdate:
         assert result.exit_code == 0
 
     def test_update_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
         yaml_file = _write_team_yaml(tmp_path, "nope", name="Ghost Team", entry_point="eng-mgr")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "update", "nope", str(yaml_file)]
@@ -189,14 +142,14 @@ class TestTeamDelete:
     """team delete command."""
 
     def test_delete_existing(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "team1", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "team1", entry_point="eng-mgr")
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "delete", "team1"])
         assert result.exit_code == 0
 
     def test_delete_nonexistent(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
+        make_dirs(tmp_path)
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "delete", "nope"])
         assert result.exit_code == 1
         assert "Not found" in result.output
@@ -206,10 +159,10 @@ class TestTeamSearch:
     """team search command."""
 
     def test_search_by_name(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "team1", name="Engineering Team", entry_point="eng-mgr")
-        _seed_team(tmp_path, "team2", name="Marketing Team", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "team1", name="Engineering Team", entry_point="eng-mgr")
+        seed_team(tmp_path, "team2", name="Marketing Team", entry_point="eng-mgr")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "search", "--name", "Engineering"]
         )
@@ -217,21 +170,44 @@ class TestTeamSearch:
         assert "team1" in result.output
 
     def test_search_by_agent_id(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_agent(tmp_path, "dev-lead", role="Lead")
-        _seed_team(tmp_path, "team1", name="Eng Team", entry_point="eng-mgr")
-        _seed_team(tmp_path, "team2", name="Dev Team", entry_point="dev-lead")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_agent(tmp_path, "dev-lead", role="Lead")
+        seed_team(tmp_path, "team1", name="Eng Team", entry_point="eng-mgr")
+        seed_team(tmp_path, "team2", name="Dev Team", entry_point="dev-lead")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "search", "--agent-id", "eng-mgr"]
         )
         assert result.exit_code == 0
         assert "team1" in result.output
 
+    def test_search_by_description(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(
+            tmp_path,
+            "team1",
+            name="Eng Team",
+            entry_point="eng-mgr",
+            description="Handles backend services",
+        )
+        seed_team(
+            tmp_path,
+            "team2",
+            name="UX Team",
+            entry_point="eng-mgr",
+            description="Designs user interfaces",
+        )
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "search", "--description", "backend"]
+        )
+        assert result.exit_code == 0
+        assert "team1" in result.output
+
     def test_search_no_results(self, tmp_path: Path) -> None:
-        _make_dirs(tmp_path)
-        _seed_agent(tmp_path, "eng-mgr", role="Manager")
-        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "eng-mgr", role="Manager")
+        seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
         result = runner.invoke(
             app, ["--catalog-dir", str(tmp_path), "team", "search", "--name", "Ghost"]
         )

--- a/tests/cli/test_team_cmd.py
+++ b/tests/cli/test_team_cmd.py
@@ -1,0 +1,239 @@
+"""Tests for the team CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.catalog.cli.main import app
+
+runner = CliRunner()
+
+AGENT_CLASS = "akgentic.agent.BaseAgent"
+
+
+def _agent_data(agent_id: str, role: str = "engineer") -> dict[str, Any]:
+    """Build an agent entry dict suitable for YAML serialization."""
+    return {
+        "id": agent_id,
+        "tool_ids": [],
+        "card": {
+            "role": role,
+            "description": f"Test {role} agent",
+            "skills": ["coding"],
+            "agent_class": AGENT_CLASS,
+            "config": {"name": f"@{role}", "role": role},
+            "routes_to": [],
+        },
+    }
+
+
+def _team_data(
+    team_id: str,
+    name: str = "Test Team",
+    entry_point: str = "eng-mgr",
+    members: list[dict[str, Any]] | None = None,
+    description: str = "A test team",
+) -> dict[str, Any]:
+    """Build a team spec dict suitable for YAML serialization."""
+    return {
+        "id": team_id,
+        "name": name,
+        "entry_point": entry_point,
+        "message_types": ["akgentic.core.messages.UserMessage"],
+        "members": members or [{"agent_id": entry_point, "headcount": 1}],
+        "profiles": [],
+        "description": description,
+    }
+
+
+def _seed_agent(catalog_dir: Path, agent_id: str, role: str = "engineer") -> None:
+    """Seed an agent entry directly in the catalog directory."""
+    data = _agent_data(agent_id, role=role)
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _write_team_yaml(path: Path, team_id: str, **kwargs: Any) -> Path:
+    """Write a team YAML file and return its path."""
+    data = _team_data(team_id, **kwargs)
+    file = path / f"{team_id}.yaml"
+    file.write_text(yaml.dump(data, default_flow_style=False))
+    return file
+
+
+def _seed_team(catalog_dir: Path, team_id: str, **kwargs: Any) -> None:
+    """Seed a team entry directly in the catalog directory."""
+    data = _team_data(team_id, **kwargs)
+    (catalog_dir / "teams" / f"{team_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _make_dirs(tmp_path: Path) -> None:
+    for name in ("templates", "tools", "agents", "teams"):
+        (tmp_path / name).mkdir(exist_ok=True)
+
+
+class TestTeamList:
+    """team list command."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "list"])
+        assert result.exit_code == 0
+        assert "No entries found" in result.output
+
+    def test_list_with_entries(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_agent(tmp_path, "dev-lead", role="Lead")
+        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        _seed_team(tmp_path, "team2", name="Dev", entry_point="dev-lead")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "list"])
+        assert result.exit_code == 0
+        assert "team1" in result.output
+        assert "team2" in result.output
+
+
+class TestTeamGet:
+    """team get command."""
+
+    def test_get_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "get", "team1"])
+        assert result.exit_code == 0
+        assert "team1" in result.output
+
+    def test_get_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "get", "nope"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+
+class TestTeamCreate:
+    """team create command."""
+
+    def test_create_from_yaml(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        yaml_file = _write_team_yaml(tmp_path, "new-team", name="New Team", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 0
+        # Verify it was actually created
+        get_result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "get", "new-team"])
+        assert get_result.exit_code == 0
+        assert "new-team" in get_result.output
+
+    def test_create_duplicate(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "dup", name="Dup Team", entry_point="eng-mgr")
+        yaml_file = _write_team_yaml(tmp_path, "dup", name="Dup Team", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+
+    def test_create_with_missing_agent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        yaml_file = _write_team_yaml(
+            tmp_path,
+            "bad-team",
+            name="Bad Team",
+            entry_point="ghost-agent",
+            members=[{"agent_id": "ghost-agent", "headcount": 1}],
+        )
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "create", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+        assert "ghost-agent" in result.output
+
+
+class TestTeamUpdate:
+    """team update command."""
+
+    def test_update_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "team1", name="Old Name", entry_point="eng-mgr")
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        yaml_file = _write_team_yaml(input_dir, "team1", name="New Name", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "update", "team1", str(yaml_file)]
+        )
+        assert result.exit_code == 0
+
+    def test_update_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        yaml_file = _write_team_yaml(tmp_path, "nope", name="Ghost Team", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "update", "nope", str(yaml_file)]
+        )
+        assert result.exit_code == 1
+
+
+class TestTeamDelete:
+    """team delete command."""
+
+    def test_delete_existing(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "team1", entry_point="eng-mgr")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "delete", "team1"])
+        assert result.exit_code == 0
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "team", "delete", "nope"])
+        assert result.exit_code == 1
+        assert "Not found" in result.output
+
+
+class TestTeamSearch:
+    """team search command."""
+
+    def test_search_by_name(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "team1", name="Engineering Team", entry_point="eng-mgr")
+        _seed_team(tmp_path, "team2", name="Marketing Team", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "search", "--name", "Engineering"]
+        )
+        assert result.exit_code == 0
+        assert "team1" in result.output
+
+    def test_search_by_agent_id(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_agent(tmp_path, "dev-lead", role="Lead")
+        _seed_team(tmp_path, "team1", name="Eng Team", entry_point="eng-mgr")
+        _seed_team(tmp_path, "team2", name="Dev Team", entry_point="dev-lead")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "search", "--agent-id", "eng-mgr"]
+        )
+        assert result.exit_code == 0
+        assert "team1" in result.output
+
+    def test_search_no_results(self, tmp_path: Path) -> None:
+        _make_dirs(tmp_path)
+        _seed_agent(tmp_path, "eng-mgr", role="Manager")
+        _seed_team(tmp_path, "team1", name="Engineering", entry_point="eng-mgr")
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "team", "search", "--name", "Ghost"]
+        )
+        assert result.exit_code == 0
+        assert "No entries found" in result.output


### PR DESCRIPTION
## Summary

- Add `agent_cmd.py` with full CRUD + search (role, skill, description) subcommands
- Add `team_cmd.py` with full CRUD + search (name, description, agent-id) subcommands
- Replace stub agent/team registrations in `main.py` with real imports
- 33 new tests (17 agent, 16 team) covering all CRUD, search, cross-validation errors, delete protection, and invalid input

## Code Review Fixes Applied

- Added cross-validation error test for agent create (`CatalogValidationError` path)
- Extracted shared test helpers to `tests/cli/conftest.py` to eliminate duplication
- Fixed `# type: ignore[arg-type]` workarounds in test kwargs typing
- Added invalid YAML test for team create (`ValidationError` path)
- Added `--description` search tests for both agent and team commands
- Removed unnecessary `ValueError` catch in `team_cmd._load_entry_from_yaml`

Closes #46