### PR TITLE
Update TeamEntry entry_point to HumanProxy semantics

### DIFF
--- a/examples/03-team-entries.md
+++ b/examples/03-team-entries.md
@@ -9,12 +9,14 @@ Each node carries an `agent_id` (referencing an `AgentEntry` in the catalog),
 a `headcount` (defaulting to 1), and optional nested `members`. The tree can
 nest to arbitrary depth, mirroring real delegation chains.
 
-### entry_point Validation
+### entry_point as HumanProxy
 
-Every team has an `entry_point` — the agent that receives external messages
-(the "front door"). The catalog enforces that this agent_id appears somewhere
-in the `members` tree. An agent that only exists in `profiles` does not
-satisfy this check.
+Every team has an `entry_point` — the `AgentEntry.id` of the **HumanProxy**
+that sends the first message to the team. The HumanProxy is the user's proxy
+in the hierarchy, sitting at the root of the members tree. It uses `BaseConfig`
+(not `AgentConfig`) since it needs no prompt, tools, or LLM configuration.
+The catalog enforces that this agent_id appears somewhere in the `members` tree.
+An agent that only exists in `profiles` does not satisfy this check.
 
 ### headcount for Multi-Instance Agents
 
@@ -63,24 +65,48 @@ tree and profiles list actually exists.
 ### TeamEntry Construction
 
 ```python
+from akgentic.core import AgentCard, BaseConfig
+
+# HumanProxy agent — uses BaseConfig, no prompt/tools/LLM
+human_proxy_entry = AgentEntry(
+    id="human-proxy",
+    tool_ids=[],
+    card=AgentCard(
+        role="Human",
+        description="User-facing proxy that sends the first message",
+        skills=[],
+        agent_class="akgentic.agent.HumanProxy",
+        config=BaseConfig(name="@Human"),
+        routes_to=["@Manager"],
+    ),
+)
+
 TeamEntry(
     id="research-team",
     name="Research Team",
-    entry_point="manager",
+    entry_point="human-proxy",  # HumanProxy is the entry point
     message_types=["akgentic.agent.messages.AgentMessage"],
     members=[
         TeamMemberSpec(
-            agent_id="manager",
+            agent_id="human-proxy",
             members=[
-                TeamMemberSpec(agent_id="researcher", headcount=2,
-                               members=[TeamMemberSpec(agent_id="analyst")]),
-                TeamMemberSpec(agent_id="reviewer"),
+                TeamMemberSpec(
+                    agent_id="manager",
+                    members=[
+                        TeamMemberSpec(agent_id="researcher", headcount=2,
+                                       members=[TeamMemberSpec(agent_id="analyst")]),
+                        TeamMemberSpec(agent_id="reviewer"),
+                    ],
+                ),
             ],
         ),
     ],
     profiles=["specialist"],
 )
 ```
+
+The hierarchy is: `human-proxy` → `manager` → `researcher`/`reviewer` → `analyst`.
+The HumanProxy sits at the root, sending the first message to the manager.
 
 ### resolve_entry_point() and resolve_message_types()
 
@@ -108,9 +134,9 @@ team_catalog.search(TeamQuery(name="research"))
 
 ## Common Pitfalls
 
-- **entry_point must be in the members tree, not just any agent.** An agent
-  that only appears in `profiles` will fail validation. The entry point is
-  the team's front door — it must be part of the startup hierarchy.
+- **entry_point must be the HumanProxy in the members tree.** The entry point
+  is the HumanProxy that sends the first message to the team. It must appear
+  in the `members` tree — an agent only in `profiles` will fail validation.
 
 - **profiles are not instantiated at startup.** They are available for
   runtime hiring only. Do not expect a profiles-only agent to receive

--- a/examples/03-team-entries.md
+++ b/examples/03-team-entries.md
@@ -11,12 +11,14 @@ nest to arbitrary depth, mirroring real delegation chains.
 
 ### entry_point as HumanProxy
 
