### PR TITLE
Team composition, member trees & profiles (example 03)

### DIFF
--- a/examples/02-agent-entries.md
+++ b/examples/02-agent-entries.md
@@ -142,5 +142,6 @@ prompt = entry.resolve_template(template_catalog)
 - **[Example 01 — Template & Tool Entry Basics](01-catalog-entries.md):**
   Covers `TemplateEntry` and `ToolEntry` — the leaf entries that agents
   reference.
-- **Example 03 — Team Composition** *(coming soon):* Introduces
-  `TeamSpec` and `TeamMemberSpec` — composing agents into teams.
+- **[Example 03 — Team Composition, Member Trees & Profiles](03-team-specs.md):**
+  `TeamSpec` with nested `TeamMemberSpec`, entry_point validation, and
+  recursive `TeamQuery` search.

--- a/examples/03-team-specs.md
+++ b/examples/03-team-specs.md
@@ -135,5 +135,5 @@ team_catalog.search(TeamQuery(name="research"))
 
 - [Example 02 — Agent Entries & Cross-Validation](02-agent-entries.md):
   How `AgentEntry` cross-validates tool_ids, templates, and routes_to
-- [Example 04 — YAML Repository Round-Trip](04-yaml-round-trip.md):
+- **Example 04 — YAML Repository Round-Trip** *(coming soon):*
   Persisting and loading catalog entries from YAML files

--- a/examples/03-team-specs.md
+++ b/examples/03-team-specs.md
@@ -1,0 +1,139 @@
+# Example 03 — Team Composition, Member Trees & Profiles
+
+## Concepts Covered
+
+### TeamSpec with Nested TeamMemberSpec
+
+A `TeamSpec` defines a team as a hierarchical tree of `TeamMemberSpec` nodes.
+Each node carries an `agent_id` (referencing an `AgentEntry` in the catalog),
+a `headcount` (defaulting to 1), and optional nested `members`. The tree can
+nest to arbitrary depth, mirroring real delegation chains.
+
+### entry_point Validation
+
+Every team has an `entry_point` — the agent that receives external messages
+(the "front door"). The catalog enforces that this agent_id appears somewhere
+in the `members` tree. An agent that only exists in `profiles` does not
+satisfy this check.
+
+### headcount for Multi-Instance Agents
+
+Setting `headcount=2` on a member tells the orchestrator to create two
+instances of that agent at startup. This is useful for parallel workers
+(e.g. two researchers processing different queries simultaneously).
+
+### members vs profiles
+
+- **members** — agents instantiated at startup as part of the tree; they
+  receive routed messages according to the hierarchy.
+- **profiles** — agent IDs registered with the orchestrator for runtime
+  hiring (like an Expert who joins on demand) but **not** part of the
+  initial tree.
+
+### message_types FQCN Validation
+
+`message_types` stores fully qualified class name strings (e.g.
+`"akgentic.agent.messages.AgentMessage"`). The catalog validates each FQCN
+at `create()` time using `import_class()`, catching typos and missing
+modules before runtime.
+
+### Recursive TeamQuery Search
+
+`TeamQuery(agent_id="researcher")` searches the entire nested member tree
+recursively using `agent_in_members()`. This finds teams containing that
+agent at any depth — not just at the top level.
+`TeamQuery(name="research")` performs a case-insensitive substring match
+on the team name.
+
+## Key API Patterns
+
+### TeamCatalog Construction with Upstream Wiring
+
+```python
+team_catalog = TeamCatalog(
+    repository=team_repo,
+    agent_catalog=agent_catalog,  # Required for member/profile validation
+)
+```
+
+`TeamCatalog` is the fourth catalog in the wiring chain. It requires
+`AgentCatalog` so it can validate that every `agent_id` in the members
+tree and profiles list actually exists.
+
+### TeamSpec Construction
+
+```python
+TeamSpec(
+    id="research-team",
+    name="Research Team",
+    entry_point="manager",
+    message_types=["akgentic.agent.messages.AgentMessage"],
+    members=[
+        TeamMemberSpec(
+            agent_id="manager",
+            members=[
+                TeamMemberSpec(agent_id="researcher", headcount=2,
+                               members=[TeamMemberSpec(agent_id="analyst")]),
+                TeamMemberSpec(agent_id="reviewer"),
+            ],
+        ),
+    ],
+    profiles=["specialist"],
+)
+```
+
+### resolve_entry_point() and resolve_message_types()
+
+These are methods on `TeamSpec` (not on the catalog service):
+
+```python
+team = team_catalog.get("research-team")
+entry_agent = team.resolve_entry_point(agent_catalog)   # → AgentEntry
+msg_types = team.resolve_message_types()                # → list[type]
+```
+
+`resolve_entry_point()` looks up the entry point agent_id in the catalog
+and returns the full `AgentEntry`. `resolve_message_types()` imports each
+FQCN string and returns the actual Python class objects.
+
+### Recursive TeamQuery
+
+```python
+# Finds team because "researcher" is nested inside the members tree
+team_catalog.search(TeamQuery(agent_id="researcher"))
+
+# Case-insensitive substring match on team name
+team_catalog.search(TeamQuery(name="research"))
+```
+
+## Common Pitfalls
+
+- **entry_point must be in the members tree, not just any agent.** An agent
+  that only appears in `profiles` will fail validation. The entry point is
+  the team's front door — it must be part of the startup hierarchy.
+
+- **profiles are not instantiated at startup.** They are available for
+  runtime hiring only. Do not expect a profiles-only agent to receive
+  messages in the initial team setup.
+
+- **message_types uses FQCN strings, not class objects.** Pass
+  `"akgentic.agent.messages.AgentMessage"` (a string), not the imported
+  class. The catalog resolves these strings at registration time.
+
+- **headcount defaults to 1.** You only need to set it explicitly when you
+  want multiple instances of the same agent.
+
+- **agent_id in TeamQuery does a recursive walk.** It searches the entire
+  nested tree, not just top-level members. This is useful for finding which
+  team a deeply nested agent belongs to.
+
+- **Agent creation order matters.** Because `routes_to` validation checks
+  against existing agents' `config.name` values, create leaf agents first,
+  then agents that route to them.
+
+## Related Examples
+
+- [Example 02 — Agent Entries & Cross-Validation](02-agent-entries.md):
+  How `AgentEntry` cross-validates tool_ids, templates, and routes_to
+- [Example 04 — YAML Repository Round-Trip](04-yaml-round-trip.md):
+  Persisting and loading catalog entries from YAML files

