### PR TITLE
Fix ToolEntry Custom ToolCard Serialization

### DIFF
--- a/src/akgentic/catalog/models/tool.py
+++ b/src/akgentic/catalog/models/tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, model_serializer, model_validator
 
 from akgentic.catalog.models._types import NonEmptyStr
 from akgentic.core.utils.deserializer import import_class
@@ -54,6 +54,21 @@ class ToolEntry(BaseModel):
                 raise ValueError(f"Cannot resolve tool_class '{tool_class_path}': {e}") from e
             data["tool"] = klass.model_validate(data["tool"])
         return data
+
+    @model_serializer
+    def serialize_model(self) -> dict[str, Any]:
+        """Serialize tool field against runtime type to preserve custom ToolCard subclass fields.
+
+        Pydantic v2 serializes the ``tool`` field against the declared
+        ``ToolCard`` annotation, which only includes ``name`` and
+        ``description``.  Calling ``model_dump()`` on the runtime instance
+        directly captures all subclass fields.
+        """
+        return {
+            "id": self.id,
+            "tool_class": self.tool_class,
+            "tool": self.tool.model_dump(),
+        }
 
 
 __all__ = ["ToolEntry"]

--- a/src/akgentic/catalog/models/tool.py
+++ b/src/akgentic/catalog/models/tool.py
@@ -55,20 +55,19 @@ class ToolEntry(BaseModel):
             data["tool"] = klass.model_validate(data["tool"])
         return data
 
-    @model_serializer
-    def serialize_model(self) -> dict[str, Any]:
+    @model_serializer(mode="wrap")
+    def serialize_model(self, handler: Any) -> dict[str, Any]:  # noqa: ANN401
         """Serialize tool field against runtime type to preserve custom ToolCard subclass fields.
 
         Pydantic v2 serializes the ``tool`` field against the declared
         ``ToolCard`` annotation, which only includes ``name`` and
-        ``description``.  Calling ``model_dump()`` on the runtime instance
-        directly captures all subclass fields.
+        ``description``.  Using ``mode='wrap'`` delegates to the default
+        handler for all fields, then overrides ``tool`` by calling
+        ``model_dump()`` on the runtime instance to capture subclass fields.
         """
-        return {
-            "id": self.id,
-            "tool_class": self.tool_class,
-            "tool": self.tool.model_dump(),
-        }
+        data: dict[str, Any] = handler(self)
+        data["tool"] = self.tool.model_dump()
+        return data
 
 
 __all__ = ["ToolEntry"]

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -205,6 +205,9 @@ class TestRoundTripToolEntry:
         assert restored.id == "web-search"
         assert restored.tool_class == "tests.models.test_round_trip.SearchToolCard"
 
+        # Guard: serializer includes all model fields
+        assert set(dumped.keys()) == set(ToolEntry.model_fields.keys())
+
 
 class TestRoundTripTeamSpec:
     """AC3: TeamSpec recursive tree and metadata round-trip."""

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
 from akgentic.agent.config import AgentConfig
 from akgentic.core.agent import Akgent
 from akgentic.core.agent_state import BaseState
@@ -174,15 +173,6 @@ class TestRoundTripAgentEntry:
 class TestRoundTripToolEntry:
     """AC2: ToolEntry with custom ToolCard subclass round-trip."""
 
-    @pytest.mark.xfail(
-        reason=(
-            "ADR-02 Fragile Spot #4: ToolEntry.tool is typed as abstract ToolCard, "
-            "so Pydantic v2 model_dump() serializes only base fields (name, description), "
-            "silently dropping custom subclass fields. Fix requires adding a custom "
-            "model_serializer to ToolEntry or ToolCard."
-        ),
-        strict=True,
-    )
     def test_custom_tool_card_fields_survive_round_trip(self) -> None:
         """Custom ToolCard subclass fields survive model_dump -> model_validate."""
         original = ToolEntry(


### PR DESCRIPTION
## Summary

- Added `@model_serializer(mode='wrap')` to `ToolEntry` so custom `ToolCard` subclass fields survive `model_dump()` round-trips (ADR-02 Fragile Spot #4)
- Removed `xfail` marker from round-trip test — now passes green (638/638)
- Code review fix: switched from `mode='plain'` (hard-coded fields) to `mode='wrap'` (delegates to default handler, only overrides `tool`)
- Added serializer completeness guard assertion in test

Closes #51