### PR TITLE
Remove akgentic-agent runtime dependency from catalog

### DIFF
--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -463,8 +463,6 @@ def validate_cmd(
 
     # Agents
     if catalog is None or catalog == "agents":
-        from akgentic.agent.config import AgentConfig
-
         agent_entries = agent_catalog.list()
         agent_count = len(agent_entries)
         agent_ids_set = {a.id for a in agent_entries}
@@ -481,8 +479,8 @@ def validate_cmd(
                     errors.append(f"Agent '{agent.id}': tool '{tool_id}' not found")
             # Check @template reference
             config = agent.card.config
-            if isinstance(config, AgentConfig):
-                prompt = config.prompt
+            if hasattr(config, "prompt"):
+                prompt = config.prompt  # ADR-003: duck-type gate
                 if _is_catalog_ref(prompt.template):
                     template_id = _resolve_ref(prompt.template)
                     tmpl = template_catalog.get(template_id)

--- a/src/akgentic/catalog/models/agent.py
+++ b/src/akgentic/catalog/models/agent.py
@@ -174,7 +174,9 @@ class AgentEntry(BaseModel):
 
         Combines ``resolve_tools`` and ``resolve_template`` into a single
         convenience method that returns an ``AgentCard`` ready for use with
-        the actor system.
+        the actor system.  Resolution is duck-typed per ADR-003: tool and
+        prompt assignments are skipped when the concrete config lacks those
+        attributes (e.g. plain ``BaseConfig``).
 
         Args:
             tool_catalog: Catalog service providing tool lookups.
@@ -189,9 +191,10 @@ class AgentEntry(BaseModel):
         if hasattr(config, "tools"):
             config.tools = self.resolve_tools(tool_catalog)  # ADR-003: duck-type gate
 
-        resolved_prompt = self.resolve_template(template_catalog)
-        if hasattr(config, "prompt") and resolved_prompt is not None:
-            config.prompt = resolved_prompt  # ADR-003: duck-type gate
+        if hasattr(config, "prompt"):
+            resolved_prompt = self.resolve_template(template_catalog)
+            if resolved_prompt is not None:
+                config.prompt = resolved_prompt  # ADR-003: duck-type gate
 
         return AgentCard(
             role=card.role,

--- a/src/akgentic/catalog/models/agent.py
+++ b/src/akgentic/catalog/models/agent.py
@@ -6,7 +6,6 @@ from typing import Any, Protocol, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
-from akgentic.agent.config import AgentConfig
 from akgentic.catalog.models._types import NonEmptyStr
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
@@ -155,9 +154,9 @@ class AgentEntry(BaseModel):
             CatalogValidationError: If the @-referenced template is not found.
         """
         config = self.card.config
-        if not isinstance(config, AgentConfig):
+        if not hasattr(config, "prompt"):
             return None
-        prompt = config.prompt
+        prompt: PromptTemplate = config.prompt  # ADR-003: duck-type gate
         if not _is_catalog_ref(prompt.template):
             return prompt
         template_id = _resolve_ref(prompt.template)
@@ -186,13 +185,13 @@ class AgentEntry(BaseModel):
         """
         card = self.card
         config = card.get_config_copy()
-        assert isinstance(config, AgentConfig)
 
-        config.tools = self.resolve_tools(tool_catalog)
+        if hasattr(config, "tools"):
+            config.tools = self.resolve_tools(tool_catalog)  # ADR-003: duck-type gate
 
         resolved_prompt = self.resolve_template(template_catalog)
-        if resolved_prompt is not None:
-            config.prompt = resolved_prompt
+        if hasattr(config, "prompt") and resolved_prompt is not None:
+            config.prompt = resolved_prompt  # ADR-003: duck-type gate
 
         return AgentCard(
             role=card.role,

--- a/src/akgentic/catalog/services/agent_catalog.py
+++ b/src/akgentic/catalog/services/agent_catalog.py
@@ -6,7 +6,6 @@ import builtins
 import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from akgentic.agent.config import AgentConfig
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.team import TeamEntry, agent_in_members
@@ -99,8 +98,8 @@ class AgentCatalog:
 
         # AC2: Template @-reference validation
         config = entry.card.config
-        if isinstance(config, AgentConfig):
-            prompt = config.prompt
+        if hasattr(config, "prompt"):
+            prompt = config.prompt  # ADR-003: duck-type gate
             if _is_catalog_ref(prompt.template):
                 template_id = _resolve_ref(prompt.template)
                 tpl_entry = self._template_catalog.get(template_id)

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -152,8 +152,9 @@ class TemplateCatalog:
             for agent in self._agent_catalog.repository.list():
                 config = agent.card.config
                 if hasattr(config, "prompt"):
-                    if _is_catalog_ref(config.prompt.template):  # ADR-003: duck-type gate
-                        ref_id = _resolve_ref(config.prompt.template)
+                    prompt = config.prompt  # ADR-003: duck-type gate
+                    if _is_catalog_ref(prompt.template):
+                        ref_id = _resolve_ref(prompt.template)
                         if ref_id == id:
                             errors.append(
                                 f"Agent '{agent.id}' references template '@{id}' — cannot delete"

--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -6,7 +6,6 @@ import builtins
 import logging
 from typing import TYPE_CHECKING
 
-from akgentic.agent.config import AgentConfig
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.refs import _is_catalog_ref, _resolve_ref
@@ -152,8 +151,8 @@ class TemplateCatalog:
         if self._agent_catalog is not None:
             for agent in self._agent_catalog.repository.list():
                 config = agent.card.config
-                if isinstance(config, AgentConfig):
-                    if _is_catalog_ref(config.prompt.template):
+                if hasattr(config, "prompt"):
+                    if _is_catalog_ref(config.prompt.template):  # ADR-003: duck-type gate
                         ref_id = _resolve_ref(config.prompt.template)
                         if ref_id == id:
                             errors.append(


### PR DESCRIPTION
## Summary

- Remove all static `from akgentic.agent.config import AgentConfig` imports from catalog source code (4 files)
- Replace `isinstance(config, AgentConfig)` checks with duck-type `hasattr` gates per ADR-003
- Catalog now depends only on `akgentic-core`, `akgentic-llm`, and `akgentic-tool` at runtime

## Review Fixes Applied

- Consistent `config.prompt` local variable binding across all duck-typed files
- Updated `to_agent_card()` docstring to document duck-typed resolution behavior
- Eliminated redundant `hasattr` check by guarding `resolve_template()` call

## Verification

- 642 tests pass, ruff clean, mypy strict clean
- `grep -r "from akgentic.agent" src/` returns zero matches
- No `akgentic-agent` in `[project.dependencies]`

Closes #75