### PR TITLE
Full Catalog Wiring, Delete Protection & Env Vars (Story 9-5)

### DIFF
--- a/examples/04-yaml-persistence.md
+++ b/examples/04-yaml-persistence.md
@@ -117,6 +117,6 @@ repo.list()     # Re-reads from disk, returns updated data
 
 - [Example 03 — Team Composition, Member Trees & Profiles](03-team-specs.md):
   TeamSpec hierarchies, entry_point validation, members vs profiles
-- **Example 05 — Full Catalog Wiring, Delete Protection & Env Vars**
-  *(coming soon):* Service-layer catalogs with cross-validation and
-  environment variable substitution
+- [Example 05 — Full Catalog Wiring, Delete Protection & Env Vars](05-catalog-wiring.md):
+  Service-layer catalogs with bidirectional wiring, delete protection across
+  every boundary, update re-validation, and environment variable substitution

--- a/examples/05-catalog-wiring.md
+++ b/examples/05-catalog-wiring.md
@@ -1,0 +1,138 @@
+# Example 05 — Full Catalog Wiring, Delete Protection & Env Vars
+
+## Concepts Covered
+
+### Bidirectional Catalog Wiring
+
+Catalog services use a two-phase wiring pattern. **Phase 1 (construction-time
+upstream refs)** lets `AgentCatalog` validate that `tool_ids`, `@template`
+references, and `routes_to` targets exist when you call `create()` or
+`update()`. **Phase 2 (post-construction downstream back-refs)** lets
+`TemplateCatalog`, `ToolCatalog`, and `AgentCatalog` check whether any
+downstream consumer still depends on an entry before allowing `delete()`.
+
+Without Phase 2, delete protection is silently disabled — catalogs allow
+deletes without checking downstream dependencies. This is by design for
+simpler use cases (e.g. tests) where full wiring isn't needed.
+
+### Delete Protection Across Every Boundary
+
+Four boundaries are protected:
+
+- **Tool → Agent:** `ToolCatalog.validate_delete()` checks if any agent has
+  the tool in `tool_ids`.
+- **Template → Agent:** `TemplateCatalog.validate_delete()` checks if any
+  agent's `config.prompt.template` is an `@`-reference resolving to this
+  template ID.
+- **Agent → Team (members):** `AgentCatalog.validate_delete()` checks if
+  any team references the agent in its member tree (recursive walk).
+- **Agent → Agent (routes_to):** `AgentCatalog.validate_delete()` checks
+  if any other agent's `routes_to` contains this agent's `config.name`.
+
+Note that `routes_to` uses **agent names** (e.g. `"@Reviewer"`) not catalog
+entry IDs (e.g. `"reviewer"`). The delete check resolves the agent being
+deleted to its `config.name` and searches other agents' `routes_to` lists.
+
+### Correct Deletion Order
+
+Entries must be deleted in **reverse dependency order**: teams first (no
+downstream dependents), then agents, then tools and templates. Attempting
+to delete in the wrong order raises `CatalogValidationError`.
+
+### Update Re-Validation
+
+`agent_catalog.update()` runs the same cross-catalog validation as
+`create()`. If the updated agent references a non-existent tool or template,
+`CatalogValidationError` is raised and the update is rejected.
+
+### Environment Variable Substitution
+
+`resolve_env_vars()` is a standalone utility function that replaces `${VAR}`
+patterns in a string with the corresponding environment variable value. If
+the variable is not set, `OSError` is raised. The catalog stores `"${VAR}"`
+as a literal string — resolution happens at instantiation time (when a tool
+is actually used at runtime), not at YAML load time. This keeps catalog
+entries portable and secret-free.
+
+### CatalogValidationError vs EntryNotFoundError
+
+Two distinct error types serve different failure modes:
+
+- **`CatalogValidationError`** — business rule violations: duplicate IDs,
+  broken cross-references, delete protection violations. Access details via
+  the `.errors` attribute (`list[str]`).
+- **`EntryNotFoundError`** — simple lookup failure: the entry doesn't exist.
+  Raised by `update()` and `delete()` when the target ID is not found.
+
+## Key API Patterns
+
+### Two-Phase Wiring
+
+```python
+# Phase 1 — upstream refs (create/update validation)
+template_catalog = TemplateCatalog(template_repo)
+tool_catalog = ToolCatalog(tool_repo)
+agent_catalog = AgentCatalog(agent_repo, template_catalog, tool_catalog)
+team_catalog = TeamCatalog(team_repo, agent_catalog)
+
+# Phase 2 — downstream back-refs (delete protection)
+template_catalog.agent_catalog = agent_catalog
+tool_catalog.agent_catalog = agent_catalog
+agent_catalog.team_catalog = team_catalog
+```
+
+### Delete Protection Checks
+
+```python
+try:
+    tool_catalog.delete("web-search")  # agent references this tool
+except CatalogValidationError as e:
+    for error in e.errors:
+        print(error)
+```
+
+### resolve_env_vars() Usage
+
+```python
+import os
+from akgentic.catalog import resolve_env_vars
+
+os.environ["API_KEY"] = "sk-secret"
+resolved = resolve_env_vars("Bearer ${API_KEY}")  # → "Bearer sk-secret"
+
+resolve_env_vars("${MISSING}")  # raises OSError
+```
+
+## Common Pitfalls
+
+- **Must wire back-refs after construction for delete protection.** Without
+  setting `template_catalog.agent_catalog = agent_catalog` (and the other
+  two back-ref assignments), delete protection is silently disabled and
+  `delete()` calls succeed even when downstream consumers depend on the
+  entry.
+
+- **Deletion order matters — reverse dependency graph.** Delete teams before
+  agents, agents before tools and templates. Attempting to delete a tool
+  while an agent still references it raises `CatalogValidationError`.
+
+- **`${VAR}` stays as a literal in YAML until `resolve_env_vars()` is
+  called.** The catalog intentionally stores environment variable references
+  as plain strings. Resolution is a separate, explicit step — typically
+  done at runtime when instantiating a tool, not when loading from the
+  catalog.
+
+- **`CatalogValidationError` vs `EntryNotFoundError` — different exception
+  types.** Don't catch a generic `Exception`. Use `CatalogValidationError`
+  for business rule violations (broken references, delete protection) and
+  `EntryNotFoundError` for missing entries.
+
+- **`routes_to` uses agent names, not catalog IDs.** Agent names follow the
+  `"@Name"` convention (from `config.name`). If you check `routes_to` for
+  an ID like `"reviewer"` you'll miss the match — it contains `"@Reviewer"`.
+
+## Related Examples
+
+- [Example 04 — YAML Repository Round-Trip](04-yaml-persistence.md):
+  Repository-level persistence mechanics, file layout, caching, and reload
+- **Example 06 — Compound Queries & Cross-Catalog Search** *(coming soon):*
+  Query composition, match semantics, and cross-catalog search chaining

