### PR TITLE
ci: add GitHub Actions workflow for tests and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workspace
+        uses: actions/checkout@v4
+        with:
+          repository: b12consulting/akgentic-quick-start
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Override catalog submodule with PR branch
+        if: github.event_name == 'pull_request'
+        working-directory: packages/akgentic-catalog
+        run: |
+          git fetch origin ${{ github.head_ref }}
+          git checkout FETCH_HEAD
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-packages --all-extras
+
+      - name: Type checking
+        run: uv run mypy packages/akgentic-catalog/src/
+
+      - name: Linting
+        run: uv run ruff check packages/akgentic-catalog/src/
+
+      - name: Run tests with coverage
+        run: >
+          uv run pytest packages/akgentic-catalog/tests/
+          --cov=akgentic.catalog
+          --cov-report=term-missing
+          --cov-fail-under=80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,18 @@ jobs:
           uv run pytest packages/akgentic-catalog/tests/
           --cov=akgentic.catalog
           --cov-report=term-missing
+          --cov-report=json:coverage.json
           --cov-fail-under=80
+
+      - name: Update coverage badge
+        if: github.ref_name == 'master' && github.event_name == 'push'
+        run: |
+          COVERAGE=$(python -c "import json; print(int(json.load(open('coverage.json'))['totals']['percent_covered_display']))")
+          if [ "$COVERAGE" -ge 90 ]; then COLOR="brightgreen"
+          elif [ "$COVERAGE" -ge 80 ]; then COLOR="green"
+          elif [ "$COVERAGE" -ge 70 ]; then COLOR="yellow"
+          else COLOR="red"; fi
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > badge.json
+          gh gist edit 2e867a62d5ce56bff5e5d468e288a08b -f coverage.json badge.json
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,10 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
 
-      - name: Override catalog submodule with PR branch
-        if: github.event_name == 'pull_request'
+      - name: Override catalog submodule with current branch
         working-directory: packages/akgentic-catalog
         run: |
-          git fetch origin ${{ github.head_ref }}
+          git fetch origin ${{ github.head_ref || github.ref_name }}
           git checkout FETCH_HEAD
 
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+env:
+  NO_COLOR: "1"
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # akgentic-catalog
 
+[![CI](https://github.com/b12consulting/akgentic-catalog/actions/workflows/ci.yml/badge.svg)](https://github.com/b12consulting/akgentic-catalog/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/jltournay/2e867a62d5ce56bff5e5d468e288a08b/raw/coverage.json)](https://github.com/b12consulting/akgentic-catalog/actions/workflows/ci.yml)
+
 Configuration management for the [Akgentic](https://github.com/b12consulting/akgentic-quick-start)
 multi-agent framework. Register, validate, query, and persist **templates**,
 **tools**, **agents**, and **teams** through a unified catalog layer with

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
+
+
+@pytest.fixture(autouse=True)
+def _disable_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable Rich/Typer ANSI color output so assertions match on CI."""
+    monkeypatch.setenv("NO_COLOR", "1")
 
 AGENT_CLASS = "akgentic.agent.BaseAgent"
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import pytest
+import re
+
 import yaml
 
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
-@pytest.fixture(autouse=True)
-def _disable_color(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Disable Rich/Typer ANSI color output so assertions match on CI."""
-    monkeypatch.setenv("NO_COLOR", "1")
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text for CI-safe assertions."""
+    return ANSI_RE.sub("", text)
+
 
 AGENT_CLASS = "akgentic.agent.BaseAgent"
 

--- a/tests/cli/test_backend_selection.py
+++ b/tests/cli/test_backend_selection.py
@@ -13,6 +13,8 @@ from akgentic.catalog.cli.main import GlobalState, app
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.mongo._helpers import to_document
 
+from .conftest import strip_ansi
+
 if TYPE_CHECKING:
     import pymongo.collection
 
@@ -141,17 +143,17 @@ class TestBackendHelpOutput:
     def test_help_lists_backend_option(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "--backend" in result.output
+        assert "--backend" in strip_ansi(result.output)
 
     def test_help_lists_mongo_uri_option(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "--mongo-uri" in result.output
+        assert "--mongo-uri" in strip_ansi(result.output)
 
     def test_help_lists_mongo_db_option(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "--mongo-db" in result.output
+        assert "--mongo-db" in strip_ansi(result.output)
 
 
 # --- AC-2: Missing MongoDB options error ---

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -6,6 +6,8 @@ from typer.testing import CliRunner
 
 from akgentic.catalog.cli.main import app
 
+from .conftest import strip_ansi
+
 runner = CliRunner()
 
 
@@ -15,14 +17,16 @@ class TestCliHelp:
     def test_help_lists_subcommands(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
+        output = strip_ansi(result.output)
         for cmd in ("template", "tool", "agent", "team", "import", "validate"):
-            assert cmd in result.output, f"Expected subcommand '{cmd}' in help output"
+            assert cmd in output, f"Expected subcommand '{cmd}' in help output"
 
     def test_help_lists_global_options(self) -> None:
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "--catalog-dir" in result.output
-        assert "--format" in result.output
+        output = strip_ansi(result.output)
+        assert "--catalog-dir" in output
+        assert "--format" in output
 
 
 class TestImportValidateHelp:
@@ -31,10 +35,12 @@ class TestImportValidateHelp:
     def test_import_help(self) -> None:
         result = runner.invoke(app, ["import", "--help"])
         assert result.exit_code == 0
-        assert "PYTHON_FILE" in result.output
-        assert "--dry-run" in result.output
+        output = strip_ansi(result.output)
+        assert "PYTHON_FILE" in output
+        assert "--dry-run" in output
 
     def test_validate_help(self) -> None:
         result = runner.invoke(app, ["validate", "--help"])
         assert result.exit_code == 0
-        assert "--catalog" in result.output
+        output = strip_ansi(result.output)
+        assert "--catalog" in output


### PR DESCRIPTION
## Summary
- Add CI workflow that runs mypy, ruff, and pytest with 80% coverage threshold
- Checks out parent workspace with recursive submodules for cross-package dependencies
- Overrides catalog submodule with PR branch on pull requests