### PR TITLE
Template & Tool Entry Basics (Example 01)

### DIFF
--- a/examples/01-catalog-entries.md
+++ b/examples/01-catalog-entries.md
@@ -1,0 +1,123 @@
+# Example 01 — Template & Tool Entry Basics
+
+Your first contact with the catalog API: learn the two simplest entity types before
+encountering cross-catalog dependencies in later examples.
+
+## Concepts Covered
+
+### Creating catalogs backed by YAML repositories
+
+Each catalog type (`TemplateCatalog`, `ToolCatalog`) wraps a repository that persists
+entries as individual YAML files in a directory.  You create a repository pointing at
+a directory path, then wrap it in the corresponding service:
+
+```python
+template_repo = YamlTemplateCatalogRepository(Path(tmpdir) / "templates")
+template_catalog = TemplateCatalog(repository=template_repo)
+```
+
+The **service** is the correct entry point — not the raw repository.  Services enforce
+business rules (duplicate-ID checks, FQCN validation) that repositories do not.
+
+### Registering, retrieving, and listing entries
+
+- `catalog.create(entry)` — Validates and persists a new entry, returning its ID.
+- `catalog.get(id)` — Returns the entry by exact ID, or `None` if not found.
+- `catalog.list()` — Returns all entries in the catalog.
+
+### TemplateEntry placeholder auto-parsing
+
+`TemplateEntry` has a `placeholders` computed field that uses Python's
+`string.Formatter().parse()` to extract `{placeholder}` names from the template
+string.  The field is read-only and always derived — never stored:
+
+```python
+entry = TemplateEntry(id="research-prompt", template="You are a {role} researching {topic}")
+entry.placeholders  # → ["role", "topic"]
+```
+
+### ToolEntry FQCN class resolution
+
+`ToolEntry` carries a `tool_class` string (a fully qualified class name) and a `tool`
+dict.  A `model_validator(mode="before")` dynamically imports the class at `tool_class`,
+then validates the raw dict against that class's Pydantic schema.  This is exactly how
+YAML deserialization works:
+
+```python
+entry = ToolEntry(
+    id="web-search",
+    tool_class="akgentic.tool.search.search.SearchTool",
+    tool={"name": "Web Search", "description": "...", "web_search": {"max_results": 5}},
+)
+```
+
+After construction, `entry.tool` is a fully validated `SearchTool` instance — not a dict.
+
+### Duplicate-ID error handling
+
+Attempting to `create()` an entry with an ID that already exists in the catalog raises
+`CatalogValidationError`.  The exception carries an `errors` list of human-readable
+message strings:
+
+```python
+try:
+    tool_catalog.create(duplicate_entry)
+except CatalogValidationError as e:
+    for error in e.errors:
+        print(f"  Validation error: {error}")
+```
+
+## Key API Patterns
+
+### TemplateCatalog / ToolCatalog construction
+
+Both catalog services follow the same construction pattern — repository first, then
+service:
+
+```python
+from akgentic.catalog import (
+    TemplateCatalog, ToolCatalog,
+    YamlTemplateCatalogRepository, YamlToolCatalogRepository,
+)
+
+template_catalog = TemplateCatalog(repository=YamlTemplateCatalogRepository(path))
+tool_catalog = ToolCatalog(repository=YamlToolCatalogRepository(path))
+```
+
+### Create / Get / List operations
+
+All catalog services share the same CRUD interface:
+
+| Method | Returns | Raises |
+|---|---|---|
+| `create(entry)` | `str` (entry ID) | `CatalogValidationError` on duplicate ID |
+| `get(id)` | `Entry \| None` | — |
+| `list()` | `list[Entry]` | — |
+
+### CatalogValidationError handling
+
+`CatalogValidationError` is distinct from Pydantic's `ValidationError`.  It represents
+a business-rule violation (duplicate ID, missing reference, etc.) rather than a schema
+validation failure.  Access `e.errors` for a list of error message strings.
+
+## Common Pitfalls
+
+- **FQCN must be fully qualified.** `SearchTool` is not enough — you need
+  `akgentic.tool.search.search.SearchTool` (note the double `search`: module path, then
+  class name).
+
+- **Duplicate IDs are caught at `create()` time, not later.** The service checks for
+  existing entries with the same ID before persisting.  You won't get a silent overwrite.
+
+- **Use the service layer, not raw repositories.** Repositories provide storage only;
+  services provide validation.  Going directly to the repository skips duplicate checks
+  and FQCN resolution validation.
+
+- **`TemplateEntry.placeholders` is read-only.**  You cannot set it — it is always
+  derived from the `template` string.
+
+## Related Examples
+
+- **[Example 02 — Agent Entries & Cross-Validation](02-agent-entries.md):** Introduces
+  `AgentEntry`, which references templates and tools by ID — adding cross-catalog
+  dependency validation.