--- a/examples/05_catalog_wiring.py
+++ b/examples/05_catalog_wiring.py
@@ -1,0 +1,388 @@
+"""Example 05 — Full Catalog Wiring, Delete Protection & Env Vars.
+
+Purpose
+-------
+Demonstrate the catalog's referential integrity mechanisms and runtime secret
+handling.  This example operates at the **service layer** (not the repository
+layer used in example 04), showing the production entry point for creating,
+validating, updating, and deleting catalog entries with full cross-catalog
+protection.
+
+What you'll learn
+-----------------
+* **Bidirectional catalog wiring** — construction-time upstream refs for
+  create/update validation, post-construction downstream back-refs for delete
+  protection.
+* **Delete protection across every boundary** — tool → agent, template → agent,
+  agent → team (members), agent → agent (routes_to).
+* **Correct deletion order** — reverse dependency graph: teams first, then
+  agents, then tools and templates.
+* **Update re-validation** — ``agent_catalog.update()`` re-runs full
+  cross-catalog validation.
+* **``resolve_env_vars()``** — replaces ``${VAR}`` patterns with environment
+  variable values at runtime, not at load time.
+* **``CatalogValidationError`` vs ``EntryNotFoundError``** — two distinct error
+  types for business-rule violations vs simple lookup failures.
+
+Explanation
+-----------
+**Forward references** (upstream wiring) enable create-time validation:
+``AgentCatalog`` receives ``TemplateCatalog`` and ``ToolCatalog`` at
+construction so it can verify that ``tool_ids`` and ``@template`` refs point
+to existing entries.  ``TeamCatalog`` receives ``AgentCatalog`` for member
+validation.
+
+**Back-references** (downstream wiring) enable delete-time protection:
+``template_catalog.agent_catalog = agent_catalog`` lets the template catalog
+check whether any agent still uses a template before allowing deletion.
+Without these back-refs, deletes proceed unchecked — by design for simpler
+use cases like tests.
+
+**Environment variables** are stored as ``${VAR}`` literals in YAML.
+``resolve_env_vars()`` resolves them at instantiation time (when a tool is
+actually used at runtime), keeping catalog entries portable and secret-free.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import tempfile
+from pathlib import Path
+
+from akgentic.agent.config import AgentConfig
+from akgentic.core import AgentCard
+from akgentic.llm.config import ModelConfig
+from akgentic.llm.prompts import PromptTemplate
+
+from akgentic.catalog import (
+    AgentCatalog,
+    AgentEntry,
+    CatalogValidationError,
+    EntryNotFoundError,
+    TeamCatalog,
+    TeamMemberSpec,
+    TeamSpec,
+    TemplateCatalog,
+    TemplateEntry,
+    ToolCatalog,
+    ToolEntry,
+    YamlAgentCatalogRepository,
+    YamlTeamCatalogRepository,
+    YamlTemplateCatalogRepository,
+    YamlToolCatalogRepository,
+    resolve_env_vars,
+)
+
+
+def main() -> None:
+    """Run example demonstrating full catalog wiring and delete protection."""
+    with (
+        tempfile.TemporaryDirectory() as template_dir,
+        tempfile.TemporaryDirectory() as tool_dir,
+        tempfile.TemporaryDirectory() as agent_dir,
+        tempfile.TemporaryDirectory() as team_dir,
+    ):
+        # =============================================================
+        # Section 1: Two-phase bidirectional catalog wiring
+        # =============================================================
+        print("=== Two-Phase Bidirectional Catalog Wiring ===\n")
+
+        # Phase 1 — construction-time upstream refs (for create/update validation)
+        template_repo = YamlTemplateCatalogRepository(Path(template_dir))
+        tool_repo = YamlToolCatalogRepository(Path(tool_dir))
+        agent_repo = YamlAgentCatalogRepository(Path(agent_dir))
+        team_repo = YamlTeamCatalogRepository(Path(team_dir))
+
+        template_catalog = TemplateCatalog(template_repo)
+        tool_catalog = ToolCatalog(tool_repo)
+        agent_catalog = AgentCatalog(agent_repo, template_catalog, tool_catalog)
+        team_catalog = TeamCatalog(team_repo, agent_catalog)
+
+        print("  Phase 1 (upstream): AgentCatalog ← TemplateCatalog, ToolCatalog")
+        print("  Phase 1 (upstream): TeamCatalog ← AgentCatalog")
+
+        # Phase 2 — post-construction downstream back-refs (for delete protection)
+        template_catalog.agent_catalog = agent_catalog
+        tool_catalog.agent_catalog = agent_catalog
+        agent_catalog.team_catalog = team_catalog
+
+        print("  Phase 2 (downstream): TemplateCatalog → AgentCatalog")
+        print("  Phase 2 (downstream): ToolCatalog → AgentCatalog")
+        print("  Phase 2 (downstream): AgentCatalog → TeamCatalog")
+        print()
+
+        # =============================================================
+        # Section 2: Populate catalogs bottom-up
+        # =============================================================
+        print("=== Populating Catalogs Bottom-Up ===\n")
+
+        # Templates
+        research_prompt = TemplateEntry(
+            id="research-prompt",
+            template="You are a {role}. {instructions}",
+        )
+        template_catalog.create(research_prompt)
+        print(f"  Created template: {research_prompt.id!r}")
+
+        # Tools
+        web_search_tool = ToolEntry(
+            id="web-search",
+            tool_class="akgentic.tool.search.search.SearchTool",
+            tool={
+                "name": "Web Search",
+                "description": "Search the web for current information",
+                "web_search": {"max_results": 5},
+                "web_crawl": True,
+                "web_fetch": True,
+            },
+        )
+        tool_catalog.create(web_search_tool)
+        print(f"  Created tool: {web_search_tool.id!r}")
+
+        # Agents — create reviewer first (researcher routes_to reviewer)
+        reviewer_entry = AgentEntry(
+            id="reviewer",
+            card=AgentCard(
+                role="Reviewer",
+                description="Reviews research findings",
+                skills=["review", "editing"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Reviewer",
+                    role="Reviewer",
+                    prompt=PromptTemplate(
+                        template="You are a {role}. {instructions}",
+                        params={
+                            "role": "Reviewer",
+                            "instructions": "Review findings.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai",
+                        model="gpt-4.1",
+                        temperature=0.3,
+                    ),
+                ),
+            ),
+        )
+        agent_catalog.create(reviewer_entry)
+        print(f"  Created agent: {reviewer_entry.id!r} (name={reviewer_entry.card.config.name!r})")
+
+        researcher_entry = AgentEntry(
+            id="researcher",
+            tool_ids=["web-search"],
+            card=AgentCard(
+                role="Researcher",
+                description="Researches topics using web search",
+                skills=["research", "analysis"],
+                agent_class="akgentic.agent.agent.BaseAgent",
+                config=AgentConfig(
+                    name="@Researcher",
+                    role="Researcher",
+                    prompt=PromptTemplate(
+                        template="@research-prompt",
+                        params={
+                            "role": "Researcher",
+                            "instructions": "Research topics.",
+                        },
+                    ),
+                    model_cfg=ModelConfig(
+                        provider="openai",
+                        model="gpt-4.1",
+                        temperature=0.3,
+                    ),
+                ),
+                routes_to=["@Reviewer"],
+            ),
+        )
+        agent_catalog.create(researcher_entry)
+        print(
+            f"  Created agent: {researcher_entry.id!r} "
+            f"(name={researcher_entry.card.config.name!r}, "
+            f"routes_to={researcher_entry.card.routes_to})"
+        )
+
+        # Team with nested member tree
+        research_team = TeamSpec(
+            id="research-team",
+            name="Research Team",
+            description="A team for research tasks",
+            entry_point="researcher",
+            message_types=["akgentic.agent.messages.AgentMessage"],
+            members=[
+                TeamMemberSpec(
+                    agent_id="researcher",
+                    headcount=1,
+                    members=[TeamMemberSpec(agent_id="reviewer", headcount=1)],
+                ),
+            ],
+        )
+        team_catalog.create(research_team)
+        print(f"  Created team: {research_team.id!r} (entry_point={research_team.entry_point!r})")
+        print()
+
+        # =============================================================
+        # Section 3: Delete protection — tool referenced by agent
+        # =============================================================
+        print("=== Delete Protection: Tool Referenced by Agent ===\n")
+
+        try:
+            tool_catalog.delete("web-search")
+            raise AssertionError("Expected CatalogValidationError")
+        except CatalogValidationError as e:
+            print("  Blocked! Cannot delete tool 'web-search':")
+            for error in e.errors:
+                print(f"    {error}")
+        print()
+
+        # =============================================================
+        # Section 4: Delete protection — template referenced by agent
+        # =============================================================
+        print("=== Delete Protection: Template Referenced by Agent ===\n")
+
+        try:
+            template_catalog.delete("research-prompt")
+            raise AssertionError("Expected CatalogValidationError")
+        except CatalogValidationError as e:
+            print("  Blocked! Cannot delete template 'research-prompt':")
+            for error in e.errors:
+                print(f"    {error}")
+        print()
+
+        # =============================================================
+        # Section 5: Delete protection — agent referenced by team
+        # =============================================================
+        print("=== Delete Protection: Agent Referenced by Team (Members) ===\n")
+
+        try:
+            agent_catalog.delete("researcher")
+            raise AssertionError("Expected CatalogValidationError")
+        except CatalogValidationError as e:
+            print("  Blocked! Cannot delete agent 'researcher':")
+            for error in e.errors:
+                print(f"    {error}")
+        print()
+
+        # =============================================================
+        # Section 6: Delete protection — agent referenced by routes_to
+        # =============================================================
+        print("=== Delete Protection: Agent Referenced by routes_to ===\n")
+
+        try:
+            agent_catalog.delete("reviewer")
+            raise AssertionError("Expected CatalogValidationError")
+        except CatalogValidationError as e:
+            print("  Blocked! Cannot delete agent 'reviewer':")
+            for error in e.errors:
+                print(f"    {error}")
+        print()
+
+        # =============================================================
+        # Section 7: Clean deletion in reverse dependency order
+        # =============================================================
+        print("=== Clean Deletion in Reverse Order ===\n")
+
+        # Teams first
+        team_catalog.delete("research-team")
+        assert team_catalog.list() == []
+        print("  Deleted team 'research-team' — team list is now empty")
+
+        # Agents next
+        agent_catalog.delete("researcher")
+        agent_catalog.delete("reviewer")
+        assert agent_catalog.list() == []
+        print("  Deleted agents 'researcher', 'reviewer' — agent list is now empty")
+
+        # Tools and templates last
+        tool_catalog.delete("web-search")
+        assert tool_catalog.list() == []
+        print("  Deleted tool 'web-search' — tool list is now empty")
+
+        template_catalog.delete("research-prompt")
+        assert template_catalog.list() == []
+        print("  Deleted template 'research-prompt' — template list is now empty")
+        print()
+
+        # =============================================================
+        # Section 8: Update re-validation
+        # =============================================================
+        print("=== Update Re-Validation ===\n")
+
+        # Re-create entries for update demo
+        template_catalog.create(research_prompt)
+        tool_catalog.create(web_search_tool)
+        agent_catalog.create(reviewer_entry)
+        agent_catalog.create(researcher_entry)
+
+        # Failed update: invalid tool reference
+        bad_update = copy.deepcopy(researcher_entry)
+        bad_update.tool_ids = ["nonexistent-tool"]
+        try:
+            agent_catalog.update("researcher", bad_update)
+            raise AssertionError("Expected CatalogValidationError")
+        except CatalogValidationError as e:
+            print("  Update blocked (invalid tool ref):")
+            for error in e.errors:
+                print(f"    {error}")
+
+        # Successful update: valid changes
+        good_update = copy.deepcopy(researcher_entry)
+        good_update.card = AgentCard(
+            role="Senior Researcher",
+            description="Senior researcher with web search",
+            skills=["research", "analysis"],
+            agent_class="akgentic.agent.agent.BaseAgent",
+            config=researcher_entry.card.config,
+            routes_to=["@Reviewer"],
+        )
+        agent_catalog.update("researcher", good_update)
+        updated = agent_catalog.get("researcher")
+        assert updated.card.role == "Senior Researcher"
+        print(f"  Update succeeded: role changed to {updated.card.role!r}")
+        print()
+
+        # =============================================================
+        # Section 9: EntryNotFoundError
+        # =============================================================
+        print("=== EntryNotFoundError ===\n")
+
+        try:
+            agent_catalog.delete("nonexistent-agent")
+            raise AssertionError("Expected EntryNotFoundError")
+        except EntryNotFoundError as e:
+            print(f"  Delete non-existent: {e}")
+
+        try:
+            agent_catalog.update("nonexistent-agent", researcher_entry)
+            raise AssertionError("Expected EntryNotFoundError")
+        except EntryNotFoundError as e:
+            print(f"  Update non-existent: {e}")
+        print()
+
+        # =============================================================
+        # Section 10: Environment variable substitution
+        # =============================================================
+        print("=== Environment Variable Substitution ===\n")
+
+        os.environ["SEARCH_API_KEY"] = "sk-test-secret-key"
+
+        resolved = resolve_env_vars("Bearer ${SEARCH_API_KEY}")
+        assert resolved == "Bearer sk-test-secret-key"
+        print(f"  resolve_env_vars('Bearer ${{SEARCH_API_KEY}}') → {resolved!r}")
+
+        try:
+            resolve_env_vars("${MISSING_VAR}")
+            raise AssertionError("Expected OSError")
+        except OSError as e:
+            print(f"  resolve_env_vars('${{MISSING_VAR}}') → Error: {e}")
+
+        del os.environ["SEARCH_API_KEY"]
+        print("  Cleaned up SEARCH_API_KEY env var")
+        print()
+
+        print("=== Example 05 complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_catalog_wiring.py
+++ b/examples/05_catalog_wiring.py
@@ -266,6 +266,8 @@ def main() -> None:
 
         # =============================================================
         # Section 6: Delete protection — agent referenced by routes_to
+        # (also triggers team-member protection since reviewer is in
+        #  the team's member tree — multiple boundaries fire at once)
         # =============================================================
         print("=== Delete Protection: Agent Referenced by routes_to ===\n")
 
@@ -274,6 +276,7 @@ def main() -> None:
             raise AssertionError("Expected CatalogValidationError")
         except CatalogValidationError as e:
             print("  Blocked! Cannot delete agent 'reviewer':")
+            print("  (Both routing AND team-member protection fire simultaneously)")
             for error in e.errors:
                 print(f"    {error}")
         print()
@@ -338,6 +341,7 @@ def main() -> None:
         )
         agent_catalog.update("researcher", good_update)
         updated = agent_catalog.get("researcher")
+        assert updated is not None, "expected 'researcher' to exist after update"
         assert updated.card.role == "Senior Researcher"
         print(f"  Update succeeded: role changed to {updated.card.role!r}")
         print()

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,6 +55,17 @@ across files. Uses repositories directly (not service-layer catalogs).
 
 Companion docs: [04-yaml-persistence.md](04-yaml-persistence.md)
 
+### [05_catalog_wiring.py](05_catalog_wiring.py) — Full Catalog Wiring, Delete Protection & Env Vars
+
+Service-layer catalogs with bidirectional wiring: construction-time upstream
+refs for create/update validation, post-construction downstream back-refs for
+delete protection across every boundary (tool→agent, template→agent,
+agent→team, agent→agent routes_to). Also covers correct deletion order,
+update re-validation, `EntryNotFoundError`, and `resolve_env_vars()` for
+`${VAR}` substitution.
+
+Companion docs: [05-catalog-wiring.md](05-catalog-wiring.md)
+
 ## Prerequisites
 
 All examples require:


### PR DESCRIPTION
## Summary

- Two-phase bidirectional catalog wiring (upstream for create/update validation, downstream back-refs for delete protection)
- Delete protection across all four boundaries: tool→agent, template→agent, agent→team (members), agent→agent (routes_to)
- Clean deletion in reverse dependency order with assertions
- Update re-validation and EntryNotFoundError handling
- `resolve_env_vars()` demonstration for `${VAR}` substitution
- Companion markdown documentation with concepts, patterns, and pitfalls
- Updated README.md and example 04 forward link

### Code review fixes
- Added None guard after `agent_catalog.get()` (mypy `union-attr` fix, pattern alignment with examples 01-03)
- Clarified Section 6 output that both routing and team-member protection fire simultaneously

Closes #62