### PR TITLE
Agent entries & cross-validation (Example 02)

### DIFF
--- a/examples/02-agent-entries.md
+++ b/examples/02-agent-entries.md
@@ -1,0 +1,146 @@
+# Example 02 — Agent Entries & Cross-Validation
+
+Learn how `AgentCatalog` validates cross-catalog references at registration
+time, and how `resolve_tools()` / `resolve_template()` bridge catalog-form
+configuration to runtime objects.
+
+## Concepts Covered
+
+### AgentCatalog wiring to ToolCatalog and TemplateCatalog
+
+Unlike leaf catalogs (`TemplateCatalog`, `ToolCatalog`), `AgentCatalog` requires
+upstream catalogs as constructor dependencies.  This *construction-time wiring*
+enables cross-validation on every `create()` call:
+
+```python
+agent_catalog = AgentCatalog(
+    repository=agent_repo,
+    template_catalog=template_catalog,
+    tool_catalog=tool_catalog,
+)
+```
+
+Without this wiring, the catalog cannot verify that an agent's `tool_ids`,
+`@`-template references, or `routes_to` targets actually exist.
+
+### AgentEntry with tool_ids, @-template reference, and routes_to
+
+`AgentEntry` carries three kinds of cross-catalog references:
+
+- **`tool_ids`** — A list of `ToolEntry.id` strings referencing tools in the
+  `ToolCatalog`.  These are catalog IDs, not `ToolCard` instances.
+- **`card.config.prompt.template`** — When prefixed with `@`, this is a catalog
+  reference to a `TemplateEntry.id` in the `TemplateCatalog`.
+- **`card.routes_to`** — A list of agent routing names (`config.name` values)
+  for agents already registered in the `AgentCatalog`.
+
+All three are validated during `create()` — if any reference doesn't resolve,
+`CatalogValidationError` is raised before the entry is persisted.
+
+### agent_class FQCN resolution
+
+The `agent_class` field on `AgentCard` stores the fully qualified Python class
+name as a string.  For the framework's built-in agent:
+
+```python
+agent_class="akgentic.agent.agent.BaseAgent"
+```
+
+This FQCN is validated during entry construction to ensure the class is
+importable.
+
+### Cross-catalog validation errors
+
+`AgentCatalog.create()` checks all cross-references before persisting:
+
+| Reference type | What is checked | Error on failure |
+|---|---|---|
+| `tool_ids` | Each ID exists in `ToolCatalog` | `"Tool 'x' not found in ToolCatalog"` |
+| `@template` | Template ID exists in `TemplateCatalog` | `"Template '@x' not found in TemplateCatalog"` |
+| `routes_to` | Each name matches an agent's `config.name` | `"Route target '@x' not found in AgentCatalog"` |
+
+### resolve_tools() and resolve_template()
+
+These methods on `AgentEntry` bridge catalog-form to runtime-form:
+
+```python
+entry = agent_catalog.get("researcher")
+tools = entry.resolve_tools(tool_catalog)           # -> list[ToolCard]
+prompt = entry.resolve_template(template_catalog)   # -> PromptTemplate | None
+```
+
+- `resolve_tools()` looks up each `tool_ids` entry and returns hydrated
+  `ToolCard` instances.
+- `resolve_template()` resolves `@`-prefixed template references, returning a
+  `PromptTemplate` with the actual template string and the original params.
+
+## Key API Patterns
+
+### AgentCatalog construction with upstream catalogs
+
+```python
+from akgentic.catalog import (
+    AgentCatalog, TemplateCatalog, ToolCatalog,
+    YamlAgentCatalogRepository, YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+)
+
+template_catalog = TemplateCatalog(repository=template_repo)
+tool_catalog = ToolCatalog(repository=tool_repo)
+agent_catalog = AgentCatalog(
+    repository=agent_repo,
+    template_catalog=template_catalog,
+    tool_catalog=tool_catalog,
+)
+```
+
+### Cross-validation on create
+
+When you call `agent_catalog.create(entry)`, the service validates all
+cross-references *before* persisting.  This means prerequisite entries (templates
+and tools) must exist in their respective catalogs first.
+
+### resolve_tools / resolve_template usage
+
+After retrieving an `AgentEntry`, call these methods to get runtime objects:
+
+```python
+entry = agent_catalog.get("researcher")
+
+# Catalog-form: tool_ids=["web-search"] (string IDs)
+# Runtime-form: list[ToolCard] (hydrated Pydantic models)
+tools = entry.resolve_tools(tool_catalog)
+
+# Catalog-form: prompt.template="@research-prompt" (catalog reference)
+# Runtime-form: PromptTemplate with resolved template string
+prompt = entry.resolve_template(template_catalog)
+```
+
+## Common Pitfalls
+
+- **`@`-reference applies only to `prompt.template`, not `config.name`.**
+  `"@Researcher"` in `config.name` is an agent routing name.
+  `"@research-prompt"` in `prompt.template` is a catalog reference to a
+  `TemplateEntry`.  These are two unrelated uses of `@`.
+
+- **`tool_ids` are catalog IDs, not `ToolCard` instances.**  You store string
+  IDs like `["web-search"]` in the entry.  Use `resolve_tools()` to get the
+  actual `ToolCard` objects at runtime.
+
+- **`routes_to` uses agent names, not catalog IDs.**
+  `routes_to=["@Reviewer"]` references `config.name="@Reviewer"`, not
+  `AgentEntry.id="reviewer"`.  The `@` prefix is part of the routing name
+  convention.
+
+- **Import `AgentConfig` from `akgentic.agent.config`, not `akgentic.core`.**
+  The core package has a `AgentConfig` alias that only exposes `name`, `role`,
+  `squad_id`.  The agent package version adds `prompt`, `model_cfg`, and
+  `tools` fields.  Using the wrong import silently drops fields.
+
+## Related Examples
+
+- **[Example 01 — Template & Tool Entry Basics](01-catalog-entries.md):**
+  Covers `TemplateEntry` and `ToolEntry` — the leaf entries that agents
+  reference.
+- **[Example 03 — Team Composition](03-team-composition.md):** Introduces
+  `TeamSpec` and `TeamMemberSpec` — composing agents into teams.