--- a/examples/01_catalog_entries.py
+++ b/examples/01_catalog_entries.py
@@ -1,0 +1,159 @@
+"""Example 01 — Template & Tool Entry Basics.
+
+Purpose
+-------
+First contact with the catalog API.  Learn the two simplest entity types —
+``TemplateEntry`` and ``ToolEntry`` — before encountering cross-catalog
+dependencies introduced in later examples.
+
+What you'll learn
+-----------------
+* Creating catalogs backed by YAML file repositories
+* Registering, retrieving, and listing catalog entries
+* ``TemplateEntry`` placeholder auto-parsing (``{role}``, ``{topic}``)
+* ``ToolEntry`` FQCN class resolution (``SearchTool``, ``PlanningTool``)
+* Duplicate-ID error handling via ``CatalogValidationError``
+
+Explanation
+-----------
+The service layer (``TemplateCatalog``, ``ToolCatalog``) is the correct entry
+point — **not** the raw repositories.  Services enforce business rules that
+repositories do not: duplicate-ID rejection, FQCN resolution, and (in later
+examples) cross-catalog reference checks.
+
+``TemplateEntry`` exposes a read-only ``placeholders`` computed field that uses
+``string.Formatter().parse()`` to extract ``{placeholder}`` names from the
+template string.
+
+``ToolEntry`` carries a ``tool_class`` FQCN string and a ``tool`` dict.  A
+``model_validator(mode="before")`` dynamically imports the class at
+``tool_class``, then validates the raw dict against that class's Pydantic
+schema — exactly the path taken during YAML deserialization.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from akgentic.catalog import (
+    CatalogValidationError,
+    TemplateCatalog,
+    TemplateEntry,
+    ToolCatalog,
+    ToolEntry,
+    YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+)
+
+
+def main() -> None:
+    """Run example demonstrating TemplateEntry and ToolEntry catalog basics."""
+    with (
+        tempfile.TemporaryDirectory() as template_dir,
+        tempfile.TemporaryDirectory() as tool_dir,
+    ):
+        # --- Create catalogs backed by YAML repositories ---
+        template_repo = YamlTemplateCatalogRepository(Path(template_dir))
+        tool_repo = YamlToolCatalogRepository(Path(tool_dir))
+
+        template_catalog = TemplateCatalog(repository=template_repo)
+        tool_catalog = ToolCatalog(repository=tool_repo)
+
+        print("=== TemplateCatalog & ToolCatalog created ===\n")
+
+        # --- TemplateEntry with auto-parsed placeholders ---
+        research_prompt = TemplateEntry(
+            id="research-prompt",
+            template="You are a {role} researching {topic}",
+        )
+        template_catalog.create(research_prompt)
+
+        print(f"Created TemplateEntry: id={research_prompt.id!r}")
+        print(f"  template : {research_prompt.template!r}")
+        print(f"  placeholders (auto-parsed): {research_prompt.placeholders}")
+        print()
+
+        # --- ToolEntry: SearchTool via FQCN ---
+        web_search_entry = ToolEntry(
+            id="web-search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Web Search",
+                "description": "Search the web for current information",
+                "web_search": {"max_results": 5},
+            },
+        )
+        tool_catalog.create(web_search_entry)
+
+        print(f"Created ToolEntry: id={web_search_entry.id!r}")
+        print(f"  tool_class: {web_search_entry.tool_class!r}")
+        print(f"  tool.name : {web_search_entry.tool.name!r}")
+        print()
+
+        # --- ToolEntry: PlanningTool via FQCN ---
+        planning_entry = ToolEntry(
+            id="planning",
+            tool_class="akgentic.tool.planning.planning.PlanningTool",
+            tool={
+                "name": "Planning",
+                "description": "Planning tool to manage team plans and tasks",
+                "get_planning": True,
+                "get_planning_task": True,
+                "update_planning": True,
+            },
+        )
+        tool_catalog.create(planning_entry)
+
+        print(f"Created ToolEntry: id={planning_entry.id!r}")
+        print(f"  tool_class: {planning_entry.tool_class!r}")
+        print(f"  tool.name : {planning_entry.tool.name!r}")
+        print()
+
+        # --- Get and list operations ---
+        print("=== Get & List Operations ===\n")
+
+        retrieved_template = template_catalog.get("research-prompt")
+        print(f"get('research-prompt'): id={retrieved_template.id!r}")
+
+        retrieved_tool = tool_catalog.get("web-search")
+        print(f"get('web-search')    : id={retrieved_tool.id!r}")
+        print()
+
+        all_templates = template_catalog.list()
+        print(f"template_catalog.list() → {len(all_templates)} entries:")
+        for t in all_templates:
+            print(f"  - {t.id}")
+
+        all_tools = tool_catalog.list()
+        print(f"tool_catalog.list()     → {len(all_tools)} entries:")
+        for t in all_tools:
+            print(f"  - {t.id} ({t.tool_class})")
+        print()
+
+        # --- Duplicate ID error handling ---
+        print("=== Duplicate ID Error Handling ===\n")
+
+        duplicate_entry = ToolEntry(
+            id="web-search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Duplicate Search",
+                "description": "This should fail",
+                "web_search": True,
+            },
+        )
+
+        try:
+            tool_catalog.create(duplicate_entry)
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (as expected):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        print("=== Example 01 complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/01_catalog_entries.py
+++ b/examples/01_catalog_entries.py
@@ -114,21 +114,23 @@ def main() -> None:
         print("=== Get & List Operations ===\n")
 
         retrieved_template = template_catalog.get("research-prompt")
+        assert retrieved_template is not None, "expected 'research-prompt' to exist"
         print(f"get('research-prompt'): id={retrieved_template.id!r}")
 
         retrieved_tool = tool_catalog.get("web-search")
+        assert retrieved_tool is not None, "expected 'web-search' to exist"
         print(f"get('web-search')    : id={retrieved_tool.id!r}")
         print()
 
         all_templates = template_catalog.list()
         print(f"template_catalog.list() → {len(all_templates)} entries:")
-        for t in all_templates:
-            print(f"  - {t.id}")
+        for tmpl in all_templates:
+            print(f"  - {tmpl.id}")
 
         all_tools = tool_catalog.list()
         print(f"tool_catalog.list()     → {len(all_tools)} entries:")
-        for t in all_tools:
-            print(f"  - {t.id} ({t.tool_class})")
+        for tool in all_tools:
+            print(f"  - {tool.id} ({tool.tool_class})")
         print()
 
         # --- Duplicate ID error handling ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,27 +1,34 @@
 # akgentic-catalog Examples
 
-Examples demonstrating the akgentic-catalog module capabilities.
+Progressive examples demonstrating the akgentic-catalog module capabilities.
+Each example is a self-contained script paired with a companion `.md` file
+explaining concepts.
 
 ## Running the Examples
 
 From the **project root**:
 
 ```bash
-uv run python packages/akgentic-catalog/examples/00_example.py
+uv run python packages/akgentic-catalog/examples/01_catalog_entries.py
 ```
 
 From the **akgentic-catalog directory**:
 
 ```bash
 cd packages/akgentic-catalog
-uv run python examples/00_example.py
+uv run python examples/01_catalog_entries.py
 ```
 
 ## Available Examples
 
-### [00_example.py](00_example.py) - Simple catalog Setup ✅
+### [01_catalog_entries.py](01_catalog_entries.py) — Template & Tool Entry Basics
 
-## Planned Examples
+First contact with the catalog API: create, retrieve, and list `TemplateEntry`
+and `ToolEntry` — the two leaf entity types with no cross-catalog dependencies.
+Demonstrates placeholder auto-parsing, FQCN class resolution, and duplicate-ID
+error handling.
+
+Companion docs: [01-catalog-entries.md](01-catalog-entries.md)
 
 ## Prerequisites
 

--- a/src/akgentic/catalog/repositories/yaml/_base.py
+++ b/src/akgentic/catalog/repositories/yaml/_base.py
@@ -154,14 +154,14 @@ class YamlRepositoryBase[T: BaseModel]:
         file_path = self._catalog_dir / f"{entry_id}.yaml"
         self._catalog_dir.mkdir(parents=True, exist_ok=True)
 
-        data: _list[dict[str, object]] = [entry.model_dump()]
+        data: _list[dict[str, object]] = [entry.model_dump(mode="json")]
         if file_path.exists():
             file_data = yaml.safe_load(file_path.read_text(encoding="utf-8"))
             if file_data is None:
                 file_data = []
             if not isinstance(file_data, builtins.list):
                 file_data = [file_data]
-            file_data.append(entry.model_dump())
+            file_data.append(entry.model_dump(mode="json"))
             data = file_data
 
         file_path.write_text(
@@ -191,7 +191,7 @@ class YamlRepositoryBase[T: BaseModel]:
                 raw = [raw]
             for i, item in enumerate(raw):
                 if item.get("id") == id:
-                    raw[i] = entry.model_dump()
+                    raw[i] = entry.model_dump(mode="json")
                     yaml_path.write_text(
                         yaml.dump(
                             raw,


### PR DESCRIPTION
## Summary

- Add `examples/01_catalog_entries.py` — self-contained script demonstrating TemplateEntry and ToolEntry CRUD with placeholder auto-parsing, FQCN resolution (SearchTool, PlanningTool), get/list operations, and duplicate-ID error handling
- Add `examples/01-catalog-entries.md` — companion documentation with concepts covered, key API patterns, common pitfalls, and forward reference to example 02
- Fix pre-existing bug in `repositories/yaml/_base.py`: use `model_dump(mode="json")` in create/update to produce YAML-safe serialization (Channels enums/sets were incompatible with `yaml.safe_load()`)
- Update `examples/README.md` to list example 01

Closes #54