-Every team has an `entry_point` — the `AgentEntry.id` of the **HumanProxy**
-that sends the first message to the team. The HumanProxy is the user's proxy
-in the hierarchy, sitting at the root of the members tree. It uses `BaseConfig`
-(not `AgentConfig`) since it needs no prompt, tools, or LLM configuration.
-The catalog enforces that this agent_id appears somewhere in the `members` tree.
-An agent that only exists in `profiles` does not satisfy this check.
+Every team has an `entry_point` — by ADR-003 convention, this is the
+`AgentEntry.id` of the **HumanProxy** that sends the first message to the
+team. The HumanProxy is the user's proxy in the hierarchy, sitting at the
+root of the members tree. It uses `BaseConfig` (not `AgentConfig`) since it
+needs no prompt, tools, or LLM configuration. The catalog enforces that the
+entry_point agent_id appears somewhere in the `members` tree (any agent is
+technically valid, but HumanProxy is the recommended pattern). An agent that
+only exists in `profiles` does not satisfy this check.
 
 ### headcount for Multi-Instance Agents
 
@@ -134,9 +136,10 @@ team_catalog.search(TeamQuery(name="research"))
 
 ## Common Pitfalls
 
-- **entry_point must be the HumanProxy in the members tree.** The entry point
-  is the HumanProxy that sends the first message to the team. It must appear
-  in the `members` tree — an agent only in `profiles` will fail validation.
+- **entry_point should be the HumanProxy in the members tree (per ADR-003).**
+  By convention, the entry point is the HumanProxy that sends the first message
+  to the team. It must appear in the `members` tree — an agent only in
+  `profiles` will fail validation.
 
 - **profiles are not instantiated at startup.** They are available for
   runtime hiring only. Do not expect a profiles-only agent to receive

--- a/examples/03_team_entries.py
+++ b/examples/03_team_entries.py
@@ -9,7 +9,7 @@ catalog services (Template, Tool, Agent, **Team**) wired together.
 What you'll learn
 -----------------
 * ``TeamEntry`` with nested ``TeamMemberSpec`` for multi-level hierarchies
-* ``entry_point`` validation — must reference an agent in the members tree
+* ``entry_point`` as HumanProxy — the user's proxy that sends the first message
 * ``headcount`` for multi-instance agents (e.g. two researchers)
 * ``members`` vs ``profiles`` — startup instantiation vs runtime hiring pool
 * ``message_types`` FQCN validation at registration time
@@ -18,9 +18,10 @@ What you'll learn
 Explanation
 -----------
 A ``TeamEntry`` defines how agents are composed into a working team.  The
-``members`` tree mirrors the delegation hierarchy from ``agent_team.py``:
-the manager receives external messages (``entry_point``), delegates to
-researchers and reviewers, and researchers further delegate to analysts.
+``members`` tree starts with a **HumanProxy** as the ``entry_point`` — the
+user's proxy that sends the first message to the team.  The HumanProxy
+delegates to the manager, who further delegates to researchers, reviewers,
+and analysts.
 
 ``profiles`` lists agents that the orchestrator can hire on-demand at
 runtime — like an Expert who joins only when needed — but are **not** part
@@ -38,7 +39,7 @@ import tempfile
 from pathlib import Path
 
 from akgentic.agent.config import AgentConfig
-from akgentic.core import AgentCard
+from akgentic.core import AgentCard, BaseConfig
 from akgentic.llm.config import ModelConfig
 from akgentic.llm.prompts import PromptTemplate
 
@@ -111,8 +112,8 @@ def main() -> None:
         print(f"Created ToolEntry: id={web_search_entry.id!r}")
         print()
 
-        # --- Create 5 agents (leaf-first for routes_to validation) ---
-        print("=== Creating 5 Agents (leaf-first order) ===\n")
+        # --- Create 6 agents (leaf-first for routes_to validation) ---
+        print("=== Creating 6 Agents (leaf-first order) ===\n")
 
         analyst_entry = AgentEntry(
             id="analyst",
@@ -251,6 +252,21 @@ def main() -> None:
         )
         agent_catalog.create(manager_entry)
         print(f"  Created: id={manager_entry.id!r} (routes to @Researcher, @Reviewer)")
