### PR TITLE
refactor: rename TeamSpec to TeamEntry for naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ from akgentic.catalog import (
     AgentEntry,
     TeamCatalog,
     TeamMemberSpec,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     TemplateEntry,
     ToolCatalog,
@@ -181,7 +181,7 @@ with tempfile.TemporaryDirectory() as tmp:
     ))
 
     # Register a team
-    team_catalog.create(TeamSpec(
+    team_catalog.create(TeamEntry(
         id="research-team",
         name="Research Team",
         entry_point="researcher",
@@ -204,7 +204,7 @@ flowchart TD
         TE[TemplateEntry]
         OE[ToolEntry]
         AE[AgentEntry]
-        TS[TeamSpec]
+        TS[TeamEntry]
     end
     subgraph "Repositories"
         YR[YAML Repos]
@@ -309,12 +309,12 @@ Cross-validation at `create()`/`update()` time ensures:
 - `@template-id` references resolve and placeholders match config params
 - `routes_to` agent names exist in AgentCatalog
 
-### TeamSpec
+### TeamEntry
 
 Team composition with hierarchical member trees and runtime profiles.
 
 ```python
-team = TeamSpec(
+team = TeamEntry(
     id="dev-team",
     name="Development Team",
     entry_point="lead",
@@ -523,7 +523,7 @@ uv run python examples/01_catalog_entries.py
 |---|---|---|
 | 01 | `01_catalog_entries.py` | Template & Tool Entry Basics |
 | 02 | `02_agent_entries.py` | Agent Entries & Cross-Validation |
-| 03 | `03_team_specs.py` | Team Composition, Member Trees & Profiles |
+| 03 | `03_team_entrys.py` | Team Composition, Member Trees & Profiles |
 | 04 | `04_yaml_persistence.py` | YAML Repository Round-Trip |
 | 05 | `05_catalog_wiring.py` | Full Catalog Wiring, Delete Protection & Env Vars |
 | 06 | `06_search_and_query.py` | Compound Queries & Cross-Catalog Search |

--- a/docs/cli-usage-guide.md
+++ b/docs/cli-usage-guide.md
@@ -73,7 +73,7 @@ my-catalog/
   templates/     # TemplateEntry YAML files
   tools/         # ToolEntry YAML files
   agents/        # AgentEntry YAML files
-  teams/         # TeamSpec YAML files
+  teams/         # TeamEntry YAML files
 ```
 
 ### MongoDB Backend
@@ -95,7 +95,7 @@ ak-catalog --backend mongodb agent list
 ```
 
 MongoDB uses four collections: `template_entries`, `tool_entries`,
-`agent_entries`, and `team_specs`.
+`agent_entries`, and `team_entries`.
 
 **Validation rules:**
 
@@ -411,13 +411,13 @@ ak-catalog import entries.py
 ### Python Entry File Format
 
 ```python
-from akgentic.catalog import TemplateEntry, ToolEntry, AgentEntry, TeamSpec
+from akgentic.catalog import TemplateEntry, ToolEntry, AgentEntry, TeamEntry
 
 entries = [
     TemplateEntry(id="greeting", template="Hello {name}!"),
     ToolEntry(id="search", tool_class="akgentic.tool.search.search.SearchTool"),
     AgentEntry(id="researcher", tool_ids=["search"], card=...),
-    TeamSpec(id="team", name="My Team", entry_point="researcher", members=[...]),
+    TeamEntry(id="team", name="My Team", entry_point="researcher", members=[...]),
 ]
 ```
 
@@ -555,7 +555,7 @@ card:
     - "@Reviewer"
 ```
 
-### TeamSpec
+### TeamEntry
 
 ```yaml
 id: research-team

--- a/examples/02-agent-entries.md
+++ b/examples/02-agent-entries.md
@@ -142,6 +142,6 @@ prompt = entry.resolve_template(template_catalog)
 - **[Example 01 — Template & Tool Entry Basics](01-catalog-entries.md):**
   Covers `TemplateEntry` and `ToolEntry` — the leaf entries that agents
   reference.
-- **[Example 03 — Team Composition, Member Trees & Profiles](03-team-specs.md):**
-  `TeamSpec` with nested `TeamMemberSpec`, entry_point validation, and
+- **[Example 03 — Team Composition, Member Trees & Profiles](03-team-entries.md):**
+  `TeamEntry` with nested `TeamMemberSpec`, entry_point validation, and
   recursive `TeamQuery` search.

--- a/examples/03-team-entries.md
+++ b/examples/03-team-entries.md
@@ -2,9 +2,9 @@
 
 ## Concepts Covered
 
-### TeamSpec with Nested TeamMemberSpec
+### TeamEntry with Nested TeamMemberSpec
 
-A `TeamSpec` defines a team as a hierarchical tree of `TeamMemberSpec` nodes.
+A `TeamEntry` defines a team as a hierarchical tree of `TeamMemberSpec` nodes.
 Each node carries an `agent_id` (referencing an `AgentEntry` in the catalog),
 a `headcount` (defaulting to 1), and optional nested `members`. The tree can
 nest to arbitrary depth, mirroring real delegation chains.
@@ -60,10 +60,10 @@ team_catalog = TeamCatalog(
 `AgentCatalog` so it can validate that every `agent_id` in the members
 tree and profiles list actually exists.
 
-### TeamSpec Construction
+### TeamEntry Construction
 
 ```python
-TeamSpec(
+TeamEntry(
     id="research-team",
     name="Research Team",
     entry_point="manager",
@@ -84,7 +84,7 @@ TeamSpec(
 
 ### resolve_entry_point() and resolve_message_types()
 
-These are methods on `TeamSpec` (not on the catalog service):
+These are methods on `TeamEntry` (not on the catalog service):
 
 ```python
 team = team_catalog.get("research-team")

--- a/examples/03_team_entries.py
+++ b/examples/03_team_entries.py
@@ -2,13 +2,13 @@
 
 Purpose
 -------
-Demonstrate how ``TeamSpec`` captures hierarchical team structure and how
+Demonstrate how ``TeamEntry`` captures hierarchical team structure and how
 the catalog validates it.  This is the first example that exercises all four
 catalog services (Template, Tool, Agent, **Team**) wired together.
 
 What you'll learn
 -----------------
-* ``TeamSpec`` with nested ``TeamMemberSpec`` for multi-level hierarchies
+* ``TeamEntry`` with nested ``TeamMemberSpec`` for multi-level hierarchies
 * ``entry_point`` validation — must reference an agent in the members tree
 * ``headcount`` for multi-instance agents (e.g. two researchers)
 * ``members`` vs ``profiles`` — startup instantiation vs runtime hiring pool
@@ -17,7 +17,7 @@ What you'll learn
 
 Explanation
 -----------
-A ``TeamSpec`` defines how agents are composed into a working team.  The
+A ``TeamEntry`` defines how agents are composed into a working team.  The
 ``members`` tree mirrors the delegation hierarchy from ``agent_team.py``:
 the manager receives external messages (``entry_point``), delegates to
 researchers and reviewers, and researchers further delegate to analysts.
@@ -49,7 +49,7 @@ from akgentic.catalog import (
     TeamCatalog,
     TeamMemberSpec,
     TeamQuery,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     TemplateEntry,
     ToolCatalog,
@@ -62,7 +62,7 @@ from akgentic.catalog import (
 
 
 def main() -> None:
-    """Run example demonstrating TeamSpec with hierarchical member trees."""
+    """Run example demonstrating TeamEntry with hierarchical member trees."""
     with (
         tempfile.TemporaryDirectory() as template_dir,
         tempfile.TemporaryDirectory() as tool_dir,
@@ -253,10 +253,10 @@ def main() -> None:
         print(f"  Created: id={manager_entry.id!r} (routes to @Researcher, @Reviewer)")
         print()
 
-        # --- Create TeamSpec with nested member tree ---
-        print("=== TeamSpec with Two-Level Nested Members ===\n")
+        # --- Create TeamEntry with nested member tree ---
+        print("=== TeamEntry with Two-Level Nested Members ===\n")
 
-        research_team = TeamSpec(
+        research_team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="Multi-level research team with hierarchical delegation",
@@ -282,7 +282,7 @@ def main() -> None:
         )
         team_catalog.create(research_team)
 
-        print(f"Created TeamSpec: id={research_team.id!r}")
+        print(f"Created TeamEntry: id={research_team.id!r}")
         print(f"  name         : {research_team.name!r}")
         print(f"  entry_point  : {research_team.entry_point!r}")
         print(f"  message_types: {research_team.message_types}")
@@ -355,7 +355,7 @@ def main() -> None:
 
         try:
             team_catalog.create(
-                TeamSpec(
+                TeamEntry(
                     id="bad-entry-point-team",
                     name="Bad Entry Point Team",
                     entry_point="specialist",
@@ -377,7 +377,7 @@ def main() -> None:
 
         try:
             team_catalog.create(
-                TeamSpec(
+                TeamEntry(
                     id="bad-member-team",
                     name="Bad Member Team",
                     entry_point="nonexistent-agent",
@@ -398,7 +398,7 @@ def main() -> None:
 
         try:
             team_catalog.create(
-                TeamSpec(
+                TeamEntry(
                     id="bad-msg-team",
                     name="Bad Message Type Team",
                     entry_point="manager",

--- a/examples/04-yaml-persistence.md
+++ b/examples/04-yaml-persistence.md
@@ -115,8 +115,8 @@ repo.list()     # Re-reads from disk, returns updated data
 
 ## Related Examples
 
-- [Example 03 — Team Composition, Member Trees & Profiles](03-team-specs.md):
-  TeamSpec hierarchies, entry_point validation, members vs profiles
+- [Example 03 — Team Composition, Member Trees & Profiles](03-team-entries.md):
+  TeamEntry hierarchies, entry_point validation, members vs profiles
 - [Example 05 — Full Catalog Wiring, Delete Protection & Env Vars](05-catalog-wiring.md):
   Service-layer catalogs with bidirectional wiring, delete protection across
   every boundary, update re-validation, and environment variable substitution

--- a/examples/04_yaml_persistence.py
+++ b/examples/04_yaml_persistence.py
@@ -4,7 +4,7 @@ Purpose
 -------
 Prove that the YAML persistence layer works correctly with full type fidelity.
 Every catalog entry type (``TemplateEntry``, ``ToolEntry``, ``AgentEntry``,
-``TeamSpec``) survives a write-to-disk / read-back cycle without data loss.
+``TeamEntry``) survives a write-to-disk / read-back cycle without data loss.
 
 What you'll learn
 -----------------
@@ -45,7 +45,7 @@ from akgentic.catalog import (
     AgentEntry,
     CatalogValidationError,
     TeamMemberSpec,
-    TeamSpec,
+    TeamEntry,
     TemplateEntry,
     ToolEntry,
     YamlAgentCatalogRepository,
@@ -130,8 +130,8 @@ def main() -> None:
         agent_repo.create(researcher_entry)
         print(f"Created AgentEntry: id={researcher_entry.id!r}")
 
-        # TeamSpec
-        research_team = TeamSpec(
+        # TeamEntry
+        research_team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="A small research team",
@@ -140,7 +140,7 @@ def main() -> None:
             members=[TeamMemberSpec(agent_id="researcher", headcount=1)],
         )
         team_repo.create(research_team)
-        print(f"Created TeamSpec: id={research_team.id!r}")
+        print(f"Created TeamEntry: id={research_team.id!r}")
         print()
 
         # ---------------------------------------------------------------
@@ -217,7 +217,7 @@ def main() -> None:
         assert fresh_team.entry_point == research_team.entry_point
         assert len(fresh_team.members) == len(research_team.members)
         print(
-            f"  TeamSpec round-trip OK: id={fresh_team.id!r}, "
+            f"  TeamEntry round-trip OK: id={fresh_team.id!r}, "
             f"entry_point={fresh_team.entry_point!r}"
         )
         print()

--- a/examples/05_catalog_wiring.py
+++ b/examples/05_catalog_wiring.py
@@ -62,7 +62,7 @@ from akgentic.catalog import (
     EntryNotFoundError,
     TeamCatalog,
     TeamMemberSpec,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     TemplateEntry,
     ToolCatalog,
@@ -204,7 +204,7 @@ def main() -> None:
         )
 
         # Team with nested member tree
-        research_team = TeamSpec(
+        research_team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="A team for research tasks",

--- a/examples/06_search_and_query.py
+++ b/examples/06_search_and_query.py
@@ -66,7 +66,7 @@ from akgentic.catalog import (
     TeamCatalog,
     TeamMemberSpec,
     TeamQuery,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     TemplateEntry,
     TemplateQuery,
@@ -241,7 +241,7 @@ def main() -> None:
             print(f"  Agent: {agent.id!r}  role={agent.card.role!r}  skills={agent.card.skills}")
 
         # --- Teams (2) ---
-        research_team = TeamSpec(
+        research_team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="Research and analysis team",
@@ -255,7 +255,7 @@ def main() -> None:
                 ),
             ],
         )
-        engineering_team = TeamSpec(
+        engineering_team = TeamEntry(
             id="engineering-team",
             name="Engineering Team",
             description="Engineering coordination team",

--- a/examples/07_python_first.py
+++ b/examples/07_python_first.py
@@ -10,7 +10,7 @@ writes YAML as a side effect.
 What you'll learn
 -----------------
 * **All-Python construction** — build ``TemplateEntry``, ``ToolEntry``,
-  ``AgentEntry``, and ``TeamSpec`` entirely via Pydantic constructors.
+  ``AgentEntry``, and ``TeamEntry`` entirely via Pydantic constructors.
 * **Identical validation** — entries go through the same ``create()``
   pipeline regardless of origin (Python, YAML, REST, CLI).
 * **YAML as side effect** — after ``create()``, YAML files appear on disk
@@ -42,7 +42,7 @@ from akgentic.catalog import (
     AgentQuery,
     TeamCatalog,
     TeamMemberSpec,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     TemplateEntry,
     ToolCatalog,
@@ -186,8 +186,8 @@ def main() -> None:
         agent_catalog.create(analyst)
         print(f"  AgentEntry created: id={analyst.id!r}  role={analyst.card.role!r}")
 
-        # TeamSpec — built entirely in Python
-        team = TeamSpec(
+        # TeamEntry — built entirely in Python
+        team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="Research and analysis team",
@@ -202,7 +202,7 @@ def main() -> None:
             ],
         )
         team_catalog.create(team)
-        print(f"  TeamSpec created: id={team.id!r}  name={team.name!r}")
+        print(f"  TeamEntry created: id={team.id!r}  name={team.name!r}")
         print()
 
         # =============================================================
@@ -343,7 +343,7 @@ def main() -> None:
                 "Agent for test scenarios",
                 tool_ids=["test-search"],
             ))
-            test_team_cat.create(TeamSpec(
+            test_team_cat.create(TeamEntry(
                 id="test-team",
                 name="Test Team",
                 description="Team for testing",

--- a/examples/08-custom-types.md
+++ b/examples/08-custom-types.md
@@ -26,7 +26,7 @@ full agent configuration surface.
 ### Custom Message Types
 
 Pydantic `BaseModel` subclasses serve as typed message contracts between
-agents.  When registered in `TeamSpec.message_types` as FQCNs, the catalog
+agents.  When registered in `TeamEntry.message_types` as FQCNs, the catalog
 validates they resolve to real Python classes.
 
 ### receiveMsg\_ Convention

--- a/examples/08_custom_types.py
+++ b/examples/08_custom_types.py
@@ -46,7 +46,7 @@ from akgentic.catalog import (
     AgentEntry,
     TeamCatalog,
     TeamMemberSpec,
-    TeamSpec,
+    TeamEntry,
     TemplateCatalog,
     ToolCatalog,
     ToolEntry,
@@ -438,11 +438,11 @@ def main() -> None:
         print()
 
         # =============================================================
-        # Section 7: Register TeamSpec with custom message_types FQCN
+        # Section 7: Register TeamEntry with custom message_types FQCN
         # =============================================================
-        print("=== Section 7: TeamSpec with Custom message_types ===\n")
+        print("=== Section 7: TeamEntry with Custom message_types ===\n")
 
-        team = TeamSpec(
+        team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="AI research team with custom message types",
@@ -453,7 +453,7 @@ def main() -> None:
             ],
         )
         team_catalog.create(team)
-        print(f"  TeamSpec created: id={team.id!r}, name={team.name!r}")
+        print(f"  TeamEntry created: id={team.id!r}, name={team.name!r}")
         print(f"  message_types: {team.message_types}")
 
         # Verify message type FQCN validation

--- a/examples/README.md
+++ b/examples/README.md
@@ -38,13 +38,13 @@ How `AgentCatalog` validates cross-catalog references (`tool_ids`,
 
 Companion docs: [02-agent-entries.md](02-agent-entries.md)
 
-### [03_team_specs.py](03_team_specs.py) — Team Composition, Member Trees & Profiles
+### [03_team_entries.py](03_team_entries.py) — Team Composition, Member Trees & Profiles
 
-All four catalogs wired together. `TeamSpec` with nested `TeamMemberSpec`
+All four catalogs wired together. `TeamEntry` with nested `TeamMemberSpec`
 hierarchies, `entry_point` validation, `headcount`, members vs profiles,
 `message_types` FQCN validation, and recursive `TeamQuery` search.
 
-Companion docs: [03-team-specs.md](03-team-specs.md)
+Companion docs: [03-team-entries.md](03-team-entries.md)
 
 ### [04_yaml_persistence.py](04_yaml_persistence.py) — YAML Repository Round-Trip
 

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -1,6 +1,6 @@
 """Public API surface for akgentic-catalog.
 
-Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamSpec),
+Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamEntry),
 query models, error types, abstract and YAML repository interfaces,
 catalog services, and the resolve_env_vars utility. MongoDB backend exports
 are conditionally available when pymongo is installed.
@@ -12,7 +12,7 @@ from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import (
@@ -41,7 +41,7 @@ __all__ = [
     "TeamCatalogRepository",
     "TeamMemberSpec",
     "TeamQuery",
-    "TeamSpec",
+    "TeamEntry",
     "TemplateCatalog",
     "TemplateCatalogRepository",
     "TemplateEntry",

--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -163,7 +163,7 @@ def _wire_mongodb_backend(
         config.get_collection(client, config.agent_entries_collection)
     )
     team_repo = MongoTeamCatalogRepository(
-        config.get_collection(client, config.team_specs_collection)
+        config.get_collection(client, config.team_entries_collection)
     )
 
     # Create services in dependency order

--- a/src/akgentic/catalog/api/team_router.py
+++ b/src/akgentic/catalog/api/team_router.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Response
 
 from akgentic.catalog.models.errors import EntryNotFoundError
 from akgentic.catalog.models.queries import TeamQuery
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 
 if TYPE_CHECKING:
     from akgentic.catalog.services.team_catalog import TeamCatalog
@@ -40,24 +40,24 @@ def _get_catalog() -> TeamCatalog:
     return _catalog
 
 
-@router.post("/", response_model=TeamSpec, status_code=201)
-async def create_team(entry: TeamSpec) -> TeamSpec:
-    """Create a new team spec."""
+@router.post("/", response_model=TeamEntry, status_code=201)
+async def create_team(entry: TeamEntry) -> TeamEntry:
+    """Create a new team entry."""
     logger.debug("POST /api/teams — creating %s", entry.id)
     _get_catalog().create(entry)
     return entry
 
 
-@router.get("/", response_model=list[TeamSpec])
-async def list_teams() -> list[TeamSpec]:
-    """List all team specs."""
+@router.get("/", response_model=list[TeamEntry])
+async def list_teams() -> list[TeamEntry]:
+    """List all team entries."""
     logger.debug("GET /api/teams — listing all")
     return _get_catalog().list()
 
 
-@router.get("/{id}", response_model=TeamSpec)
-async def get_team(id: str) -> TeamSpec:
-    """Get a team spec by id."""
+@router.get("/{id}", response_model=TeamEntry)
+async def get_team(id: str) -> TeamEntry:
+    """Get a team entry by id."""
     logger.debug("GET /api/teams/%s", id)
     entry = _get_catalog().get(id)
     if entry is None:
@@ -65,16 +65,16 @@ async def get_team(id: str) -> TeamSpec:
     return entry
 
 
-@router.post("/search", response_model=list[TeamSpec])
-async def search_teams(query: TeamQuery) -> list[TeamSpec]:
-    """Search team specs by query."""
+@router.post("/search", response_model=list[TeamEntry])
+async def search_teams(query: TeamQuery) -> list[TeamEntry]:
+    """Search team entries by query."""
     logger.debug("POST /api/teams/search")
     return _get_catalog().search(query)
 
 
-@router.put("/{id}", response_model=TeamSpec)
-async def update_team(id: str, entry: TeamSpec) -> TeamSpec:
-    """Update an existing team spec."""
+@router.put("/{id}", response_model=TeamEntry)
+async def update_team(id: str, entry: TeamEntry) -> TeamEntry:
+    """Update an existing team entry."""
     logger.debug("PUT /api/teams/%s", id)
     _get_catalog().update(id, entry)
     return entry
@@ -82,7 +82,7 @@ async def update_team(id: str, entry: TeamSpec) -> TeamSpec:
 
 @router.delete("/{id}", status_code=204)
 async def delete_team(id: str) -> Response:
-    """Delete a team spec."""
+    """Delete a team entry."""
     logger.debug("DELETE /api/teams/%s", id)
     _get_catalog().delete(id)
     return Response(status_code=204)

--- a/src/akgentic/catalog/cli/_catalog.py
+++ b/src/akgentic/catalog/cli/_catalog.py
@@ -137,7 +137,7 @@ def build_mongo_catalogs(
         config.get_collection(client, config.agent_entries_collection)
     )
     team_repo = MongoTeamCatalogRepository(
-        config.get_collection(client, config.team_specs_collection)
+        config.get_collection(client, config.team_entries_collection)
     )
 
     # Create services in dependency order

--- a/src/akgentic/catalog/cli/_output.py
+++ b/src/akgentic/catalog/cli/_output.py
@@ -41,7 +41,7 @@ _TABLE_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("card.role", "Role"),
         ("card.description", "Description"),
     ],
-    "TeamSpec": [
+    "TeamEntry": [
         ("id", "ID"),
         ("name", "Name"),
         ("entry_point", "Entry Point"),

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -20,7 +20,7 @@ from akgentic.catalog.cli._output import OutputFormat
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.agent import AgentEntry
-    from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+    from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
     from akgentic.catalog.models.template import TemplateEntry
     from akgentic.catalog.models.tool import ToolEntry
     from akgentic.catalog.services.agent_catalog import AgentCatalog
@@ -167,7 +167,7 @@ def _load_entries_module(file_path: Path) -> list[Any]:
 
 def _classify_entries(
     entries: list[Any],
-) -> tuple[list[TemplateEntry], list[ToolEntry], list[AgentEntry], list[TeamSpec]]:
+) -> tuple[list[TemplateEntry], list[ToolEntry], list[AgentEntry], list[TeamEntry]]:
     """Classify entries by type into four lists.
 
     Args:
@@ -177,14 +177,14 @@ def _classify_entries(
         Tuple of (templates, tools, agents, teams).
     """
     from akgentic.catalog.models.agent import AgentEntry as _AgentEntry
-    from akgentic.catalog.models.team import TeamSpec as _TeamSpec
+    from akgentic.catalog.models.team import TeamEntry as _TeamEntry
     from akgentic.catalog.models.template import TemplateEntry as _TemplateEntry
     from akgentic.catalog.models.tool import ToolEntry as _ToolEntry
 
     templates: list[TemplateEntry] = []
     tools: list[ToolEntry] = []
     agents: list[AgentEntry] = []
-    teams: list[TeamSpec] = []
+    teams: list[TeamEntry] = []
 
     for entry in entries:
         if isinstance(entry, _TemplateEntry):
@@ -193,7 +193,7 @@ def _classify_entries(
             tools.append(entry)
         elif isinstance(entry, _AgentEntry):
             agents.append(entry)
-        elif isinstance(entry, _TeamSpec):
+        elif isinstance(entry, _TeamEntry):
             teams.append(entry)
         else:
             err_console.print(
@@ -341,7 +341,7 @@ def _import_dry_run(
     templates: list[TemplateEntry],
     tools: list[ToolEntry],
     agents: list[AgentEntry],
-    teams: list[TeamSpec],
+    teams: list[TeamEntry],
     template_catalog: TemplateCatalog,
     tool_catalog: ToolCatalog,
     agent_catalog: AgentCatalog,

--- a/src/akgentic/catalog/cli/team_cmd.py
+++ b/src/akgentic/catalog/cli/team_cmd.py
@@ -15,7 +15,7 @@ from akgentic.catalog.cli._catalog import build_catalogs_from_state
 from akgentic.catalog.cli._output import render
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import TeamQuery
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 
 if TYPE_CHECKING:
     from akgentic.catalog.cli.main import GlobalState
@@ -36,14 +36,14 @@ def _state(ctx: typer.Context) -> GlobalState:
     return get_state(ctx)
 
 
-def _load_entry_from_yaml(file: Path) -> TeamSpec:
-    """Load a TeamSpec from a YAML file.
+def _load_entry_from_yaml(file: Path) -> TeamEntry:
+    """Load a TeamEntry from a YAML file.
 
     Args:
         file: Path to the YAML file.
 
     Returns:
-        A validated TeamSpec instance.
+        A validated TeamEntry instance.
 
     Raises:
         typer.Exit: If the file cannot be read or parsed.
@@ -54,7 +54,7 @@ def _load_entry_from_yaml(file: Path) -> TeamSpec:
         err_console.print(f"[red]Error reading file:[/red] {exc}")
         raise typer.Exit(code=1) from exc
     try:
-        return TeamSpec.model_validate(data)
+        return TeamEntry.model_validate(data)
     except ValidationError as exc:
         err_console.print(f"[red]Validation error:[/red] {exc}")
         raise typer.Exit(code=1) from exc

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -1,6 +1,6 @@
 """Public API surface for catalog data models.
 
-Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamSpec,
+Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamEntry,
 TeamMemberSpec), query filter models (TemplateQuery, ToolQuery, AgentQuery,
 TeamQuery), and error types (CatalogValidationError, EntryNotFoundError).
 """
@@ -10,7 +10,7 @@ from __future__ import annotations
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
@@ -21,7 +21,7 @@ __all__ = [
     "EntryNotFoundError",
     "TeamMemberSpec",
     "TeamQuery",
-    "TeamSpec",
+    "TeamEntry",
     "TemplateEntry",
     "TemplateQuery",
     "ToolEntry",

--- a/src/akgentic/catalog/models/queries.py
+++ b/src/akgentic/catalog/models/queries.py
@@ -52,7 +52,7 @@ class AgentQuery(BaseModel):
 
 
 class TeamQuery(BaseModel):
-    """Query model for filtering team specs."""
+    """Query model for filtering team entries."""
 
     model_config = ConfigDict(frozen=True)
 

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -13,7 +13,7 @@ from akgentic.core.utils.deserializer import import_class
 
 __all__ = [
     "TeamMemberSpec",
-    "TeamSpec",
+    "TeamEntry",
     "agent_in_members",
 ]
 
@@ -54,7 +54,7 @@ def agent_in_members(agent_id: str, members: list[TeamMemberSpec]) -> bool:
     return False
 
 
-class TeamSpec(BaseModel):
+class TeamEntry(BaseModel):
     """A team composition with entry point, message types, and member hierarchy."""
 
     id: NonEmptyStr = Field(description="Unique catalog identifier for this team")

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
@@ -231,11 +231,11 @@ class TeamCatalogRepository(ABC):
     """Abstract repository for team catalog entries."""
 
     @abstractmethod
-    def create(self, team_spec: TeamSpec) -> str:
-        """Persist a new team spec.
+    def create(self, team_entry: TeamEntry) -> str:
+        """Persist a new team entry.
 
         Args:
-            team_spec: The team spec to create.
+            team_entry: The team entry to create.
 
         Returns:
             The id of the created entry.
@@ -245,38 +245,38 @@ class TeamCatalogRepository(ABC):
         """
 
     @abstractmethod
-    def get(self, id: str) -> TeamSpec | None:
-        """Retrieve a team spec by id.
+    def get(self, id: str) -> TeamEntry | None:
+        """Retrieve a team entry by id.
 
         Args:
-            id: The team spec id.
+            id: The team entry id.
 
         Returns:
-            The team spec, or None if not found.
+            The team entry, or None if not found.
         """
 
     @abstractmethod
-    def list(self) -> _list[TeamSpec]:
-        """Return all team specs."""
+    def list(self) -> _list[TeamEntry]:
+        """Return all team entries."""
 
     @abstractmethod
-    def search(self, query: TeamQuery) -> _list[TeamSpec]:
-        """Filter team specs matching query criteria.
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
+        """Filter team entries matching query criteria.
 
         Args:
             query: Query with optional filter fields (AND semantics).
 
         Returns:
-            Matching team specs.
+            Matching team entries.
         """
 
     @abstractmethod
-    def update(self, id: str, team_spec: TeamSpec) -> None:
-        """Update an existing team spec.
+    def update(self, id: str, team_entry: TeamEntry) -> None:
+        """Update an existing team entry.
 
         Args:
             id: The id of the entry to update.
-            team_spec: The new entry data.
+            team_entry: The new entry data.
 
         Raises:
             EntryNotFoundError: If no entry with the given id exists.
@@ -284,7 +284,7 @@ class TeamCatalogRepository(ABC):
 
     @abstractmethod
     def delete(self, id: str) -> None:
-        """Delete a team spec by id.
+        """Delete a team entry by id.
 
         Args:
             id: The id of the entry to delete.

--- a/src/akgentic/catalog/repositories/mongo/_config.py
+++ b/src/akgentic/catalog/repositories/mongo/_config.py
@@ -43,9 +43,9 @@ class MongoCatalogConfig(BaseModel):
         default="agent_entries",
         description="Collection name for agent catalog entries",
     )
-    team_specs_collection: str = Field(
-        default="team_specs",
-        description="Collection name for team spec catalog entries",
+    team_entries_collection: str = Field(
+        default="team_entries",
+        description="Collection name for team catalog entries",
     )
 
     @field_validator("connection_string")

--- a/src/akgentic/catalog/repositories/mongo/team_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/team_repo.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from pymongo.errors import DuplicateKeyError
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.catalog.models.team import TeamSpec, agent_in_members
+from akgentic.catalog.models.team import TeamEntry, agent_in_members
 from akgentic.catalog.repositories.base import TeamCatalogRepository
 from akgentic.catalog.repositories.mongo._helpers import from_document, to_document
 
@@ -28,24 +28,24 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
     """MongoDB-backed team catalog repository.
 
     Args:
-        collection: A pymongo Collection for team specs.
+        collection: A pymongo Collection for team entries.
     """
 
     def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
         """Initialize with a pymongo Collection and ensure unique index on _id.
 
         Args:
-            collection: The MongoDB collection for team specs.
+            collection: The MongoDB collection for team entries.
         """
         self._collection = collection
         self._collection.create_index("_id", unique=True)
         logger.info("MongoTeamCatalogRepository initialized with index on _id")
 
-    def create(self, team_spec: TeamSpec) -> str:
-        """Persist a new team spec.
+    def create(self, team_entry: TeamEntry) -> str:
+        """Persist a new team entry.
 
         Args:
-            team_spec: The team spec to create.
+            team_entry: The team entry to create.
 
         Returns:
             The id of the created entry.
@@ -53,36 +53,36 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
         Raises:
             CatalogValidationError: If an entry with the same id already exists.
         """
-        doc = to_document(team_spec)
+        doc = to_document(team_entry)
         try:
             self._collection.insert_one(doc)
         except DuplicateKeyError as e:
-            raise CatalogValidationError([f"Entry with id '{team_spec.id}' already exists"]) from e
-        logger.debug("Created team spec with id=%s", team_spec.id)
-        return team_spec.id
+            raise CatalogValidationError([f"Entry with id '{team_entry.id}' already exists"]) from e
+        logger.debug("Created team entry with id=%s", team_entry.id)
+        return team_entry.id
 
-    def get(self, id: str) -> TeamSpec | None:
-        """Retrieve a team spec by id.
+    def get(self, id: str) -> TeamEntry | None:
+        """Retrieve a team entry by id.
 
         Args:
-            id: The team spec id.
+            id: The team entry id.
 
         Returns:
-            The team spec, or None if not found.
+            The team entry, or None if not found.
         """
         doc = self._collection.find_one({"_id": id})
         if doc is None:
-            logger.debug("Team spec not found: id=%s", id)
+            logger.debug("Team entry not found: id=%s", id)
             return None
-        return from_document(doc, TeamSpec)
+        return from_document(doc, TeamEntry)
 
-    def list(self) -> _list[TeamSpec]:
-        """Return all team specs."""
-        entries = [from_document(doc, TeamSpec) for doc in self._collection.find()]
-        logger.debug("Listed %d team specs", len(entries))
+    def list(self) -> _list[TeamEntry]:
+        """Return all team entries."""
+        entries = [from_document(doc, TeamEntry) for doc in self._collection.find()]
+        logger.debug("Listed %d team entries", len(entries))
         return entries
 
-    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
         """Filter teams by AND-ing all non-None query fields.
 
         Applies server-side filters for ``id``, ``name``, and ``description``
@@ -93,7 +93,7 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
             query: Query with optional filter fields.
 
         Returns:
-            Matching team specs.
+            Matching team entries.
         """
         mongo_filter: dict[str, Any] = {}
         if query.id is not None:
@@ -109,38 +109,38 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
                 "$options": "i",
             }
 
-        results = [from_document(doc, TeamSpec) for doc in self._collection.find(mongo_filter)]
+        results = [from_document(doc, TeamEntry) for doc in self._collection.find(mongo_filter)]
 
         # Client-side recursive filter for agent_id in member tree
         if query.agent_id is not None:
             results = [t for t in results if agent_in_members(query.agent_id, t.members)]
 
-        logger.debug("Search returned %d team specs", len(results))
+        logger.debug("Search returned %d team entries", len(results))
         return results
 
-    def update(self, id: str, team_spec: TeamSpec) -> None:
-        """Update an existing team spec.
+    def update(self, id: str, team_entry: TeamEntry) -> None:
+        """Update an existing team entry.
 
         Args:
             id: The id of the entry to update.
-            team_spec: The new entry data.
+            team_entry: The new entry data.
 
         Raises:
-            CatalogValidationError: If team_spec.id does not match id.
+            CatalogValidationError: If team_entry.id does not match id.
             EntryNotFoundError: If no entry with the given id exists.
         """
-        if team_spec.id != id:
+        if team_entry.id != id:
             raise CatalogValidationError(
-                [f"Entry id mismatch: expected '{id}', got '{team_spec.id}'"]
+                [f"Entry id mismatch: expected '{id}', got '{team_entry.id}'"]
             )
-        doc = to_document(team_spec)
+        doc = to_document(team_entry)
         result = self._collection.replace_one({"_id": id}, doc)
         if result.matched_count == 0:
             raise EntryNotFoundError(f"Entry with id '{id}' not found")
-        logger.debug("Updated team spec with id=%s", id)
+        logger.debug("Updated team entry with id=%s", id)
 
     def delete(self, id: str) -> None:
-        """Delete a team spec by id.
+        """Delete a team entry by id.
 
         Args:
             id: The id of the entry to delete.
@@ -151,4 +151,4 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
         result = self._collection.delete_one({"_id": id})
         if result.deleted_count == 0:
             raise EntryNotFoundError(f"Entry with id '{id}' not found")
-        logger.debug("Deleted team spec with id=%s", id)
+        logger.debug("Deleted team entry with id=%s", id)

--- a/src/akgentic/catalog/repositories/yaml/team_repo.py
+++ b/src/akgentic/catalog/repositories/yaml/team_repo.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.repositories.base import TeamCatalogRepository
 from akgentic.catalog.repositories.yaml._base import YamlRepositoryBase
 
@@ -37,10 +37,10 @@ def _agent_in_members(agent_id: str, members: _list[TeamMemberSpec]) -> bool:
     return False
 
 
-class YamlTeamCatalogRepository(TeamCatalogRepository, YamlRepositoryBase[TeamSpec]):
+class YamlTeamCatalogRepository(TeamCatalogRepository, YamlRepositoryBase[TeamEntry]):
     """YAML directory-backed team catalog repository."""
 
-    _entry_type = TeamSpec
+    _entry_type = TeamEntry
 
     def __init__(self, catalog_dir: Path) -> None:
         """Initialize with the directory containing team YAML files.
@@ -50,36 +50,36 @@ class YamlTeamCatalogRepository(TeamCatalogRepository, YamlRepositoryBase[TeamSp
         """
         YamlRepositoryBase.__init__(self, catalog_dir)
 
-    def create(self, team_spec: TeamSpec) -> str:
-        """Persist a new team spec."""
-        return YamlRepositoryBase.create(self, team_spec)
+    def create(self, team_entry: TeamEntry) -> str:
+        """Persist a new team entry."""
+        return YamlRepositoryBase.create(self, team_entry)
 
-    def get(self, id: str) -> TeamSpec | None:
-        """Retrieve a team spec by id."""
+    def get(self, id: str) -> TeamEntry | None:
+        """Retrieve a team entry by id."""
         return YamlRepositoryBase.get(self, id)
 
-    def list(self) -> _list[TeamSpec]:
-        """Return all team specs."""
+    def list(self) -> _list[TeamEntry]:
+        """Return all team entries."""
         return YamlRepositoryBase.list(self)
 
-    def update(self, id: str, team_spec: TeamSpec) -> None:
-        """Update an existing team spec."""
-        YamlRepositoryBase.update(self, id, team_spec)
+    def update(self, id: str, team_entry: TeamEntry) -> None:
+        """Update an existing team entry."""
+        YamlRepositoryBase.update(self, id, team_entry)
 
     def delete(self, id: str) -> None:
-        """Delete a team spec by id."""
+        """Delete a team entry by id."""
         YamlRepositoryBase.delete(self, id)
 
-    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
         """Filter teams by AND-ing all non-None query fields.
 
         Args:
             query: Query with optional filter fields.
 
         Returns:
-            Matching team specs.
+            Matching team entries.
         """
-        results: _list[TeamSpec] = []
+        results: _list[TeamEntry] = []
         for entry in self._ensure_loaded():
             if query.id is not None and entry.id != query.id:
                 continue

--- a/src/akgentic/catalog/services/agent_catalog.py
+++ b/src/akgentic/catalog/services/agent_catalog.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from akgentic.agent.config import AgentConfig
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.catalog.models.team import TeamSpec, agent_in_members
+from akgentic.catalog.models.team import TeamEntry, agent_in_members
 from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
 from akgentic.catalog.repositories.base import AgentCatalogRepository
 from akgentic.catalog.services.template_catalog import TemplateCatalog
@@ -29,8 +29,8 @@ _list = builtins.list  # Alias: the service's list() method shadows the built-in
 class _TeamCatalogProtocol(Protocol):
     """Structural type for team catalog (avoids circular import with TeamCatalog)."""
 
-    def list(self) -> _list[TeamSpec]:
-        """List all team specs."""
+    def list(self) -> _list[TeamEntry]:
+        """List all team entries."""
         ...
 
 

--- a/src/akgentic/catalog/services/team_catalog.py
+++ b/src/akgentic/catalog/services/team_catalog.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec, agent_in_members
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec, agent_in_members
 from akgentic.catalog.repositories.base import TeamCatalogRepository
 from akgentic.core.utils.deserializer import import_class
 
@@ -62,14 +62,14 @@ class TeamCatalog:
 
     def _validate_entry(
         self,
-        entry: TeamSpec,
+        entry: TeamEntry,
         *,
         exclude_id: str | None = None,
     ) -> _list[str]:
         """Cross-validate a team entry. Shared by create and update.
 
         Args:
-            entry: The team spec to validate.
+            entry: The team entry to validate.
             exclude_id: If set, skip the duplicate-id check for this id (used by update).
 
         Returns:
@@ -104,11 +104,11 @@ class TeamCatalog:
 
         return errors
 
-    def validate_create(self, entry: TeamSpec) -> _list[str]:
+    def validate_create(self, entry: TeamEntry) -> _list[str]:
         """Check duplicate id, entry_point, member agents, profiles, and message types.
 
         Args:
-            entry: The team spec to validate.
+            entry: The team entry to validate.
 
         Returns:
             List of validation error strings (empty if valid).
@@ -117,11 +117,11 @@ class TeamCatalog:
 
     # --- CRUD Operations ---
 
-    def create(self, entry: TeamSpec) -> str:
+    def create(self, entry: TeamEntry) -> str:
         """Persist a new team entry.
 
         Args:
-            entry: The team spec to create.
+            entry: The team entry to create.
 
         Returns:
             The id of the created entry.
@@ -137,42 +137,42 @@ class TeamCatalog:
         logger.info("team created: %s", entry.id)
         return result
 
-    def get(self, id: str) -> TeamSpec | None:
+    def get(self, id: str) -> TeamEntry | None:
         """Retrieve a team entry by id.
 
         Args:
             id: The team entry id.
 
         Returns:
-            The team spec, or None if not found.
+            The team entry, or None if not found.
         """
         return self.repository.get(id)
 
-    def list(self) -> _list[TeamSpec]:
+    def list(self) -> _list[TeamEntry]:
         """List all team entries.
 
         Returns:
-            All team specs in the repository.
+            All team entries in the repository.
         """
         return self.repository.list()
 
-    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
         """Search team entries by query.
 
         Args:
             query: Query with optional filter fields.
 
         Returns:
-            Matching team specs.
+            Matching team entries.
         """
         return self.repository.search(query)
 
-    def update(self, id: str, entry: TeamSpec) -> None:
+    def update(self, id: str, entry: TeamEntry) -> None:
         """Update an existing team entry.
 
         Args:
             id: The id of the entry to update.
-            entry: The new team spec data.
+            entry: The new team entry data.
 
         Raises:
             EntryNotFoundError: If no entry with the given id exists.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
-
-import re
 
 import yaml
 
@@ -54,7 +53,7 @@ def team_data(
     members: list[dict[str, Any]] | None = None,
     description: str = "A test team",
 ) -> dict[str, Any]:
-    """Build a team spec dict suitable for YAML serialization."""
+    """Build a team entry dict suitable for YAML serialization."""
     return {
         "id": team_id,
         "name": name,

--- a/tests/cli/test_import_cmd.py
+++ b/tests/cli/test_import_cmd.py
@@ -32,7 +32,7 @@ MIXED_ENTRIES_FILE = """\
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.team import TeamSpec, TeamMemberSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.tool.search import SearchTool, WebSearch
 
 entries = [
@@ -57,7 +57,7 @@ entries = [
             "routes_to": [],
         },
     }),
-    TeamSpec(
+    TeamEntry(
         id="mix-team",
         name="Mix Team",
         entry_point="mix-agent",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import builtins
 from typing import TYPE_CHECKING
 
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
@@ -85,10 +85,10 @@ def make_team(
     members: _list[TeamMemberSpec] | None = None,
     profiles: _list[str] | None = None,
     message_types: _list[str] | None = None,
-) -> TeamSpec:
-    """Create a TeamSpec for testing with optional members and config."""
+) -> TeamEntry:
+    """Create a TeamEntry for testing with optional members and config."""
     default_members = members or [TeamMemberSpec(agent_id="agent-1")]
-    return TeamSpec(
+    return TeamEntry(
         id=id,
         name=name,
         entry_point=entry_point,

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -19,7 +19,7 @@ from akgentic.core.agent_state import BaseState
 from akgentic.tool.core import ToolCard
 
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
@@ -209,12 +209,12 @@ class TestRoundTripToolEntry:
         assert set(dumped.keys()) == set(ToolEntry.model_fields.keys())
 
 
-class TestRoundTripTeamSpec:
-    """AC3: TeamSpec recursive tree and metadata round-trip."""
+class TestRoundTripTeamEntry:
+    """AC3: TeamEntry recursive tree and metadata round-trip."""
 
     def test_recursive_member_tree_survives_round_trip(self) -> None:
         """3+ level recursive TeamMemberSpec tree with non-default headcounts."""
-        original = TeamSpec(
+        original = TeamEntry(
             id="research-team",
             name="Research Division",
             entry_point="lead",
@@ -251,7 +251,7 @@ class TestRoundTripTeamSpec:
             description="A multi-level research team",
         )
         dumped = original.model_dump()
-        restored = TeamSpec.model_validate(dumped)
+        restored = TeamEntry.model_validate(dumped)
 
         # Top level
         assert len(restored.members) == 1
@@ -285,7 +285,7 @@ class TestRoundTripTeamSpec:
 
     def test_profiles_and_message_types_survive_round_trip(self) -> None:
         """profiles list and message_types FQCN strings preserved."""
-        original = TeamSpec(
+        original = TeamEntry(
             id="dev-team",
             name="Development Team",
             entry_point="manager",
@@ -300,7 +300,7 @@ class TestRoundTripTeamSpec:
             description="A development team with hiring pool",
         )
         dumped = original.model_dump()
-        restored = TeamSpec.model_validate(dumped)
+        restored = TeamEntry.model_validate(dumped)
 
         assert restored.message_types == [
             "akgentic.core.agent_state.BaseState",

--- a/tests/models/test_team_entry.py
+++ b/tests/models/test_team_entry.py
@@ -1,11 +1,11 @@
-"""Tests for TeamMemberSpec and TeamSpec models."""
+"""Tests for TeamMemberSpec and TeamEntry models."""
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError
-from akgentic.catalog.models.team import TeamMemberSpec, TeamSpec
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from tests.conftest import make_agent
 
 # --- Mock catalog helper ---
@@ -60,13 +60,13 @@ class TestTeamMemberSpec:
             TeamMemberSpec(agent_id="")
 
 
-# --- TeamSpec tests ---
+# --- TeamEntry tests ---
 
 
-class TestTeamSpec:
-    """Tests for TeamSpec model (AC #2)."""
+class TestTeamEntry:
+    """Tests for TeamEntry model (AC #2)."""
 
-    def _make_team_spec(self, **overrides: object) -> TeamSpec:
+    def _make_team_entry(self, **overrides: object) -> TeamEntry:
         defaults: dict[str, object] = {
             "id": "engineering",
             "name": "Engineering Team",
@@ -75,10 +75,10 @@ class TestTeamSpec:
             "members": [TeamMemberSpec(agent_id="eng-manager")],
         }
         defaults.update(overrides)
-        return TeamSpec(**defaults)  # type: ignore[arg-type]
+        return TeamEntry(**defaults)  # type: ignore[arg-type]
 
-    def test_valid_team_spec_all_required_fields(self) -> None:
-        team = self._make_team_spec()
+    def test_valid_team_entry_all_required_fields(self) -> None:
+        team = self._make_team_entry()
         assert team.id == "engineering"
         assert team.name == "Engineering Team"
         assert team.entry_point == "eng-manager"
@@ -86,32 +86,32 @@ class TestTeamSpec:
         assert len(team.members) == 1
 
     def test_defaults_profiles_empty_list(self) -> None:
-        team = self._make_team_spec()
+        team = self._make_team_entry()
         assert team.profiles == []
 
     def test_defaults_description_empty_string(self) -> None:
-        team = self._make_team_spec()
+        team = self._make_team_entry()
         assert team.description == ""
 
     def test_empty_id_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
-            self._make_team_spec(id="")
+            self._make_team_entry(id="")
 
     def test_empty_name_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
-            self._make_team_spec(name="")
+            self._make_team_entry(name="")
 
     def test_empty_entry_point_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
-            self._make_team_spec(entry_point="")
+            self._make_team_entry(entry_point="")
 
     def test_empty_message_types_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
-            self._make_team_spec(message_types=[])
+            self._make_team_entry(message_types=[])
 
     def test_empty_members_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
-            self._make_team_spec(members=[])
+            self._make_team_entry(members=[])
 
     def test_deeply_nested_member_tree(self) -> None:
         l3 = TeamMemberSpec(agent_id="intern")
@@ -119,15 +119,15 @@ class TestTeamSpec:
         l1 = TeamMemberSpec(agent_id="senior", members=[l2])
         l0 = TeamMemberSpec(agent_id="manager", members=[l1])
 
-        team = self._make_team_spec(members=[l0])
+        team = self._make_team_entry(members=[l0])
         assert team.members[0].members[0].members[0].members[0].agent_id == "intern"
 
     def test_profiles_accepts_strings(self) -> None:
-        team = self._make_team_spec(profiles=["extra-agent-1", "extra-agent-2"])
+        team = self._make_team_entry(profiles=["extra-agent-1", "extra-agent-2"])
         assert team.profiles == ["extra-agent-1", "extra-agent-2"]
 
     def test_custom_description(self) -> None:
-        team = self._make_team_spec(description="A great team")
+        team = self._make_team_entry(description="A great team")
         assert team.description == "A great team"
 
 
@@ -135,13 +135,13 @@ class TestTeamSpec:
 
 
 class TestResolveEntryPoint:
-    """Tests for TeamSpec.resolve_entry_point (AC #3)."""
+    """Tests for TeamEntry.resolve_entry_point (AC #3)."""
 
     def test_resolve_entry_point_returns_agent_entry(self) -> None:
         agent = make_agent(id="eng-manager")
         catalog = MockAgentCatalog({"eng-manager": agent})
 
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="eng-manager",
@@ -154,7 +154,7 @@ class TestResolveEntryPoint:
     def test_resolve_entry_point_raises_for_missing(self) -> None:
         catalog = MockAgentCatalog({})
 
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="nonexistent",
@@ -170,10 +170,10 @@ class TestResolveEntryPoint:
 
 
 class TestResolveMessageTypes:
-    """Tests for TeamSpec.resolve_message_types (AC #4)."""
+    """Tests for TeamEntry.resolve_message_types (AC #4)."""
 
     def test_resolve_valid_class_path(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -184,7 +184,7 @@ class TestResolveMessageTypes:
         assert result == [BaseModel]
 
     def test_resolve_multiple_valid_paths(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -197,7 +197,7 @@ class TestResolveMessageTypes:
         assert result[1] is ValidationError
 
     def test_single_invalid_path_raises_catalog_validation_error(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -210,7 +210,7 @@ class TestResolveMessageTypes:
         assert "nonexistent.module.FakeClass" in exc_info.value.errors[0]
 
     def test_collects_all_errors_for_multiple_invalid_paths(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -224,7 +224,7 @@ class TestResolveMessageTypes:
         assert "bad.path.Two" in exc_info.value.errors[1]
 
     def test_dotless_path_raises_catalog_validation_error(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -237,7 +237,7 @@ class TestResolveMessageTypes:
         assert "nodotpath" in exc_info.value.errors[0]
 
     def test_non_class_importable_raises_catalog_validation_error(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -249,7 +249,7 @@ class TestResolveMessageTypes:
         assert "not a class" in exc_info.value.errors[0]
 
     def test_mixed_valid_and_invalid_raises_only_for_invalid(self) -> None:
-        team = TeamSpec(
+        team = TeamEntry(
             id="team-1",
             name="Team",
             entry_point="ep",
@@ -273,7 +273,7 @@ class TestPublicAPIExports:
 
         assert Imported is TeamMemberSpec
 
-    def test_team_spec_importable_from_catalog(self) -> None:
-        from akgentic.catalog import TeamSpec as Imported
+    def test_team_entry_importable_from_catalog(self) -> None:
+        from akgentic.catalog import TeamEntry as Imported
 
-        assert Imported is TeamSpec
+        assert Imported is TeamEntry

--- a/tests/repositories/mongo/conftest.py
+++ b/tests/repositories/mongo/conftest.py
@@ -48,5 +48,5 @@ def agent_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.
 
 @pytest.fixture
 def team_collection(mongo_db: pymongo.database.Database) -> pymongo.collection.Collection:  # type: ignore[type-arg]
-    """Provide the team_specs collection."""
-    return mongo_db["team_specs"]
+    """Provide the team_entries collection."""
+    return mongo_db["team_entries"]

--- a/tests/repositories/mongo/test_config.py
+++ b/tests/repositories/mongo/test_config.py
@@ -54,7 +54,7 @@ class TestMongoCatalogConfigValidation:
         assert config.template_entries_collection == "template_entries"
         assert config.tool_entries_collection == "tool_entries"
         assert config.agent_entries_collection == "agent_entries"
-        assert config.team_specs_collection == "team_specs"
+        assert config.team_entries_collection == "team_entries"
 
     def test_custom_collection_names(self) -> None:
         """Collection names can be overridden."""

--- a/tests/repositories/mongo/test_helpers.py
+++ b/tests/repositories/mongo/test_helpers.py
@@ -42,8 +42,8 @@ class TestToDocument:
         assert doc["_id"] == "agent-1"
         assert "id" not in doc
 
-    def test_team_spec_id_becomes_underscore_id(self) -> None:
-        """TeamSpec.id is stored as _id in the document."""
+    def test_team_entry_id_becomes_underscore_id(self) -> None:
+        """TeamEntry.id is stored as _id in the document."""
         entry = make_team(id="team-1")
         doc = to_document(entry)
         assert doc["_id"] == "team-1"
@@ -83,13 +83,13 @@ class TestFromDocument:
         assert restored.id == original.id
         assert restored.card == original.card
 
-    def test_team_spec_round_trip(self) -> None:
-        """TeamSpec survives to_document → from_document round-trip."""
-        from akgentic.catalog.models.team import TeamSpec
+    def test_team_entry_round_trip(self) -> None:
+        """TeamEntry survives to_document → from_document round-trip."""
+        from akgentic.catalog.models.team import TeamEntry
 
         original = make_team(id="team-rt", name="Round Trip Team")
         doc = to_document(original)
-        restored = from_document(doc, TeamSpec)
+        restored = from_document(doc, TeamEntry)
         assert restored.id == original.id
         assert restored.name == original.name
         assert len(restored.members) == len(original.members)

--- a/tests/repositories/mongo/test_mongo_team_repo.py
+++ b/tests/repositories/mongo/test_mongo_team_repo.py
@@ -26,7 +26,7 @@ class TestCreateAndGet:
     """AC-5: MongoTeamCatalogRepository CRUD — create and get round-trip."""
 
     def test_create_and_get_round_trip(self, repo: MongoTeamCatalogRepository) -> None:
-        """Create a team spec and retrieve it by id."""
+        """Create a team entry and retrieve it by id."""
         entry = make_team(id="team-1", name="Engineering")
         created_id = repo.create(entry)
         assert created_id == "team-1"
@@ -60,7 +60,7 @@ class TestList:
         assert repo.list() == []
 
     def test_list_returns_all_entries(self, repo: MongoTeamCatalogRepository) -> None:
-        """List returns all created team specs."""
+        """List returns all created team entries."""
         repo.create(make_team(id="t1", name="Alpha"))
         repo.create(make_team(id="t2", name="Beta"))
         repo.create(make_team(id="t3", name="Gamma"))
@@ -215,7 +215,7 @@ class TestUpdate:
     """AC-5: MongoTeamCatalogRepository update with id-mismatch guard."""
 
     def test_update_existing_entry(self, repo: MongoTeamCatalogRepository) -> None:
-        """Update replaces the team spec data."""
+        """Update replaces the team entry data."""
         repo.create(make_team(id="team-1", name="Old Name"))
 
         updated = make_team(id="team-1", name="New Name")

--- a/tests/repositories/test_repositories_base.py
+++ b/tests/repositories/test_repositories_base.py
@@ -9,7 +9,7 @@ import pytest
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import (
@@ -83,19 +83,19 @@ class ConcreteAgentRepo(AgentCatalogRepository):
 
 
 class ConcreteTeamRepo(TeamCatalogRepository):
-    def create(self, team_spec: TeamSpec) -> str:
-        return team_spec.id
+    def create(self, team_entry: TeamEntry) -> str:
+        return team_entry.id
 
-    def get(self, id: str) -> TeamSpec | None:
+    def get(self, id: str) -> TeamEntry | None:
         return None
 
-    def list(self) -> list[TeamSpec]:
+    def list(self) -> list[TeamEntry]:
         return []
 
-    def search(self, query: TeamQuery) -> list[TeamSpec]:
+    def search(self, query: TeamQuery) -> list[TeamEntry]:
         return []
 
-    def update(self, id: str, team_spec: TeamSpec) -> None:
+    def update(self, id: str, team_entry: TeamEntry) -> None:
         return None
 
     def delete(self, id: str) -> None:
@@ -121,8 +121,8 @@ class PartialAgentRepo(AgentCatalogRepository):  # type: ignore[abstract]
 
 
 class PartialTeamRepo(TeamCatalogRepository):  # type: ignore[abstract]
-    def create(self, team_spec: TeamSpec) -> str:
-        return team_spec.id
+    def create(self, team_entry: TeamEntry) -> str:
+        return team_entry.id
 
 
 # --- Tests ---
@@ -235,9 +235,9 @@ class TestMethodSignatures:
 
     def test_team_repo_signatures(self) -> None:
         assert self._hints(TeamCatalogRepository, "create")["return"] is str
-        assert self._hints(TeamCatalogRepository, "get")["return"] == TeamSpec | None
-        assert self._hints(TeamCatalogRepository, "list")["return"] == builtins.list[TeamSpec]
-        assert self._hints(TeamCatalogRepository, "search")["return"] == builtins.list[TeamSpec]
+        assert self._hints(TeamCatalogRepository, "get")["return"] == TeamEntry | None
+        assert self._hints(TeamCatalogRepository, "list")["return"] == builtins.list[TeamEntry]
+        assert self._hints(TeamCatalogRepository, "search")["return"] == builtins.list[TeamEntry]
         assert self._hints(TeamCatalogRepository, "update")["return"] is type(None)
         assert self._hints(TeamCatalogRepository, "delete")["return"] is type(None)
 

--- a/tests/repositories/test_yaml_team_repo.py
+++ b/tests/repositories/test_yaml_team_repo.py
@@ -6,7 +6,7 @@ import pytest
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import TeamQuery
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from tests.repositories.conftest import write_yaml
 
@@ -35,8 +35,8 @@ def _team_dict(
 # ---- Loading (AC #2) ----
 
 
-def test_load_team_spec_from_yaml(tmp_path: Path) -> None:
-    """AC #2: Load TeamSpec from YAML with recursive TeamMemberSpec trees."""
+def test_load_team_entry_from_yaml(tmp_path: Path) -> None:
+    """AC #2: Load TeamEntry from YAML with recursive TeamMemberSpec trees."""
     members = [
         {
             "agent_id": "eng-manager",
@@ -53,7 +53,7 @@ def test_load_team_spec_from_yaml(tmp_path: Path) -> None:
     repo = YamlTeamCatalogRepository(tmp_path)
     entries = repo.list()
     assert len(entries) == 1
-    assert isinstance(entries[0], TeamSpec)
+    assert isinstance(entries[0], TeamEntry)
     assert entries[0].members[0].agent_id == "eng-manager"
     assert entries[0].members[0].members[0].agent_id == "eng-assistant"
 
@@ -62,10 +62,10 @@ def test_load_team_spec_from_yaml(tmp_path: Path) -> None:
 
 
 def test_create_persists_team(tmp_path: Path) -> None:
-    """AC #2: create() persists team spec to YAML file."""
+    """AC #2: create() persists team entry to YAML file."""
     repo = YamlTeamCatalogRepository(tmp_path)
     data = _team_dict("new-team", name="New Team")
-    entry = TeamSpec.model_validate(data)
+    entry = TeamEntry.model_validate(data)
     result_id = repo.create(entry)
     assert result_id == "new-team"
 
@@ -79,7 +79,7 @@ def test_create_duplicate_id_raises(tmp_path: Path) -> None:
     """create() raises CatalogValidationError for duplicate id."""
     write_yaml(tmp_path / "t.yaml", [_team_dict("dup")])
     repo = YamlTeamCatalogRepository(tmp_path)
-    entry = TeamSpec.model_validate(_team_dict("dup", name="Another"))
+    entry = TeamEntry.model_validate(_team_dict("dup", name="Another"))
     with pytest.raises(CatalogValidationError):
         repo.create(entry)
 
@@ -111,10 +111,10 @@ def test_list_returns_all_entries(tmp_path: Path) -> None:
 
 
 def test_update_modifies_team(tmp_path: Path) -> None:
-    """update() modifies team spec in file."""
+    """update() modifies team entry in file."""
     write_yaml(tmp_path / "t.yaml", [_team_dict("t1", name="Old Name")])
     repo = YamlTeamCatalogRepository(tmp_path)
-    updated = TeamSpec.model_validate(_team_dict("t1", name="New Name"))
+    updated = TeamEntry.model_validate(_team_dict("t1", name="New Name"))
     repo.update("t1", updated)
     entry = repo.get("t1")
     assert entry is not None
@@ -125,13 +125,13 @@ def test_update_raises_for_missing_id(tmp_path: Path) -> None:
     """update() raises EntryNotFoundError for missing id."""
     write_yaml(tmp_path / "t.yaml", [_team_dict("t1")])
     repo = YamlTeamCatalogRepository(tmp_path)
-    entry = TeamSpec.model_validate(_team_dict("nope"))
+    entry = TeamEntry.model_validate(_team_dict("nope"))
     with pytest.raises(EntryNotFoundError):
         repo.update("nope", entry)
 
 
 def test_delete_removes_team(tmp_path: Path) -> None:
-    """delete() removes team spec and deletes file if empty."""
+    """delete() removes team entry and deletes file if empty."""
     write_yaml(tmp_path / "t1.yaml", [_team_dict("t1")])
     repo = YamlTeamCatalogRepository(tmp_path)
     repo.delete("t1")

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.team import TeamSpec
+from akgentic.catalog.models.team import TeamEntry
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import (
     AgentCatalogRepository,
@@ -107,19 +107,19 @@ class InMemoryTeamCatalogRepository(TeamCatalogRepository):
     """In-memory team repository for testing service logic."""
 
     def __init__(self) -> None:
-        self._entries: dict[str, TeamSpec] = {}
+        self._entries: dict[str, TeamEntry] = {}
 
-    def create(self, team_spec: TeamSpec) -> str:
-        self._entries[team_spec.id] = team_spec
-        return team_spec.id
+    def create(self, team_entry: TeamEntry) -> str:
+        self._entries[team_entry.id] = team_entry
+        return team_entry.id
 
-    def get(self, id: str) -> TeamSpec | None:
+    def get(self, id: str) -> TeamEntry | None:
         return self._entries.get(id)
 
-    def list(self) -> _list[TeamSpec]:
+    def list(self) -> _list[TeamEntry]:
         return _list(self._entries.values())
 
-    def search(self, query: TeamQuery) -> _list[TeamSpec]:
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
         from akgentic.catalog.models.team import agent_in_members
 
         results = self.list()
@@ -141,8 +141,8 @@ class InMemoryTeamCatalogRepository(TeamCatalogRepository):
             ]
         return results
 
-    def update(self, id: str, team_spec: TeamSpec) -> None:
-        self._entries[id] = team_spec
+    def update(self, id: str, team_entry: TeamEntry) -> None:
+        self._entries[id] = team_entry
 
     def delete(self, id: str) -> None:
         del self._entries[id]
@@ -151,10 +151,10 @@ class InMemoryTeamCatalogRepository(TeamCatalogRepository):
 class MockTeamCatalog:
     """Mock team catalog satisfying _TeamCatalogProtocol (has list() method)."""
 
-    def __init__(self, teams: _list[TeamSpec]) -> None:
+    def __init__(self, teams: _list[TeamEntry]) -> None:
         self._teams = _list(teams)
 
-    def list(self) -> _list[TeamSpec]:
+    def list(self) -> _list[TeamEntry]:
         return self._teams
 
 


### PR DESCRIPTION
All catalog entry models now follow the *Entry naming convention: TemplateEntry, ToolEntry, AgentEntry, TeamEntry. Also renames team_spec variables, parameters, docstrings, file names, and the MongoDB collection field (team_specs_collection → team_entries_collection).