### PR TITLE
Support BaseConfig agents in AgentEntry

### DIFF
--- a/tests/models/test_agent_entry.py
+++ b/tests/models/test_agent_entry.py
@@ -328,6 +328,69 @@ class TestResolveTemplate:
         assert result.template == "You are a useful assistant"
 
 
+class TestBaseConfigAgent:
+    """Tests for AgentEntry with BaseConfig agents (HumanProxy, UserProxy).
+
+    Story 12-2: validates that duck-typed hasattr guards from story 12-1
+    correctly handle agents parameterized with BaseConfig (no prompt/tools).
+    """
+
+    def test_humanproxy_entry_creation(self) -> None:
+        """AC1: HumanProxy resolves to BaseConfig via MRO walk."""
+        card_data = _base_agent_card(
+            agent_class="akgentic.agent.HumanProxy",
+            config={"name": "@Human"},
+        )
+        entry = AgentEntry(id="human-proxy", card=card_data)
+        assert isinstance(entry.card.config, BaseConfig)
+        assert not hasattr(entry.card.config, "prompt")
+        assert not hasattr(entry.card.config, "tools")
+        assert entry.card.config.name == "@Human"
+
+    def test_to_agent_card_with_baseconfig(self) -> None:
+        """AC2: to_agent_card returns AgentCard with BaseConfig as-is."""
+        card_data = _base_agent_card(
+            agent_class="tests.models.test_agent_entry.BareConfigAgent",
+            config={"name": "bare-agent"},
+        )
+        entry = AgentEntry(id="bare", card=card_data)
+        tool_catalog = MockToolCatalog({})
+        template_catalog = MockTemplateCatalog({})
+
+        card = entry.to_agent_card(tool_catalog, template_catalog)
+        assert isinstance(card.config, BaseConfig)
+        assert card.config.name == "bare-agent"
+        assert card.role == "engineer"
+        assert card.description == "A test agent"
+
+    def test_to_agent_card_humanproxy_no_tools_no_prompt(self) -> None:
+        """AC2+AC4: HumanProxy card has no tools or prompt mutation."""
+        card_data = _base_agent_card(
+            agent_class="akgentic.agent.HumanProxy",
+            config={"name": "@Human"},
+            routes_to=["@Manager"],
+        )
+        entry = AgentEntry(id="human-proxy", tool_ids=[], card=card_data)
+        tool_catalog = MockToolCatalog({})
+        template_catalog = MockTemplateCatalog({})
+
+        card = entry.to_agent_card(tool_catalog, template_catalog)
+        assert isinstance(card.config, BaseConfig)
+        assert not hasattr(card.config, "prompt")
+        assert not hasattr(card.config, "tools")
+        assert card.routes_to == ["@Manager"]
+
+    def test_resolve_template_humanproxy_returns_none(self) -> None:
+        """AC3: resolve_template returns None for HumanProxy."""
+        card_data = _base_agent_card(
+            agent_class="akgentic.agent.HumanProxy",
+            config={"name": "@Human"},
+        )
+        entry = AgentEntry(id="human-proxy", card=card_data)
+        catalog = MockTemplateCatalog({})
+        assert entry.resolve_template(catalog) is None
+
+
 class TestPublicApi:
     """Tests for module exports."""
 

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from akgentic.agent.config import AgentConfig
 from akgentic.core.agent import Akgent
+from akgentic.core.agent_config import BaseConfig
 from akgentic.core.agent_state import BaseState
 from akgentic.tool.core import ToolCard
 
@@ -28,6 +29,10 @@ if TYPE_CHECKING:
 
 
 # --- Inline custom subclasses for FQCN stability ---
+
+
+class BareConfigAgent(Akgent[BaseConfig, BaseState]):
+    """Test agent using bare BaseConfig for round-trip testing."""
 
 
 class ResearchConfig(AgentConfig):
@@ -168,6 +173,36 @@ class TestRoundTripAgentEntry:
         assert restored.card.agent_class == "tests.models.test_round_trip.ResearchAgent"
         assert restored.card.metadata == {"source": "research-db", "version": 2}
         assert restored.id == "researcher"