--- a/examples/02-agent-entries.md
+++ b/examples/02-agent-entries.md
@@ -142,5 +142,5 @@ prompt = entry.resolve_template(template_catalog)
 - **[Example 01 — Template & Tool Entry Basics](01-catalog-entries.md):**
   Covers `TemplateEntry` and `ToolEntry` — the leaf entries that agents
   reference.
-- **[Example 03 — Team Composition](03-team-composition.md):** Introduces
+- **Example 03 — Team Composition** *(coming soon):* Introduces
   `TeamSpec` and `TeamMemberSpec` — composing agents into teams.

--- a/examples/02_agent_entries.py
+++ b/examples/02_agent_entries.py
@@ -89,7 +89,7 @@ def main() -> None:
         # --- Prerequisite: TemplateEntry ---
         research_prompt = TemplateEntry(
             id="research-prompt",
-            template=("You are a {role} researching {topic}. {instructions}"),
+            template="You are a {role} researching {topic}. {instructions}",
         )
         template_catalog.create(research_prompt)
 
@@ -186,6 +186,13 @@ def main() -> None:
         print(f"  prompt.params  : {researcher_entry.card.config.prompt.params}")
         print()
 
+        # --- List all registered agents ---
+        all_agents = agent_catalog.list()
+        print(f"agent_catalog.list() → {len(all_agents)} entries:")
+        for agent in all_agents:
+            print(f"  - {agent.id} (config.name={agent.card.config.name!r})")
+        print()
+
         # --- Get and inspect ---
         retrieved = agent_catalog.get("researcher")
         assert retrieved is not None, "expected 'researcher' to exist"
@@ -207,6 +214,8 @@ def main() -> None:
         print()
 
         # --- resolve_template(): @-reference → PromptTemplate ---
