### PR TITLE
fix: rename shadowed id parameter in catalog service get methods

### DIFF
--- a/src/akgentic/catalog/services/template_catalog.py
+++ b/src/akgentic/catalog/services/template_catalog.py
@@ -82,16 +82,16 @@ class TemplateCatalog:
         logger.info("template created: %s", entry.id)
         return result
 
-    def get(self, id: str) -> TemplateEntry | None:
+    def get(self, template_id: str) -> TemplateEntry | None:
         """Retrieve a template entry by id.
 
         Args:
-            id: The template entry id.
+            template_id: The template entry id.
 
         Returns:
             The template entry, or None if not found.
         """
-        return self.repository.get(id)
+        return self.repository.get(template_id)
 
     def list(self) -> _list[TemplateEntry]:
         """List all template entries.

--- a/src/akgentic/catalog/services/tool_catalog.py
+++ b/src/akgentic/catalog/services/tool_catalog.py
@@ -81,16 +81,16 @@ class ToolCatalog:
         logger.info("tool created: %s", entry.id)
         return result
 
-    def get(self, id: str) -> ToolEntry | None:
+    def get(self, tool_id: str) -> ToolEntry | None:
         """Retrieve a tool entry by id.
 
         Args:
-            id: The tool entry id.
+            tool_id: The tool entry id.
 
         Returns:
             The tool entry, or None if not found.
         """
-        return self.repository.get(id)
+        return self.repository.get(tool_id)
 
     def list(self) -> _list[ToolEntry]:
         """List all tool entries.


### PR DESCRIPTION
## Summary

- Rename `id` → `template_id` in `TemplateCatalog.get()` to match protocol signature
- Rename `id` → `tool_id` in `ToolCatalog.get()` to match protocol signature
- Fixes lint errors in `catalog_team.py` caused by parameter name mismatch between implementation and protocol

Relates to #83