+
+
+class TestRoundTripBaseConfigAgent:
+    """Story 12-2: BaseConfig agent entry round-trip serialization."""
+
+    def test_baseconfig_fields_survive_round_trip(self) -> None:
+        """BaseConfig agent survives model_dump -> model_validate."""
+        original = AgentEntry(
+            id="human-proxy",
+            tool_ids=[],
+            card={
+                "role": "Human",
+                "description": "User-facing proxy",
+                "skills": [],
+                "agent_class": "tests.models.test_round_trip.BareConfigAgent",
+                "config": {"name": "@Human", "role": "HumanProxy"},
+                "routes_to": ["@Manager"],
+            },
+        )
+        dumped = original.model_dump()
+        restored = AgentEntry.model_validate(dumped)
+
+        assert isinstance(restored.card.config, BaseConfig)
+        assert restored.card.config.name == "@Human"
+        assert restored.card.config.role == "HumanProxy"
+        assert restored.tool_ids == []
+        assert restored.card.role == "Human"
+        assert restored.card.description == "User-facing proxy"
+        assert restored.card.routes_to == ["@Manager"]
+        assert restored.id == "human-proxy"
 
 
 class TestRoundTripToolEntry:

--- a/tests/services/test_agent_catalog.py
+++ b/tests/services/test_agent_catalog.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import AgentQuery
 from akgentic.catalog.models.team import TeamMemberSpec, agent_in_members
@@ -371,3 +372,41 @@ class TestAgentInMembers:
 
     def test_empty_members(self) -> None:
         assert agent_in_members("agent-1", []) is False
+
+
+class TestBaseConfigAgentService:
+    """Story 12-2: AgentCatalog service with BaseConfig agents."""
+
+    @staticmethod
+    def _make_baseconfig_agent(
+        id: str = "human-proxy",
+        name: str = "@Human",
+    ) -> AgentEntry:
+        """Create an AgentEntry with a BaseConfig agent (HumanProxy)."""
+        return AgentEntry(
+            id=id,
+            tool_ids=[],
+            card={
+                "role": "Human",
+                "description": "User-facing proxy",
+                "skills": [],
+                "agent_class": "akgentic.agent.HumanProxy",
+                "config": {"name": name},
+                "routes_to": [],
+            },
+        )
+
+    def test_create_baseconfig_agent(self, catalog: AgentCatalog) -> None:
+        """BaseConfig agent can be created in the catalog."""
+        entry = self._make_baseconfig_agent()
+        result = catalog.create(entry)
+        assert result == "human-proxy"
+        assert catalog.get("human-proxy") is not None
+
+    def test_validate_baseconfig_agent_skips_template_check(
+        self, catalog: AgentCatalog
+    ) -> None:
+        """BaseConfig agent has no prompt — template validation is skipped."""
+        entry = self._make_baseconfig_agent()
+        errors = catalog.validate_create(entry)
+        assert errors == []


### PR DESCRIPTION
## Summary

- Add 7 tests covering BaseConfig agent path (HumanProxy, UserProxy) in AgentEntry model, round-trip serialization, and AgentCatalog service
- Validates duck-typed `hasattr` guards from story 12-1 work correctly for agents parameterized with `BaseConfig` instead of `AgentConfig`
- Test-only change — no source code modifications

## Test Coverage

**`tests/models/test_agent_entry.py`** — `TestBaseConfigAgent` (4 tests):
- HumanProxy entry creation with BaseConfig resolution via MRO walk
- `to_agent_card()` with BareConfigAgent returns card with BaseConfig as-is
- `to_agent_card()` with HumanProxy — no tools or prompt mutation
- `resolve_template()` returns None for HumanProxy

**`tests/models/test_round_trip.py`** — `TestRoundTripBaseConfigAgent` (1 test):
- BaseConfig fields survive `model_dump()` → `model_validate()` round-trip

**`tests/services/test_agent_catalog.py`** — `TestBaseConfigAgentService` (2 tests):
- `create()` with BaseConfig agent validates and persists
- `validate_create()` skips template validation for BaseConfig agent

## Results

- 649 tests pass (was 642)
- `ruff check` clean
- `mypy --strict` clean

Closes #77