--- a/examples/03_team_specs.py
+++ b/examples/03_team_specs.py
@@ -1,0 +1,421 @@
+"""Example 03 — Team Composition, Member Trees & Profiles.
+
+Purpose
+-------
+Demonstrate how ``TeamSpec`` captures hierarchical team structure and how
+the catalog validates it.  This is the first example that exercises all four
+catalog services (Template, Tool, Agent, **Team**) wired together.
+
+What you'll learn
+-----------------
+* ``TeamSpec`` with nested ``TeamMemberSpec`` for multi-level hierarchies
+* ``entry_point`` validation — must reference an agent in the members tree
+* ``headcount`` for multi-instance agents (e.g. two researchers)
+* ``members`` vs ``profiles`` — startup instantiation vs runtime hiring pool
+* ``message_types`` FQCN validation at registration time
+* Recursive ``TeamQuery`` search across nested member trees
+
+Explanation
+-----------
+A ``TeamSpec`` defines how agents are composed into a working team.  The
+``members`` tree mirrors the delegation hierarchy from ``agent_team.py``:
+the manager receives external messages (``entry_point``), delegates to
+researchers and reviewers, and researchers further delegate to analysts.
+
+``profiles`` lists agents that the orchestrator can hire on-demand at
+runtime — like an Expert who joins only when needed — but are **not** part
+of the initial tree.
+
+``message_types`` stores fully qualified class paths (e.g.
+``akgentic.agent.messages.AgentMessage``) so the team knows which message
+types it handles.  The catalog validates each FQCN at ``create()`` time,
+catching typos before runtime.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from akgentic.agent.config import AgentConfig
+from akgentic.core import AgentCard
+from akgentic.llm.config import ModelConfig
+from akgentic.llm.prompts import PromptTemplate
+
+from akgentic.catalog import (
+    AgentCatalog,
+    AgentEntry,
+    CatalogValidationError,
+    TeamCatalog,
+    TeamMemberSpec,
+    TeamQuery,
+    TeamSpec,
+    TemplateCatalog,
+    TemplateEntry,
+    ToolCatalog,
+    ToolEntry,
+    YamlAgentCatalogRepository,
+    YamlTeamCatalogRepository,
+    YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+)
+
+
+def main() -> None:
+    """Run example demonstrating TeamSpec with hierarchical member trees."""
+    with (
+        tempfile.TemporaryDirectory() as template_dir,
+        tempfile.TemporaryDirectory() as tool_dir,
+        tempfile.TemporaryDirectory() as agent_dir,
+        tempfile.TemporaryDirectory() as team_dir,
+    ):
+        # --- Wire all four catalogs ---
+        template_repo = YamlTemplateCatalogRepository(Path(template_dir))
+        tool_repo = YamlToolCatalogRepository(Path(tool_dir))
+        agent_repo = YamlAgentCatalogRepository(Path(agent_dir))
+        team_repo = YamlTeamCatalogRepository(Path(team_dir))
+
+        template_catalog = TemplateCatalog(repository=template_repo)
+        tool_catalog = ToolCatalog(repository=tool_repo)
+        agent_catalog = AgentCatalog(
+            repository=agent_repo,
+            template_catalog=template_catalog,
+            tool_catalog=tool_catalog,
+        )
+        team_catalog = TeamCatalog(
+            repository=team_repo,
+            agent_catalog=agent_catalog,
+        )
+
+        print("=== All four catalogs wired ===\n")
+
+        # --- Prerequisite: TemplateEntry ---
+        team_prompt = TemplateEntry(
+            id="team-prompt",
+            template="You are a {role}. {instructions}",
+        )
+        template_catalog.create(team_prompt)
+        print(f"Created TemplateEntry: id={team_prompt.id!r}")
+
+        # --- Prerequisite: ToolEntry ---
+        web_search_entry = ToolEntry(
+            id="web-search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Web Search",
+                "description": "Search the web for current information",
+                "web_search": {"max_results": 5},
+            },
+        )
+        tool_catalog.create(web_search_entry)
+        print(f"Created ToolEntry: id={web_search_entry.id!r}")
+        print()
+
+        # --- Create 5 agents (leaf-first for routes_to validation) ---
+        print("=== Creating 5 Agents (leaf-first order) ===\n")
+
+        analyst_entry = AgentEntry(
+            id="analyst",
+            tool_ids=["web-search"],
+            card=AgentCard(
+                role="Analyst",
+                description="Analyzes research data and produces insights",
+                skills=["analysis", "data-interpretation"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Analyst",
+                    role="Analyst",
+                    prompt=PromptTemplate(
+                        template="@team-prompt",
+                        params={
+                            "role": "Data Analyst",
+                            "instructions": "Analyze findings thoroughly.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai", model="gpt-4.1", temperature=0.2
+                    ),
+                ),
+                routes_to=[],
+            ),
+        )
+        agent_catalog.create(analyst_entry)
+        print(f"  Created: id={analyst_entry.id!r} (leaf)")
+
+        reviewer_entry = AgentEntry(
+            id="reviewer",
+            card=AgentCard(
+                role="Reviewer",
+                description="Reviews research quality and accuracy",
+                skills=["review", "fact-checking"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Reviewer",
+                    role="Reviewer",
+                    prompt=PromptTemplate(
+                        template="@team-prompt",
+                        params={
+                            "role": "Quality Reviewer",
+                            "instructions": "Check accuracy of findings.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai", model="gpt-4.1", temperature=0.2
+                    ),
+                ),
+                routes_to=[],
+            ),
+        )
+        agent_catalog.create(reviewer_entry)
+        print(f"  Created: id={reviewer_entry.id!r} (leaf)")
+
+        specialist_entry = AgentEntry(
+            id="specialist",
+            tool_ids=["web-search"],
+            card=AgentCard(
+                role="Specialist",
+                description="Domain specialist available for on-demand hiring",
+                skills=["domain-expertise", "deep-research"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Specialist",
+                    role="Specialist",
+                    prompt=PromptTemplate(
+                        template="@team-prompt",
+                        params={
+                            "role": "Domain Specialist",
+                            "instructions": "Provide expert analysis.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai", model="gpt-4.1", temperature=0.3
+                    ),
+                ),
+                routes_to=[],
+            ),
+        )
+        agent_catalog.create(specialist_entry)
+        print(f"  Created: id={specialist_entry.id!r} (profiles pool)")
+
+        researcher_entry = AgentEntry(
+            id="researcher",
+            tool_ids=["web-search"],
+            card=AgentCard(
+                role="Researcher",
+                description="Performs web research and delegates to analyst",
+                skills=["research", "web-search"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Researcher",
+                    role="Researcher",
+                    prompt=PromptTemplate(
+                        template="@team-prompt",
+                        params={
+                            "role": "Research Specialist",
+                            "instructions": "Research topics and delegate analysis.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai", model="gpt-4.1", temperature=0.3
+                    ),
+                ),
+                routes_to=["@Analyst"],
+            ),
+        )
+        agent_catalog.create(researcher_entry)
+        print(f"  Created: id={researcher_entry.id!r} (routes to @Analyst)")
+
+        manager_entry = AgentEntry(
+            id="manager",
+            card=AgentCard(
+                role="Manager",
+                description="Coordinates research team work and delegates tasks",
+                skills=["coordination", "delegation"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Manager",
+                    role="Manager",
+                    prompt=PromptTemplate(
+                        template="@team-prompt",
+                        params={
+                            "role": "Team Manager",
+                            "instructions": "Coordinate the team.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai", model="gpt-4.1", temperature=0.3
+                    ),
+                ),
+                routes_to=["@Researcher", "@Reviewer"],
+            ),
+        )
+        agent_catalog.create(manager_entry)
+        print(f"  Created: id={manager_entry.id!r} (routes to @Researcher, @Reviewer)")
+        print()
+
+        # --- Create TeamSpec with nested member tree ---
+        print("=== TeamSpec with Two-Level Nested Members ===\n")
+
+        research_team = TeamSpec(
+            id="research-team",
+            name="Research Team",
+            description="Multi-level research team with hierarchical delegation",
+            entry_point="manager",
+            message_types=["akgentic.agent.messages.AgentMessage"],
+            members=[
+                TeamMemberSpec(
+                    agent_id="manager",
+                    headcount=1,
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="researcher",
+                            headcount=2,
+                            members=[
+                                TeamMemberSpec(agent_id="analyst"),
+                            ],
+                        ),
+                        TeamMemberSpec(agent_id="reviewer"),
+                    ],
+                ),
+            ],
+            profiles=["specialist"],
+        )
+        team_catalog.create(research_team)
+
+        print(f"Created TeamSpec: id={research_team.id!r}")
+        print(f"  name         : {research_team.name!r}")
+        print(f"  entry_point  : {research_team.entry_point!r}")
+        print(f"  message_types: {research_team.message_types}")
+        print(f"  profiles     : {research_team.profiles}")
+        print("  members tree :")
+        print("    manager (entry_point)")
+        print("      ├── researcher (headcount=2)")
+        print("      │     └── analyst")
+        print("      └── reviewer")
+        print()
+
+        # --- get() and inspect ---
+        print("=== get() and Inspect ===\n")
+
+        retrieved = team_catalog.get("research-team")
+        assert retrieved is not None, "expected 'research-team' to exist"
+        print(f"team_catalog.get('research-team'): id={retrieved.id!r}")
+        print(f"  name         : {retrieved.name!r}")
+        print(f"  entry_point  : {retrieved.entry_point!r}")
+        print(f"  message_types: {retrieved.message_types}")
+        print(f"  profiles     : {retrieved.profiles}")
+        print(f"  members count: {len(retrieved.members)} top-level")
+        print()
+
+        # --- list() ---
+        all_teams = team_catalog.list()
+        print(f"team_catalog.list() → {len(all_teams)} team(s)")
+        for team in all_teams:
+            print(f"  - {team.id} ({team.name!r})")
+        print()
+
+        # --- resolve_entry_point() ---
+        print("=== resolve_entry_point() ===\n")
+
+        entry_agent = retrieved.resolve_entry_point(agent_catalog)
+        print(f"Resolved entry_point '{retrieved.entry_point}':")
+        print(f"  role       : {entry_agent.card.role!r}")
+        print(f"  config.name: {entry_agent.card.config.name!r}")
+        print()
+
+        # --- resolve_message_types() ---
+        print("=== resolve_message_types() ===\n")
+
+        msg_types = retrieved.resolve_message_types()
+        print(f"Resolved {len(msg_types)} message type(s):")
+        for cls in msg_types:
+            print(f"  - {cls.__name__}")
+        print()
+
+        # --- TeamQuery: recursive search by agent_id ---
+        print("=== TeamQuery: Recursive Search (agent_id) ===\n")
+
+        results = team_catalog.search(TeamQuery(agent_id="researcher"))
+        print(f"search(TeamQuery(agent_id='researcher')) → {len(results)} result(s):")
+        for team in results:
+            print(f"  - {team.id} ({team.name!r})")
+        print()
+
+        # --- TeamQuery: substring search by name ---
+        print("=== TeamQuery: Substring Search (name) ===\n")
+
+        results = team_catalog.search(TeamQuery(name="research"))
+        print(f"search(TeamQuery(name='research')) → {len(results)} result(s):")
+        for team in results:
+            print(f"  - {team.id} ({team.name!r})")
+        print()
+
+        # --- Error path: entry_point not in members tree ---
+        print("=== Error Path: entry_point Not in Members Tree ===\n")
+
+        try:
+            team_catalog.create(
+                TeamSpec(
+                    id="bad-entry-point-team",
+                    name="Bad Entry Point Team",
+                    entry_point="specialist",
+                    message_types=["akgentic.agent.messages.AgentMessage"],
+                    members=[
+                        TeamMemberSpec(agent_id="manager"),
+                    ],
+                    profiles=["specialist"],
+                ),
+            )
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (entry_point not in members):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        # --- Error path: member agent_id not in AgentCatalog ---
+        print("=== Error Path: Member agent_id Not in Catalog ===\n")
+
+        try:
+            team_catalog.create(
+                TeamSpec(
+                    id="bad-member-team",
+                    name="Bad Member Team",
+                    entry_point="nonexistent-agent",
+                    message_types=["akgentic.agent.messages.AgentMessage"],
+                    members=[
+                        TeamMemberSpec(agent_id="nonexistent-agent"),
+                    ],
+                ),
+            )
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (member not in catalog):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        # --- Error path: invalid message_type FQCN ---
+        print("=== Error Path: Invalid message_type FQCN ===\n")
+
+        try:
+            team_catalog.create(
+                TeamSpec(
+                    id="bad-msg-team",
+                    name="Bad Message Type Team",
+                    entry_point="manager",
+                    message_types=["nonexistent.module.FakeMessage"],
+                    members=[
+                        TeamMemberSpec(agent_id="manager"),
+                    ],
+                ),
+            )
+        except CatalogValidationError as e:
+            print("Caught CatalogValidationError (invalid message_type):")
+            for error in e.errors:
+                print(f"  Validation error: {error}")
+        print()
+
+        print("=== Example 03 complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,12 +30,30 @@ error handling.
 
 Companion docs: [01-catalog-entries.md](01-catalog-entries.md)
 
+### [02_agent_entries.py](02_agent_entries.py) — Agent Entries & Cross-Validation
+
+How `AgentCatalog` validates cross-catalog references (`tool_ids`,
+`@`-template, `routes_to`) at registration time, and how `resolve_tools()` /
+`resolve_template()` bridge catalog-form to runtime objects.
+
+Companion docs: [02-agent-entries.md](02-agent-entries.md)
+
+### [03_team_specs.py](03_team_specs.py) — Team Composition, Member Trees & Profiles
+
+All four catalogs wired together. `TeamSpec` with nested `TeamMemberSpec`
+hierarchies, `entry_point` validation, `headcount`, members vs profiles,
+`message_types` FQCN validation, and recursive `TeamQuery` search.
+
+Companion docs: [03-team-specs.md](03-team-specs.md)
+
 ## Prerequisites
 
 All examples require:
 
 - Python 3.12+
 - `akgentic` (akgentic-core)
+- `akgentic-agent`
+- `akgentic-llm`
 - `akgentic-tool`
 
 Install with:


### PR DESCRIPTION
## Summary

- Add `examples/03_team_specs.py` — self-contained example demonstrating all four catalogs wired together, TeamSpec with two-level nested member hierarchy, resolve_entry_point/resolve_message_types, recursive and substring TeamQuery search, and three error paths
- Add `examples/03-team-specs.md` — companion markdown with concepts, API patterns, and pitfalls
- Update example 02 forward link to point to example 03 (was "(coming soon)")
- Update `examples/README.md` with examples 02 and 03, and complete prerequisites list

Closes #58