+
+        human_proxy_entry = AgentEntry(
+            id="human-proxy",
+            tool_ids=[],
+            card=AgentCard(
+                role="Human",
+                description="User-facing proxy that sends the first message",
+                skills=[],
+                agent_class="akgentic.agent.HumanProxy",
+                config=BaseConfig(name="@Human"),
+                routes_to=["@Manager"],
+            ),
+        )
+        agent_catalog.create(human_proxy_entry)
+        print(f"  Created: id={human_proxy_entry.id!r} (routes to @Manager)")
         print()
 
         # --- Create TeamEntry with nested member tree ---
@@ -260,21 +276,27 @@ def main() -> None:
             id="research-team",
             name="Research Team",
             description="Multi-level research team with hierarchical delegation",
-            entry_point="manager",
+            entry_point="human-proxy",
             message_types=["akgentic.agent.messages.AgentMessage"],
             members=[
                 TeamMemberSpec(
-                    agent_id="manager",
+                    agent_id="human-proxy",
                     headcount=1,
                     members=[
                         TeamMemberSpec(
-                            agent_id="researcher",
-                            headcount=2,
+                            agent_id="manager",
+                            headcount=1,
                             members=[
-                                TeamMemberSpec(agent_id="analyst"),
+                                TeamMemberSpec(
+                                    agent_id="researcher",
+                                    headcount=2,
+                                    members=[
+                                        TeamMemberSpec(agent_id="analyst"),
+                                    ],
+                                ),
+                                TeamMemberSpec(agent_id="reviewer"),
                             ],
                         ),
-                        TeamMemberSpec(agent_id="reviewer"),
                     ],
                 ),
             ],
@@ -288,10 +310,11 @@ def main() -> None:
         print(f"  message_types: {research_team.message_types}")
         print(f"  profiles     : {research_team.profiles}")
         print("  members tree :")
-        print("    manager (entry_point)")
-        print("      ├── researcher (headcount=2)")
-        print("      │     └── analyst")
-        print("      └── reviewer")
+        print("    human-proxy (entry_point)")
+        print("      └── manager")
+        print("            ├── researcher (headcount=2)")
+        print("            │     └── analyst")
+        print("            └── reviewer")
         print()
 
         # --- get() and inspect ---
@@ -318,9 +341,10 @@ def main() -> None:
         print("=== resolve_entry_point() ===\n")
 
         entry_agent = retrieved.resolve_entry_point(agent_catalog)
-        print(f"Resolved entry_point '{retrieved.entry_point}':")
-        print(f"  role       : {entry_agent.card.role!r}")
-        print(f"  config.name: {entry_agent.card.config.name!r}")
+        print(f"Resolved entry_point '{retrieved.entry_point}' (HumanProxy):")
+        print(f"  role        : {entry_agent.card.role!r}")
+        print(f"  agent_class : {entry_agent.card.agent_class!r}")
+        print(f"  config.name : {entry_agent.card.config.name!r}")
         print()
 
         # --- resolve_message_types() ---

--- a/examples/03_team_entries.py
+++ b/examples/03_team_entries.py
@@ -255,7 +255,6 @@ def main() -> None:
 
         human_proxy_entry = AgentEntry(
             id="human-proxy",
-            tool_ids=[],
             card=AgentCard(
                 role="Human",
                 description="User-facing proxy that sends the first message",

--- a/examples/05_catalog_wiring.py
+++ b/examples/05_catalog_wiring.py
@@ -51,7 +51,7 @@ import tempfile
 from pathlib import Path
 
 from akgentic.agent.config import AgentConfig
-from akgentic.core import AgentCard
+from akgentic.core import AgentCard, BaseConfig
 from akgentic.llm.config import ModelConfig
 from akgentic.llm.prompts import PromptTemplate
 
@@ -203,18 +203,39 @@ def main() -> None:
             f"routes_to={researcher_entry.card.routes_to})"
         )
 
-        # Team with nested member tree
+        human_proxy_entry = AgentEntry(
+            id="human-proxy",
+            tool_ids=[],
+            card=AgentCard(
+                role="Human",
+                description="User-facing proxy that sends the first message",
+                skills=[],
+                agent_class="akgentic.agent.HumanProxy",
+                config=BaseConfig(name="@Human"),
+                routes_to=["@Researcher"],
+            ),
+        )
+        agent_catalog.create(human_proxy_entry)
+        print(f"  Created agent: {human_proxy_entry.id!r} (HumanProxy, routes_to=['@Researcher'])")
+
+        # Team with nested member tree — human-proxy is entry_point
         research_team = TeamEntry(
             id="research-team",
             name="Research Team",
             description="A team for research tasks",
-            entry_point="researcher",
+            entry_point="human-proxy",
             message_types=["akgentic.agent.messages.AgentMessage"],
             members=[
                 TeamMemberSpec(
-                    agent_id="researcher",
+                    agent_id="human-proxy",
                     headcount=1,
-                    members=[TeamMemberSpec(agent_id="reviewer", headcount=1)],
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="researcher",
+                            headcount=1,
+                            members=[TeamMemberSpec(agent_id="reviewer", headcount=1)],
+                        ),
+                    ],
                 ),
             ],
         )