+        # Resolves the @-reference to the catalog template string,
+        # combined with the agent's own params → a new PromptTemplate.
         print("=== resolve_template() ===\n")
 
         resolved_prompt = retrieved.resolve_template(template_catalog)
@@ -217,6 +226,7 @@ def main() -> None:
         print()
 
         # --- Error path: missing tool_id ---
+        # Key difference: tool_ids references a tool that doesn't exist in ToolCatalog
         print("=== Error Path: Missing tool_id ===\n")
 
         bad_tool_config = AgentConfig(
@@ -251,6 +261,7 @@ def main() -> None:
         print()
 
         # --- Error path: missing @template ---
+        # Key difference: prompt.template uses @-reference to a nonexistent TemplateEntry
         print("=== Error Path: Missing @template ===\n")
 
         bad_template_config = AgentConfig(
@@ -284,6 +295,7 @@ def main() -> None:
         print()
 
         # --- Error path: invalid routes_to ---
+        # Key difference: routes_to references an agent name not registered in AgentCatalog
         print("=== Error Path: Invalid routes_to ===\n")
 
         bad_route_config = AgentConfig(

--- a/examples/02_agent_entries.py
+++ b/examples/02_agent_entries.py
@@ -1,0 +1,323 @@
+"""Example 02 — Agent Entries & Cross-Validation.
+
+Purpose
+-------
+Demonstrate how the catalog validates agent cross-references at registration
+time.  ``AgentEntry`` is the first entity that depends on *other* catalogs:
+its ``tool_ids`` reference ``ToolCatalog``, its ``@``-prefixed prompt template
+references ``TemplateCatalog``, and its ``routes_to`` list references other
+agents by name.
+
+What you'll learn
+-----------------
+* Wiring ``AgentCatalog`` to ``ToolCatalog`` and ``TemplateCatalog`` at
+  construction time
+* Creating an ``AgentEntry`` with ``tool_ids``, ``@``-template reference,
+  and ``routes_to``
+* ``agent_class`` FQCN resolution (``BaseAgent``)
+* Cross-catalog validation errors (missing tool, missing template, invalid
+  route target)
+* ``resolve_tools()`` and ``resolve_template()`` — bridging catalog-form to
+  runtime objects
+
+Explanation
+-----------
+``AgentCatalog`` requires ``TemplateCatalog`` and ``ToolCatalog`` as
+constructor dependencies.  This *construction-time wiring* enables
+cross-validation on every ``create()`` call: the service verifies that every
+``tool_ids`` entry exists in the tool catalog, every ``@``-prefixed
+``prompt.template`` exists in the template catalog, and every ``routes_to``
+value matches a registered agent's ``config.name``.
+
+The ``@``-reference convention applies **only** to ``prompt.template`` fields.
+Agent names like ``"@Researcher"`` in ``config.name`` and ``routes_to`` are
+*routing names* — a completely separate convention that happens to share the
+``@`` prefix.
+
+After registration, ``AgentEntry.resolve_tools()`` and
+``AgentEntry.resolve_template()`` transform catalog-form IDs into concrete
+runtime objects (``ToolCard`` list and ``PromptTemplate`` respectively),
+bridging the gap between declarative configuration and executable agents.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from akgentic.agent.config import AgentConfig
+from akgentic.core import AgentCard
+from akgentic.llm.config import ModelConfig
+from akgentic.llm.prompts import PromptTemplate
+
+from akgentic.catalog import (
+    AgentCatalog,
+    AgentEntry,
+    CatalogValidationError,
+    TemplateCatalog,
+    TemplateEntry,
+    ToolCatalog,
+    ToolEntry,
+    YamlAgentCatalogRepository,
+    YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+)
+
+
+def main() -> None:
+    """Run example demonstrating AgentEntry cross-catalog validation."""
+    with (
+        tempfile.TemporaryDirectory() as template_dir,
+        tempfile.TemporaryDirectory() as tool_dir,
+        tempfile.TemporaryDirectory() as agent_dir,
+    ):
+        # --- Create catalogs with cross-catalog wiring ---
+        template_repo = YamlTemplateCatalogRepository(Path(template_dir))
+        tool_repo = YamlToolCatalogRepository(Path(tool_dir))
+        agent_repo = YamlAgentCatalogRepository(Path(agent_dir))
+
+        template_catalog = TemplateCatalog(repository=template_repo)
+        tool_catalog = ToolCatalog(repository=tool_repo)
+        agent_catalog = AgentCatalog(
+            repository=agent_repo,
+            template_catalog=template_catalog,
+            tool_catalog=tool_catalog,
+        )
+
+        print("=== AgentCatalog wired to TemplateCatalog & ToolCatalog ===\n")
+
+        # --- Prerequisite: TemplateEntry ---
+        research_prompt = TemplateEntry(
+            id="research-prompt",
+            template=("You are a {role} researching {topic}. {instructions}"),
+        )
+        template_catalog.create(research_prompt)
+
+        print(f"Created prerequisite TemplateEntry: id={research_prompt.id!r}")
+        print(f"  template     : {research_prompt.template!r}")
+        print(f"  placeholders : {research_prompt.placeholders}")
+        print()
+
+        # --- Prerequisite: ToolEntry ---
+        web_search_entry = ToolEntry(
+            id="web-search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Web Search",
+                "description": "Search the web for current information",
+                "web_search": {"max_results": 5},
+            },
+        )
+        tool_catalog.create(web_search_entry)
+
+        print(f"Created prerequisite ToolEntry: id={web_search_entry.id!r}")
+        print(f"  tool_class: {web_search_entry.tool_class!r}")
+        print(f"  tool.name : {web_search_entry.tool.name!r}")
+        print()
+
+        # --- Route target agent (simple, no @-template) ---
+        reviewer_config = AgentConfig(
+            name="@Reviewer",
+            role="Reviewer",
+            prompt=PromptTemplate(
+                template="You review research findings for accuracy.",
+            ),
+            model_cfg=ModelConfig(
+                provider="openai",
+                model="gpt-4.1",
+                temperature=0.2,
+            ),
+        )
+        reviewer_entry = AgentEntry(
+            id="reviewer",
+            card=AgentCard(
+                role="Reviewer",
+                description="Reviews research findings for accuracy",
+                skills=["review", "fact-checking"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=reviewer_config,
+                routes_to=[],
+            ),
+        )
+        agent_catalog.create(reviewer_entry)
+
+        print(f"Created route-target AgentEntry: id={reviewer_entry.id!r}")
+        print(f"  config.name: {reviewer_entry.card.config.name!r}")
+        print()
+
+        # --- Main agent with tool_ids, @-template, and routes_to ---
+        print("=== AgentEntry with Cross-Catalog References ===\n")
+
+        researcher_config = AgentConfig(
+            name="@Researcher",
+            role="Researcher",
+            prompt=PromptTemplate(
+                template="@research-prompt",
+                params={
+                    "role": "Research Specialist",
+                    "topic": "technology trends",
+                    "instructions": "Provide thorough analysis with sources.",
+                },
+            ),
+            model_cfg=ModelConfig(
+                provider="openai",
+                model="gpt-4.1",
+                temperature=0.3,
+            ),
+        )
+        researcher_entry = AgentEntry(
+            id="researcher",
+            tool_ids=["web-search"],
+            card=AgentCard(
+                role="Researcher",
+                description="Performs web research and analysis",
+                skills=["research", "analysis"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=researcher_config,
+                routes_to=["@Reviewer"],
+            ),
+        )
+        agent_catalog.create(researcher_entry)
+
+        print(f"Created AgentEntry: id={researcher_entry.id!r}")
+        print(f"  tool_ids  : {researcher_entry.tool_ids}")
+        print(f"  routes_to : {researcher_entry.card.routes_to}")
+        print(f"  prompt.template: {researcher_entry.card.config.prompt.template!r}")
+        print(f"  prompt.params  : {researcher_entry.card.config.prompt.params}")
+        print()
+
+        # --- Get and inspect ---
+        retrieved = agent_catalog.get("researcher")
+        assert retrieved is not None, "expected 'researcher' to exist"
+        print(f"get('researcher'): id={retrieved.id!r}")
+        print(f"  card.role       : {retrieved.card.role!r}")
+        print(f"  card.agent_class: {retrieved.card.agent_class!r}")
+        print(f"  card.config.name: {retrieved.card.config.name!r}")
+        print()
+
+        # --- resolve_tools(): catalog-form → runtime ToolCards ---
+        print("=== resolve_tools() ===\n")
+
+        tools = retrieved.resolve_tools(tool_catalog)
+        print(f"Resolved {len(tools)} tool(s):")
+        for tool_card in tools:
+            print(f"  - type: {type(tool_card).__name__}")
+            print(f"    name: {tool_card.name!r}")
+            print(f"    description: {tool_card.description!r}")
+        print()
+
+        # --- resolve_template(): @-reference → PromptTemplate ---
+        print("=== resolve_template() ===\n")
+
+        resolved_prompt = retrieved.resolve_template(template_catalog)
+        assert resolved_prompt is not None, "expected resolved prompt"
+        print("Resolved PromptTemplate:")
+        print(f"  template: {resolved_prompt.template!r}")
+        print(f"  params  : {resolved_prompt.params}")
+        print()
+
+        # --- Error path: missing tool_id ---
+        print("=== Error Path: Missing tool_id ===\n")
+
+        bad_tool_config = AgentConfig(
+            name="@BadToolAgent",
+            role="Test",
+            prompt=PromptTemplate(template="Test prompt."),
+            model_cfg=ModelConfig(
+                provider="openai",
+                model="gpt-4.1",
+                temperature=0.5,
+            ),
+        )
+        bad_tool_entry = AgentEntry(
+            id="bad-tool-agent",
+            tool_ids=["nonexistent-tool"],
+            card=AgentCard(
+                role="Test",
+                description="Agent with missing tool reference",
+                skills=["test"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=bad_tool_config,
+                routes_to=[],
+            ),
+        )
+
+        try:
+            agent_catalog.create(bad_tool_entry)
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (missing tool_id):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        # --- Error path: missing @template ---
+        print("=== Error Path: Missing @template ===\n")
+
+        bad_template_config = AgentConfig(
+            name="@BadTemplateAgent",
+            role="Test",
+            prompt=PromptTemplate(template="@nonexistent-template"),
+            model_cfg=ModelConfig(
+                provider="openai",
+                model="gpt-4.1",
+                temperature=0.5,
+            ),
+        )
+        bad_template_entry = AgentEntry(
+            id="bad-template-agent",
+            card=AgentCard(
+                role="Test",
+                description="Agent with missing template reference",
+                skills=["test"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=bad_template_config,
+                routes_to=[],
+            ),
+        )
+
+        try:
+            agent_catalog.create(bad_template_entry)
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (missing @template):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        # --- Error path: invalid routes_to ---
+        print("=== Error Path: Invalid routes_to ===\n")
+
+        bad_route_config = AgentConfig(
+            name="@BadRouteAgent",
+            role="Test",
+            prompt=PromptTemplate(template="Test prompt."),
+            model_cfg=ModelConfig(
+                provider="openai",
+                model="gpt-4.1",
+                temperature=0.5,
+            ),
+        )
+        bad_route_entry = AgentEntry(
+            id="bad-route-agent",
+            card=AgentCard(
+                role="Test",
+                description="Agent with invalid route target",
+                skills=["test"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=bad_route_config,
+                routes_to=["@NonexistentAgent"],
+            ),
+        )
+
+        try:
+            agent_catalog.create(bad_route_entry)
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (invalid routes_to):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        print("=== Example 02 complete ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `examples/02_agent_entries.py` — self-contained example demonstrating `AgentEntry` registration with cross-catalog validation against tools, templates, and route targets
- Add `examples/02-agent-entries.md` — companion documentation covering concepts, API patterns, and common pitfalls
- Code review fixes: added `agent_catalog.list()` demo, clarifying comments on error paths and resolve_template merge, minor style cleanup

Closes #56