### PR TITLE
feat: CLI import and validate commands (story 6-3)

### DIFF
--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -6,18 +6,28 @@ groups for managing catalog entries.
 
 from __future__ import annotations
 
+import importlib.util
 import logging
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import typer
 from rich.console import Console
 
 from akgentic.catalog.cli._output import OutputFormat
 
+if TYPE_CHECKING:
+    from akgentic.catalog.models.agent import AgentEntry
+    from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+    from akgentic.catalog.models.template import TemplateEntry
+    from akgentic.catalog.models.tool import ToolEntry
+
 __all__ = ["app"]
 
 logger = logging.getLogger(__name__)
+err_console = Console(stderr=True)
 
 
 @dataclass
@@ -118,16 +128,409 @@ def _validate_mongodb_options(
     return errors
 
 
+def _load_entries_module(file_path: Path) -> list[Any]:
+    """Load a Python module and return its ``entries`` list.
+
+    Args:
+        file_path: Path to a ``.py`` file containing an ``entries`` variable.
+
+    Returns:
+        The list of catalog entries defined in the module.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ImportError: If the module cannot be loaded.
+        ValueError: If the module lacks ``entries`` or it is not a list.
+    """
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    spec = importlib.util.spec_from_file_location("_catalog_import", file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module from {file_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_catalog_import"] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop("_catalog_import", None)
+    entries = getattr(module, "entries", None)
+    if entries is None:
+        raise ValueError(f"Module {file_path} does not define an 'entries' variable")
+    if not isinstance(entries, list):
+        raise ValueError(f"'entries' in {file_path} must be a list")
+    if not entries:
+        raise ValueError(f"'entries' in {file_path} is empty")
+    return entries
+
+
+def _classify_entries(
+    entries: list[Any],
+) -> tuple[list[TemplateEntry], list[ToolEntry], list[AgentEntry], list[TeamSpec]]:
+    """Classify entries by type into four lists.
+
+    Args:
+        entries: Raw list of catalog entry objects.
+
+    Returns:
+        Tuple of (templates, tools, agents, teams).
+    """
+    from akgentic.catalog.models.agent import AgentEntry as _AgentEntry
+    from akgentic.catalog.models.team import TeamSpec as _TeamSpec
+    from akgentic.catalog.models.template import TemplateEntry as _TemplateEntry
+    from akgentic.catalog.models.tool import ToolEntry as _ToolEntry
+
+    templates: list[TemplateEntry] = []
+    tools: list[ToolEntry] = []
+    agents: list[AgentEntry] = []
+    teams: list[TeamSpec] = []
+
+    for entry in entries:
+        if isinstance(entry, _TemplateEntry):
+            templates.append(entry)
+        elif isinstance(entry, _ToolEntry):
+            tools.append(entry)
+        elif isinstance(entry, _AgentEntry):
+            agents.append(entry)
+        elif isinstance(entry, _TeamSpec):
+            teams.append(entry)
+        else:
+            err_console.print(
+                f"[yellow]Warning:[/yellow] Skipping unknown entry type: {type(entry).__name__}"
+            )
+
+    return templates, tools, agents, teams
+
+
+def _collect_member_ids(members: list[TeamMemberSpec]) -> set[str]:
+    """Recursively collect all agent_ids from a members tree.
+
+    Args:
+        members: The member tree to traverse.
+
+    Returns:
+        Set of all agent_id values found in the tree.
+    """
+    ids: set[str] = set()
+    for m in members:
+        ids.add(m.agent_id)
+        if m.members:
+            ids |= _collect_member_ids(m.members)
+    return ids
+
+
 @app.command("import")
-def import_cmd() -> None:
-    """Import catalog entries from external sources."""
-    typer.echo("Not yet implemented")
+def import_cmd(
+    ctx: typer.Context,
+    python_file: Path = typer.Argument(help="Path to a Python file with an 'entries' list"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate without persisting"),
+) -> None:
+    """Import catalog entries from a Python file."""
+    from akgentic.catalog.cli._catalog import build_catalogs_from_state
+    from akgentic.catalog.models.errors import CatalogValidationError
+
+    state = get_state(ctx)
+    template_catalog, tool_catalog, agent_catalog, team_catalog = build_catalogs_from_state(state)
+
+    try:
+        entries = _load_entries_module(python_file)
+    except (FileNotFoundError, ImportError, ValueError) as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        logger.warning("Failed to load entries from %s: %s", python_file, exc)
+        raise typer.Exit(code=1) from exc
+
+    templates, tools, agents, teams = _classify_entries(entries)
+    logger.info(
+        "Classified entries: %s templates, %s tools, %s agents, %s teams",
+        len(templates),
+        len(tools),
+        len(agents),
+        len(teams),
+    )
+
+    if dry_run:
+        _import_dry_run(
+            templates,
+            tools,
+            agents,
+            teams,
+            template_catalog,
+            tool_catalog,
+            agent_catalog,
+            team_catalog,
+        )
+        return
+
+    errors: list[str] = []
+    created = 0
+    updated = 0
+
+    # Resolution order: templates + tools first
+    for tmpl in templates:
+        try:
+            if template_catalog.get(tmpl.id) is None:
+                template_catalog.create(tmpl)
+                err_console.print(f"[green]Created template:[/green] {tmpl.id}")
+                created += 1
+            else:
+                template_catalog.update(tmpl.id, tmpl)
+                err_console.print(f"[blue]Updated template:[/blue] {tmpl.id}")
+                updated += 1
+        except CatalogValidationError as exc:
+            for err in exc.errors:
+                errors.append(f"Template '{tmpl.id}': {err}")
+
+    for tool in tools:
+        try:
+            if tool_catalog.get(tool.id) is None:
+                tool_catalog.create(tool)
+                err_console.print(f"[green]Created tool:[/green] {tool.id}")
+                created += 1
+            else:
+                tool_catalog.update(tool.id, tool)
+                err_console.print(f"[blue]Updated tool:[/blue] {tool.id}")
+                updated += 1
+        except CatalogValidationError as exc:
+            for err in exc.errors:
+                errors.append(f"Tool '{tool.id}': {err}")
+
+    # Then agents
+    batch_names = {a.card.config.name for a in agents if a.card.config.name}
+    for agent in agents:
+        try:
+            if agent_catalog.get(agent.id) is None:
+                agent_catalog.create(agent, pending_names=batch_names)
+                err_console.print(f"[green]Created agent:[/green] {agent.id}")
+                created += 1
+            else:
+                agent_catalog.update(agent.id, agent)
+                err_console.print(f"[blue]Updated agent:[/blue] {agent.id}")
+                updated += 1
+        except (CatalogValidationError, ValueError) as exc:
+            if isinstance(exc, CatalogValidationError):
+                for err in exc.errors:
+                    errors.append(f"Agent '{agent.id}': {err}")
+            else:
+                errors.append(f"Agent '{agent.id}': {exc}")
+
+    # Finally teams
+    for team in teams:
+        try:
+            if team_catalog.get(team.id) is None:
+                team_catalog.create(team)
+                err_console.print(f"[green]Created team:[/green] {team.id}")
+                created += 1
+            else:
+                team_catalog.update(team.id, team)
+                err_console.print(f"[blue]Updated team:[/blue] {team.id}")
+                updated += 1
+        except CatalogValidationError as exc:
+            for err in exc.errors:
+                errors.append(f"Team '{team.id}': {err}")
+
+    # Summary
+    err_console.print(f"\nImported: {created} created, {updated} updated, {len(errors)} errors")
+    if errors:
+        for err in errors:
+            err_console.print(f"[red]  - {err}[/red]")
+        raise typer.Exit(code=1)
+
+
+def _import_dry_run(
+    templates: list[TemplateEntry],
+    tools: list[ToolEntry],
+    agents: list[AgentEntry],
+    teams: list[TeamSpec],
+    template_catalog: Any,
+    tool_catalog: Any,
+    agent_catalog: Any,
+    team_catalog: Any,
+) -> None:
+    """Validate entries without persisting (dry-run mode).
+
+    Args:
+        templates: Template entries to validate.
+        tools: Tool entries to validate.
+        agents: Agent entries to validate.
+        teams: Team entries to validate.
+        template_catalog: Template catalog service.
+        tool_catalog: Tool catalog service.
+        agent_catalog: Agent catalog service for cross-validation.
+        team_catalog: Team catalog service for cross-validation.
+    """
+    would_create = 0
+    would_update = 0
+    error_count = 0
+
+    for tmpl in templates:
+        if template_catalog.get(tmpl.id) is None:
+            would_create += 1
+        else:
+            would_update += 1
+
+    for tool in tools:
+        if tool_catalog.get(tool.id) is None:
+            would_create += 1
+        else:
+            would_update += 1
+
+    batch_names = {a.card.config.name for a in agents if a.card.config.name}
+    for agent in agents:
+        existing = agent_catalog.get(agent.id)
+        errs = agent_catalog.validate_create(agent, pending_names=batch_names)
+        # Filter out "already exists" errors for entries that exist
+        if existing is not None:
+            errs = [e for e in errs if "already exists" not in e]
+            would_update += 1
+        else:
+            filtered = [e for e in errs if "already exists" not in e]
+            if not filtered:
+                would_create += 1
+            errs = filtered
+        if errs:
+            for err in errs:
+                err_console.print(f"[red]  Agent '{agent.id}': {err}[/red]")
+            error_count += len(errs)
+
+    for team in teams:
+        errs = team_catalog.validate_create(team)
+        existing = team_catalog.get(team.id)
+        if existing is not None:
+            errs = [e for e in errs if "already exists" not in e]
+            would_update += 1
+        else:
+            filtered = [e for e in errs if "already exists" not in e]
+            if not filtered:
+                would_create += 1
+            errs = filtered
+        if errs:
+            for err in errs:
+                err_console.print(f"[red]  Team '{team.id}': {err}[/red]")
+            error_count += len(errs)
+
+    err_console.print(
+        f"\nDry run: {would_create} would be created, "
+        f"{would_update} would be updated, {error_count} errors"
+    )
+    if error_count:
+        raise typer.Exit(code=1)
 
 
 @app.command("validate")
-def validate_cmd() -> None:
-    """Validate catalog entries for consistency."""
-    typer.echo("Not yet implemented")
+def validate_cmd(
+    ctx: typer.Context,
+    catalog: str | None = typer.Option(
+        None, "--catalog", help="Validate specific catalog: templates, tools, agents, teams"
+    ),
+) -> None:
+    """Validate catalog entries for cross-reference consistency."""
+    from akgentic.catalog.cli._catalog import build_catalogs_from_state
+    from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
+    from akgentic.core.utils.deserializer import import_class
+
+    valid_catalogs = ("templates", "tools", "agents", "teams")
+    if catalog is not None and catalog not in valid_catalogs:
+        err_console.print(
+            f"[red]Error:[/red] Invalid catalog '{catalog}'. "
+            f"Must be one of: {', '.join(valid_catalogs)}"
+        )
+        raise typer.Exit(code=1)
+
+    state = get_state(ctx)
+    template_catalog, tool_catalog, agent_catalog, team_catalog = build_catalogs_from_state(state)
+
+    errors: list[str] = []
+    template_count = 0
+    tool_count = 0
+    agent_count = 0
+    team_count = 0
+
+    # Templates
+    if catalog is None or catalog == "templates":
+        template_entries = template_catalog.list()
+        template_count = len(template_entries)
+
+    # Tools
+    if catalog is None or catalog == "tools":
+        tool_entries = tool_catalog.list()
+        tool_count = len(tool_entries)
+
+    # Agents
+    if catalog is None or catalog == "agents":
+        from akgentic.agent.config import AgentConfig
+
+        agent_entries = agent_catalog.list()
+        agent_count = len(agent_entries)
+        known_names = {a.card.config.name for a in agent_entries if a.card.config.name}
+
+        for agent in agent_entries:
+            # Check tool_ids
+            for tool_id in agent.tool_ids:
+                if tool_catalog.get(tool_id) is None:
+                    errors.append(f"Agent '{agent.id}': tool '{tool_id}' not found")
+            # Check @template reference
+            config = agent.card.config
+            if isinstance(config, AgentConfig):
+                prompt = config.prompt
+                if _is_catalog_ref(prompt.template):
+                    template_id = _resolve_ref(prompt.template)
+                    tmpl = template_catalog.get(template_id)
+                    if tmpl is None:
+                        errors.append(f"Agent '{agent.id}': template '@{template_id}' not found")
+                    else:
+                        provided = set(prompt.params.keys())
+                        expected = set(tmpl.placeholders)
+                        missing = expected - provided
+                        extra = provided - expected
+                        if missing:
+                            errors.append(
+                                f"Agent '{agent.id}': missing params for "
+                                f"'@{template_id}': {missing}"
+                            )
+                        if extra:
+                            errors.append(
+                                f"Agent '{agent.id}': extra params for '@{template_id}': {extra}"
+                            )
+            # Check routes_to
+            for route_name in agent.card.routes_to:
+                if route_name not in known_names:
+                    errors.append(f"Agent '{agent.id}': route target '{route_name}' not found")
+
+    # Teams
+    if catalog is None or catalog == "teams":
+        team_entries = team_catalog.list()
+        team_count = len(team_entries)
+
+        for team in team_entries:
+            all_member_ids = _collect_member_ids(team.members)
+            # Check entry_point in members
+            if team.entry_point not in all_member_ids:
+                errors.append(f"Team '{team.id}': entry_point '{team.entry_point}' not in members")
+            # Check all member agent_ids exist
+            for member_id in all_member_ids:
+                if agent_catalog.get(member_id) is None:
+                    errors.append(f"Team '{team.id}': member agent '{member_id}' not found")
+            # Check profiles
+            for profile_id in team.profiles:
+                if agent_catalog.get(profile_id) is None:
+                    errors.append(f"Team '{team.id}': profile agent '{profile_id}' not found")
+            # Check message_types
+            for mt in team.message_types:
+                try:
+                    import_class(mt)
+                except (ImportError, AttributeError):
+                    errors.append(f"Team '{team.id}': message type '{mt}' not resolvable")
+
+    # Report
+    if errors:
+        for err in errors:
+            err_console.print(f"[red]  {err}[/red]")
+    err_console.print(
+        f"\nValidated: {template_count} templates, {tool_count} tools, "
+        f"{agent_count} agents, {team_count} teams. "
+        f"Found {len(errors)} errors."
+    )
+    if errors:
+        raise typer.Exit(code=1)
 
 
 def get_state(ctx: typer.Context) -> GlobalState:

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:
     from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
     from akgentic.catalog.models.template import TemplateEntry
     from akgentic.catalog.models.tool import ToolEntry
+    from akgentic.catalog.services.agent_catalog import AgentCatalog
+    from akgentic.catalog.services.team_catalog import TeamCatalog
+    from akgentic.catalog.services.template_catalog import TemplateCatalog
+    from akgentic.catalog.services.tool_catalog import ToolCatalog
 
 __all__ = ["app"]
 
@@ -78,7 +82,6 @@ def main(
     """Akgentic catalog CLI -- manage templates, tools, agents, and teams."""
     valid_backends = ("yaml", "mongodb")
     if backend not in valid_backends:
-        err_console = Console(stderr=True)
         err_console.print(
             f"[red]Error:[/red] Invalid backend '{backend}'. "
             f"Must be one of: {', '.join(valid_backends)}"
@@ -89,7 +92,6 @@ def main(
     if backend == "mongodb":
         errors = _validate_mongodb_options(mongo_uri, mongo_db)
         if errors:
-            err_console = Console(stderr=True)
             for err in errors:
                 err_console.print(f"[red]Error:[/red] {err}")
             logger.warning("MongoDB validation failed: %s", errors)
@@ -340,10 +342,10 @@ def _import_dry_run(
     tools: list[ToolEntry],
     agents: list[AgentEntry],
     teams: list[TeamSpec],
-    template_catalog: Any,
-    tool_catalog: Any,
-    agent_catalog: Any,
-    team_catalog: Any,
+    template_catalog: TemplateCatalog,
+    tool_catalog: ToolCatalog,
+    agent_catalog: AgentCatalog,
+    team_catalog: TeamCatalog,
 ) -> None:
     """Validate entries without persisting (dry-run mode).
 
@@ -393,8 +395,8 @@ def _import_dry_run(
 
     for team in teams:
         errs = team_catalog.validate_create(team)
-        existing = team_catalog.get(team.id)
-        if existing is not None:
+        existing_team = team_catalog.get(team.id)
+        if existing_team is not None:
             errs = [e for e in errs if "already exists" not in e]
             would_update += 1
         else:
@@ -444,6 +446,10 @@ def validate_cmd(
     agent_count = 0
     team_count = 0
 
+    # Pre-load ID sets to avoid N+1 per-entry get() calls
+    tool_ids_set: set[str] = set()
+    agent_ids_set: set[str] = set()
+
     # Templates
     if catalog is None or catalog == "templates":
         template_entries = template_catalog.list()
@@ -453,6 +459,7 @@ def validate_cmd(
     if catalog is None or catalog == "tools":
         tool_entries = tool_catalog.list()
         tool_count = len(tool_entries)
+        tool_ids_set = {t.id for t in tool_entries}
 
     # Agents
     if catalog is None or catalog == "agents":
@@ -460,12 +467,17 @@ def validate_cmd(
 
         agent_entries = agent_catalog.list()
         agent_count = len(agent_entries)
+        agent_ids_set = {a.id for a in agent_entries}
         known_names = {a.card.config.name for a in agent_entries if a.card.config.name}
+
+        # Load tool IDs if not already loaded (e.g. --catalog agents)
+        if not tool_ids_set:
+            tool_ids_set = {t.id for t in tool_catalog.list()}
 
         for agent in agent_entries:
             # Check tool_ids
             for tool_id in agent.tool_ids:
-                if tool_catalog.get(tool_id) is None:
+                if tool_id not in tool_ids_set:
                     errors.append(f"Agent '{agent.id}': tool '{tool_id}' not found")
             # Check @template reference
             config = agent.card.config
@@ -500,6 +512,10 @@ def validate_cmd(
         team_entries = team_catalog.list()
         team_count = len(team_entries)
 
+        # Load agent IDs if not already loaded (e.g. --catalog teams)
+        if not agent_ids_set:
+            agent_ids_set = {a.id for a in agent_catalog.list()}
+
         for team in team_entries:
             all_member_ids = _collect_member_ids(team.members)
             # Check entry_point in members
@@ -507,17 +523,17 @@ def validate_cmd(
                 errors.append(f"Team '{team.id}': entry_point '{team.entry_point}' not in members")
             # Check all member agent_ids exist
             for member_id in all_member_ids:
-                if agent_catalog.get(member_id) is None:
+                if member_id not in agent_ids_set:
                     errors.append(f"Team '{team.id}': member agent '{member_id}' not found")
             # Check profiles
             for profile_id in team.profiles:
-                if agent_catalog.get(profile_id) is None:
+                if profile_id not in agent_ids_set:
                     errors.append(f"Team '{team.id}': profile agent '{profile_id}' not found")
             # Check message_types
             for mt in team.message_types:
                 try:
                     import_class(mt)
-                except (ImportError, AttributeError):
+                except (ImportError, AttributeError, ValueError):
                     errors.append(f"Team '{team.id}': message type '{mt}' not resolvable")
 
     # Report

--- a/tests/cli/test_import_cmd.py
+++ b/tests/cli/test_import_cmd.py
@@ -1,0 +1,203 @@
+"""Tests for the ``ak-catalog import`` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.catalog.cli.main import app
+from tests.cli.conftest import make_dirs
+
+runner = CliRunner()
+
+
+def _write_entries_file(tmp_path: Path, content: str) -> Path:
+    """Write a Python entries file to tmp_path and return its path."""
+    py_file = tmp_path / "entries.py"
+    py_file.write_text(content)
+    return py_file
+
+
+TEMPLATE_ENTRIES_FILE = """\
+from akgentic.catalog.models.template import TemplateEntry
+
+entries = [
+    TemplateEntry(id="test-tmpl", template="Hello {name}"),
+]
+"""
+
+MIXED_ENTRIES_FILE = """\
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.team import TeamSpec, TeamMemberSpec
+from akgentic.tool.search import SearchTool, WebSearch
+
+entries = [
+    TemplateEntry(id="mix-tmpl", template="Hello {name}"),
+    ToolEntry(
+        id="mix-tool",
+        tool_class="akgentic.tool.search.SearchTool",
+        tool=SearchTool(
+            name="search", description="Web search",
+            web_search=WebSearch(max_results=5),
+        ),
+    ),
+    AgentEntry.model_validate({
+        "id": "mix-agent",
+        "tool_ids": [],
+        "card": {
+            "role": "Tester",
+            "description": "Test agent",
+            "skills": ["testing"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {"name": "@Tester", "role": "Tester"},
+            "routes_to": [],
+        },
+    }),
+    TeamSpec(
+        id="mix-team",
+        name="Mix Team",
+        entry_point="mix-agent",
+        message_types=["akgentic.core.messages.UserMessage"],
+        members=[TeamMemberSpec(agent_id="mix-agent", headcount=1)],
+    ),
+]
+"""
+
+
+class TestImportDiscovery:
+    """Test that import discovers entries by type (AC-1)."""
+
+    def test_import_templates_only(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, TEMPLATE_ENTRIES_FILE)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 0, result.output
+        assert "Created template" in result.output
+        assert "test-tmpl" in result.output
+
+    def test_import_mixed_types(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, MIXED_ENTRIES_FILE)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 0, result.output
+        assert "Created template" in result.output
+        assert "Created tool" in result.output
+        assert "Created agent" in result.output
+        assert "Created team" in result.output
+
+
+class TestImportResolutionOrder:
+    """Test that entries are dispatched in resolution order (AC-2)."""
+
+    def test_resolution_order_in_output(self, tmp_path: Path) -> None:
+        """Templates+tools should appear before agents, agents before teams."""
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, MIXED_ENTRIES_FILE)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 0, result.output
+        lines = result.output.split("\n")
+        created_lines = [line for line in lines if "Created" in line]
+        # Template and tool should come before agent and team
+        tmpl_idx = next(i for i, ln in enumerate(created_lines) if "template" in ln)
+        tool_idx = next(i for i, ln in enumerate(created_lines) if "tool" in ln)
+        agent_idx = next(i for i, ln in enumerate(created_lines) if "agent" in ln)
+        team_idx = next(i for i, ln in enumerate(created_lines) if "team" in ln)
+        assert tmpl_idx < agent_idx
+        assert tool_idx < agent_idx
+        assert agent_idx < team_idx
+
+
+class TestImportCreateUpdate:
+    """Test create-or-update logic (AC-2)."""
+
+    def test_import_updates_existing_entry(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        # Seed an existing template
+        (tmp_path / "templates" / "test-tmpl.yaml").write_text(
+            yaml.dump({"id": "test-tmpl", "template": "Old {name}"})
+        )
+        py_file = _write_entries_file(tmp_path, TEMPLATE_ENTRIES_FILE)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 0, result.output
+        assert "Updated template" in result.output
+        assert "test-tmpl" in result.output
+
+
+class TestImportDryRun:
+    """Test dry-run mode (AC-3)."""
+
+    def test_dry_run_no_persist(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, TEMPLATE_ENTRIES_FILE)
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "import", str(py_file), "--dry-run"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert "1 would be created" in result.output
+        # Verify nothing was persisted
+        assert not list((tmp_path / "templates").glob("*.yaml"))
+
+
+class TestImportErrors:
+    """Test error handling in import command."""
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "import", str(tmp_path / "nonexistent.py")]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "Error" in result.output
+
+    def test_file_without_entries(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, "x = 42\n")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 1
+        assert "entries" in result.output.lower()
+
+    def test_entries_not_a_list(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, 'entries = "not a list"\n')
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 1
+        assert "list" in result.output.lower()
+
+    def test_entries_empty_list(self, tmp_path: Path) -> None:
+        make_dirs(tmp_path)
+        py_file = _write_entries_file(tmp_path, "entries = []\n")
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        assert result.exit_code == 1
+        assert "empty" in result.output.lower()
+
+    def test_import_agent_with_bad_tool_ref(self, tmp_path: Path) -> None:
+        """Agent referencing nonexistent tool — error reported, import continues."""
+        make_dirs(tmp_path)
+        content = """\
+from akgentic.catalog.models.agent import AgentEntry
+
+entries = [
+    AgentEntry.model_validate({
+        "id": "bad-agent",
+        "tool_ids": ["nonexistent-tool"],
+        "card": {
+            "role": "Tester",
+            "description": "Test agent",
+            "skills": ["testing"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {"name": "@Tester", "role": "Tester"},
+            "routes_to": [],
+        },
+    }),
+]
+"""
+        py_file = _write_entries_file(tmp_path, content)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "import", str(py_file)])
+        # Should report errors but still exit (exit code 1 because of validation errors)
+        assert result.exit_code == 1
+        assert "nonexistent-tool" in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,4 +1,4 @@
-"""Tests for the main CLI app, help output, and stub commands."""
+"""Tests for the main CLI app and help output."""
 
 from __future__ import annotations
 
@@ -25,15 +25,16 @@ class TestCliHelp:
         assert "--format" in result.output
 
 
-class TestStubCommands:
-    """Verify stub commands print 'Not yet implemented' and exit cleanly."""
+class TestImportValidateHelp:
+    """Verify import and validate commands show help and accept arguments."""
 
-    def test_import_stub(self) -> None:
-        result = runner.invoke(app, ["import"])
+    def test_import_help(self) -> None:
+        result = runner.invoke(app, ["import", "--help"])
         assert result.exit_code == 0
-        assert "Not yet implemented" in result.output
+        assert "PYTHON_FILE" in result.output
+        assert "--dry-run" in result.output
 
-    def test_validate_stub(self) -> None:
-        result = runner.invoke(app, ["validate"])
+    def test_validate_help(self) -> None:
+        result = runner.invoke(app, ["validate", "--help"])
         assert result.exit_code == 0
-        assert "Not yet implemented" in result.output
+        assert "--catalog" in result.output

--- a/tests/cli/test_validate_cmd.py
+++ b/tests/cli/test_validate_cmd.py
@@ -1,0 +1,193 @@
+"""Tests for the ``ak-catalog validate`` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.catalog.cli.main import app
+from tests.cli.conftest import agent_data, make_dirs, seed_agent, seed_team, team_data
+
+runner = CliRunner()
+
+
+def _seed_template(catalog_dir: Path, template_id: str, template: str = "Hello {name}") -> None:
+    """Seed a template entry directly in the catalog directory."""
+    data = {"id": template_id, "template": template}
+    (catalog_dir / "templates" / f"{template_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _seed_tool(catalog_dir: Path, tool_id: str) -> None:
+    """Seed a tool entry directly in the catalog directory."""
+    data = {
+        "id": tool_id,
+        "tool_class": "akgentic.tool.search.SearchTool",
+        "tool": {
+            "name": "search",
+            "description": "Web search",
+            "web_search": {"max_results": 5},
+        },
+    }
+    (catalog_dir / "tools" / f"{tool_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _seed_agent_with_tool_ids(
+    catalog_dir: Path,
+    agent_id: str,
+    tool_ids: list[str],
+) -> None:
+    """Seed an agent entry with specific tool_ids."""
+    data = agent_data(agent_id)
+    data["tool_ids"] = tool_ids
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+def _seed_agent_with_routes(
+    catalog_dir: Path,
+    agent_id: str,
+    routes_to: list[str],
+    role: str = "engineer",
+) -> None:
+    """Seed an agent entry with specific routes_to."""
+    data = agent_data(agent_id, role=role)
+    data["card"]["routes_to"] = routes_to
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
+class TestValidateAll:
+    """Test validate on all catalogs (AC-4)."""
+
+    def test_validate_clean_catalog(self, tmp_path: Path) -> None:
+        """All entries with valid cross-refs → exit 0."""
+        make_dirs(tmp_path)
+        _seed_template(tmp_path, "tmpl-1")
+        _seed_tool(tmp_path, "tool-1")
+        seed_agent(tmp_path, "agent-1")
+        seed_team(
+            tmp_path,
+            "team-1",
+            entry_point="agent-1",
+            members=[{"agent_id": "agent-1", "headcount": 1}],
+        )
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 0, result.output
+        assert "Found 0 errors" in result.output
+
+    def test_validate_empty_catalog(self, tmp_path: Path) -> None:
+        """Empty catalog → exit 0, no errors."""
+        make_dirs(tmp_path)
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 0, result.output
+        assert "Found 0 errors" in result.output
+
+
+class TestValidateSpecific:
+    """Test validate with --catalog filter (AC-5)."""
+
+    def test_validate_agents_only(self, tmp_path: Path) -> None:
+        """--catalog agents: only agent cross-refs checked."""
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "agent-1")
+        # Seed team with broken member — should NOT be reported
+        seed_team(
+            tmp_path,
+            "team-1",
+            entry_point="nonexistent",
+            members=[{"agent_id": "nonexistent", "headcount": 1}],
+        )
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "validate", "--catalog", "agents"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "0 teams" in result.output  # teams not counted
+
+    def test_validate_templates_only(self, tmp_path: Path) -> None:
+        """--catalog templates: just counts templates, no cross-ref errors."""
+        make_dirs(tmp_path)
+        _seed_template(tmp_path, "tmpl-1")
+        # Seed agent with broken tool ref — should NOT be reported
+        _seed_agent_with_tool_ids(tmp_path, "bad-agent", ["missing-tool"])
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "validate", "--catalog", "templates"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "1 templates" in result.output
+
+    def test_validate_invalid_catalog_option(self, tmp_path: Path) -> None:
+        """Invalid --catalog value → exit 1."""
+        make_dirs(tmp_path)
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "validate", "--catalog", "invalid"]
+        )
+        assert result.exit_code == 1
+        assert "Invalid catalog" in result.output
+
+
+class TestValidateErrors:
+    """Test that validate detects various cross-reference errors (AC-4)."""
+
+    def test_validate_detects_missing_tool(self, tmp_path: Path) -> None:
+        """Agent with invalid tool_id → error reported."""
+        make_dirs(tmp_path)
+        _seed_agent_with_tool_ids(tmp_path, "bad-agent", ["nonexistent-tool"])
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 1
+        assert "nonexistent-tool" in result.output
+
+    def test_validate_detects_broken_routes_to(self, tmp_path: Path) -> None:
+        """Agent with invalid routes_to target → error reported."""
+        make_dirs(tmp_path)
+        _seed_agent_with_routes(tmp_path, "router", ["@NonExistentAgent"])
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 1
+        assert "route target" in result.output.lower()
+
+    def test_validate_detects_missing_agent_in_team(self, tmp_path: Path) -> None:
+        """Team with invalid member agent_id → error reported."""
+        make_dirs(tmp_path)
+        seed_team(
+            tmp_path,
+            "bad-team",
+            entry_point="missing-agent",
+            members=[{"agent_id": "missing-agent", "headcount": 1}],
+        )
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 1
+        assert "missing-agent" in result.output
+
+    def test_validate_detects_entry_point_not_in_members(self, tmp_path: Path) -> None:
+        """Team entry_point not in members → error reported."""
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "agent-1")
+        data = team_data("bad-team", entry_point="other-agent")
+        data["members"] = [{"agent_id": "agent-1", "headcount": 1}]
+        (tmp_path / "teams" / "bad-team.yaml").write_text(yaml.dump(data, default_flow_style=False))
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 1
+        assert "entry_point" in result.output
+
+    def test_validate_with_catalog_agents_only(self, tmp_path: Path) -> None:
+        """--catalog agents: team errors not reported."""
+        make_dirs(tmp_path)
+        seed_agent(tmp_path, "agent-1")
+        seed_team(
+            tmp_path,
+            "bad-team",
+            entry_point="missing-agent",
+            members=[{"agent_id": "missing-agent", "headcount": 1}],
+        )
+        result = runner.invoke(
+            app, ["--catalog-dir", str(tmp_path), "validate", "--catalog", "agents"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "missing-agent" not in result.output

--- a/tests/cli/test_validate_cmd.py
+++ b/tests/cli/test_validate_cmd.py
@@ -64,6 +64,23 @@ def _seed_agent_with_routes(
     )
 
 
+def _seed_agent_with_template_ref(
+    catalog_dir: Path,
+    agent_id: str,
+    template_ref: str,
+    params: dict[str, str] | None = None,
+) -> None:
+    """Seed an agent with a @template reference in its prompt config."""
+    data = agent_data(agent_id)
+    data["card"]["config"]["prompt"] = {
+        "template": template_ref,
+        "params": params or {},
+    }
+    (catalog_dir / "agents" / f"{agent_id}.yaml").write_text(
+        yaml.dump(data, default_flow_style=False)
+    )
+
+
 class TestValidateAll:
     """Test validate on all catalogs (AC-4)."""
 
@@ -143,6 +160,14 @@ class TestValidateErrors:
         result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
         assert result.exit_code == 1
         assert "nonexistent-tool" in result.output
+
+    def test_validate_detects_missing_template_ref(self, tmp_path: Path) -> None:
+        """Agent with @template ref to nonexistent template → error reported."""
+        make_dirs(tmp_path)
+        _seed_agent_with_template_ref(tmp_path, "tmpl-agent", "@missing-tmpl", {"name": "X"})
+        result = runner.invoke(app, ["--catalog-dir", str(tmp_path), "validate"])
+        assert result.exit_code == 1
+        assert "missing-tmpl" in result.output
 
     def test_validate_detects_broken_routes_to(self, tmp_path: Path) -> None:
         """Agent with invalid routes_to target → error reported."""


### PR DESCRIPTION
## Summary

- Implements `ak-catalog import <python-file>` command with resolution-order dispatch, create-or-update logic, `--dry-run` mode, and cross-reference validation
- Implements `ak-catalog validate` command with cross-reference consistency checking across all four catalogs, per-catalog filtering via `--catalog`, and detailed error reporting
- 21 tests covering import discovery, resolution order, create/update, dry-run, error handling, and validate cross-ref detection

## Code Review Fixes

- Add missing `ValueError` to validate_cmd message_type exception handler (matches service layer)
- Eliminate N+1 query pattern in validate_cmd with pre-loaded ID sets
- Add missing @template reference validation test (task 5.4)
- Replace `Any` types in `_import_dry_run` with proper service types
- Remove shadowed `err_console` locals in `main()` callback

Relates to #48