@@ -291,11 +312,12 @@ def main() -> None:
         assert team_catalog.list() == []
         print("  Deleted team 'research-team' — team list is now empty")
 
-        # Agents next
+        # Agents next — reverse dependency order: human-proxy → researcher → reviewer
+        agent_catalog.delete("human-proxy")
         agent_catalog.delete("researcher")
         agent_catalog.delete("reviewer")
         assert agent_catalog.list() == []
-        print("  Deleted agents 'researcher', 'reviewer' — agent list is now empty")
+        print("  Deleted agents 'human-proxy', 'researcher', 'reviewer' — agent list is now empty")
 
         # Tools and templates last
         tool_catalog.delete("web-search")
@@ -317,6 +339,7 @@ def main() -> None:
         tool_catalog.create(web_search_tool)
         agent_catalog.create(reviewer_entry)
         agent_catalog.create(researcher_entry)
+        agent_catalog.create(human_proxy_entry)
 
         # Failed update: invalid tool reference
         bad_update = copy.deepcopy(researcher_entry)

--- a/examples/05_catalog_wiring.py
+++ b/examples/05_catalog_wiring.py
@@ -205,7 +205,6 @@ def main() -> None:
 
         human_proxy_entry = AgentEntry(
             id="human-proxy",
-            tool_ids=[],
             card=AgentCard(
                 role="Human",
                 description="User-facing proxy that sends the first message",

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -60,7 +60,10 @@ class TeamEntry(BaseModel):
     id: NonEmptyStr = Field(description="Unique catalog identifier for this team")
     name: NonEmptyStr = Field(description="Human-readable team name")
     entry_point: NonEmptyStr = Field(
-        description="AgentEntry.id of the HumanProxy that sends the first message to the team"
+        description=(
+            "AgentEntry.id of the HumanProxy that sends the first message"
+            " to the team (ADR-003 convention)"
+        )
     )
     message_types: list[NonEmptyStr] = Field(
         min_length=1, description="Fully qualified class paths for accepted message types"

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -60,7 +60,7 @@ class TeamEntry(BaseModel):
     id: NonEmptyStr = Field(description="Unique catalog identifier for this team")
     name: NonEmptyStr = Field(description="Human-readable team name")
     entry_point: NonEmptyStr = Field(
-        description="AgentEntry.id that serves as the team front door for external messages"
+        description="AgentEntry.id of the HumanProxy that sends the first message to the team"
     )
     message_types: list[NonEmptyStr] = Field(
         min_length=1, description="Fully qualified class paths for accepted message types"


### PR DESCRIPTION
## Summary

- Update `TeamEntry.entry_point` field description to reference HumanProxy as the conventional entry point per ADR-003
- Restructure examples 03 and 05 to use a `human-proxy` AgentEntry (BaseConfig) at the root of the members tree
- Update `03-team-entries.md` documentation with HumanProxy entry_point semantics and convention qualifiers
- Code review fixes: clarify convention vs constraint in field description and docs, remove redundant `tool_ids=[]`

Closes #79