### PR TITLE
TeamEntry.to_team_card() catalog-to-runtime bridge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyyaml>=6.0",
     "akgentic",
     "akgentic-tool",
+    "akgentic-team",
 ]
 
 [project.optional-dependencies]
@@ -52,6 +53,7 @@ packages = ["src/akgentic"]
 [tool.uv.sources]
 akgentic = { workspace = true }
 akgentic-tool = { workspace = true }
+akgentic-team = { workspace = true }
 
 # Tool configurations inherit from root workspace pyproject.toml
 # Only override when package-specific behavior is needed

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -10,6 +10,7 @@ from akgentic.catalog.models._types import NonEmptyStr
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.core.utils.deserializer import import_class
+from akgentic.team.models import TeamCard, TeamCardMember
 
 __all__ = [
     "TeamMemberSpec",
@@ -77,6 +78,93 @@ class TeamEntry(BaseModel):
     description: str = Field(
         default="", description="Optional team description for catalog browsing"
     )
+
+    @staticmethod
+    def _resolve_members(
+        specs: list[TeamMemberSpec],
+        agent_catalog: _AgentCatalogProtocol,
+        errors: list[str],
+    ) -> list[tuple[str, TeamCardMember]]:
+        """Recursively resolve TeamMemberSpec list to (agent_id, TeamCardMember) pairs.
+
+        Args:
+            specs: Member specifications to resolve.
+            agent_catalog: Catalog service providing agent lookups.
+            errors: Accumulator for error messages (mutated in place).
+
+        Returns:
+            List of (agent_id, TeamCardMember) tuples for successfully resolved members.
+        """
+        resolved: list[tuple[str, TeamCardMember]] = []
+        for spec in specs:
+            entry: AgentEntry | None = agent_catalog.get(spec.agent_id)
+            if entry is None:
+                errors.append(f"Agent '{spec.agent_id}' not found in catalog")
+                # Still recurse children to collect all errors
+                TeamEntry._resolve_members(spec.members, agent_catalog, errors)
+                continue
+            children = TeamEntry._resolve_members(spec.members, agent_catalog, errors)
+            member = TeamCardMember(
+                card=entry.card,
+                headcount=spec.headcount,
+                members=[m for _, m in children],
+            )
+            resolved.append((spec.agent_id, member))
+        return resolved
+
+    def to_team_card(self, agent_catalog: _AgentCatalogProtocol) -> TeamCard:
+        """Resolve all string IDs into a runtime-ready TeamCard.
+
+        Converts the catalog-level TeamEntry (string IDs, FQCN message types)
+        into a runtime-ready TeamCard (resolved AgentCards, Python classes).
+
+        Args:
+            agent_catalog: Catalog service providing agent lookups.
+
+        Returns:
+            A TeamCard with fully resolved members, entry_point, and message_types.
+
+        Raises:
+            CatalogValidationError: If any agents are missing or message types
+                cannot be resolved. Collects ALL errors before raising.
+        """
+        errors: list[str] = []
+
+        # 1. Resolve members tree
+        resolved_pairs = self._resolve_members(self.members, agent_catalog, errors)
+
+        # 2. Resolve message types (collect errors, don't fail fast)
+        resolved_message_types: list[type] = []
+        try:
+            resolved_message_types = self.resolve_message_types()
+        except CatalogValidationError as e:
+            errors.extend(e.errors)
+
+        # 3. Raise all collected errors
+        if errors:
+            raise CatalogValidationError(errors)
+
+        # 4. Find entry_point in resolved top-level members
+        entry_point_member: TeamCardMember | None = None
+        remaining_members: list[TeamCardMember] = []
+        for agent_id, member in resolved_pairs:
+            if agent_id == self.entry_point:
+                entry_point_member = member
+            else:
+                remaining_members.append(member)
+
+        if entry_point_member is None:
+            raise CatalogValidationError(
+                [f"Entry point '{self.entry_point}' not found in resolved top-level members"]
+            )
+
+        return TeamCard(
+            name=self.name,
+            description=self.description,
+            entry_point=entry_point_member,
+            members=remaining_members,
+            message_types=resolved_message_types,
+        )
 
     def resolve_entry_point(self, agent_catalog: _AgentCatalogProtocol) -> AgentEntry:
         """Resolve entry_point id to the full AgentEntry from the catalog.

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -148,7 +148,7 @@ class TeamEntry(BaseModel):
         entry_point_member: TeamCardMember | None = None
         remaining_members: list[TeamCardMember] = []
         for agent_id, member in resolved_pairs:
-            if agent_id == self.entry_point:
+            if agent_id == self.entry_point and entry_point_member is None:
                 entry_point_member = member
             else:
                 remaining_members.append(member)

--- a/tests/models/test_team_entry_to_team_card.py
+++ b/tests/models/test_team_entry_to_team_card.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import pytest
+from akgentic.team.models import TeamCard, TeamCardMember
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError
-from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
-from akgentic.team.models import TeamCard, TeamCardMember
-
+from akgentic.catalog.models.team import TeamMemberSpec
 from tests.conftest import make_agent, make_team
 
 
@@ -345,3 +344,93 @@ class TestMessageTypesResolution:
         from pydantic import BaseModel
 
         assert result.message_types == [BaseModel]
+
+
+# ---------------------------------------------------------------------------
+# Edge case — entry_point not in top-level members
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointNotInMembers:
+    """to_team_card raises when entry_point is not among top-level resolved members."""
+
+    def test_entry_point_not_in_members_raises(self) -> None:
+        proxy = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(proxy, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                # proxy is only a child of worker, NOT at the top level
+                TeamMemberSpec(
+                    agent_id="worker",
+                    members=[TeamMemberSpec(agent_id="proxy")],
+                ),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert len(exc_info.value.errors) == 1
+        assert "Entry point" in exc_info.value.errors[0]
+        assert "proxy" in exc_info.value.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Edge case — missing agent in nested (child) members
+# ---------------------------------------------------------------------------
+
+
+class TestNestedMissingAgent:
+    """to_team_card collects errors from nested missing agents."""
+
+    def test_missing_nested_child_agent(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        manager = make_agent(id="manager", name="manager-agent")
+        catalog = _catalog_from(ep, manager)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(
+                    agent_id="manager",
+                    members=[TeamMemberSpec(agent_id="ghost-nested")],
+                ),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert len(exc_info.value.errors) == 1
+        assert "ghost-nested" in exc_info.value.errors[0]
+
+    def test_missing_agents_at_multiple_levels(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(
+                    agent_id="ghost-top",
+                    members=[TeamMemberSpec(agent_id="ghost-child")],
+                ),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        errors = exc_info.value.errors
+        assert len(errors) == 2
+        error_text = " ".join(errors)
+        assert "ghost-top" in error_text
+        assert "ghost-child" in error_text

--- a/tests/models/test_team_entry_to_team_card.py
+++ b/tests/models/test_team_entry_to_team_card.py
@@ -1,0 +1,347 @@
+"""Tests for TeamEntry.to_team_card() — catalog-to-runtime bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
+from akgentic.team.models import TeamCard, TeamCardMember
+
+from tests.conftest import make_agent, make_team
+
+
+class StubAgentCatalog:
+    """Minimal agent catalog stub satisfying _AgentCatalogProtocol."""
+
+    def __init__(self, entries: dict[str, AgentEntry]) -> None:
+        self._entries = entries
+
+    def get(self, agent_id: str) -> AgentEntry | None:
+        return self._entries.get(agent_id)
+
+
+def _catalog_from(*agents: AgentEntry) -> StubAgentCatalog:
+    """Build a StubAgentCatalog from a list of AgentEntry objects."""
+    return StubAgentCatalog({a.id: a for a in agents})
+
+
+# ---------------------------------------------------------------------------
+# Happy path — flat members
+# ---------------------------------------------------------------------------
+
+
+class TestFlatMembers:
+    """to_team_card with a single level of members."""
+
+    def test_returns_team_card(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(ep, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert isinstance(result, TeamCard)
+
+    def test_entry_point_is_correct_member(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(ep, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert isinstance(result.entry_point, TeamCardMember)
+        assert result.entry_point.card.config.name == "proxy-agent"
+
+    def test_remaining_members_exclude_entry_point(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(ep, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert len(result.members) == 1
+        assert result.members[0].card.config.name == "worker-agent"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — nested members (3 levels)
+# ---------------------------------------------------------------------------
+
+
+class TestNestedMembers:
+    """to_team_card with 3-level member hierarchy."""
+
+    def test_recursive_resolution(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        mgr = make_agent(id="manager", name="manager-agent")
+        lead = make_agent(id="lead", name="lead-agent")
+        dev = make_agent(id="dev", name="dev-agent")
+        catalog = _catalog_from(ep, mgr, lead, dev)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(
+                    agent_id="manager",
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="lead",
+                            members=[TeamMemberSpec(agent_id="dev")],
+                        ),
+                    ],
+                ),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        # manager is in members (entry_point is proxy)
+        assert len(result.members) == 1
+        manager_member = result.members[0]
+        assert manager_member.card.config.name == "manager-agent"
+
+        # lead is nested under manager
+        assert len(manager_member.members) == 1
+        lead_member = manager_member.members[0]
+        assert lead_member.card.config.name == "lead-agent"
+
+        # dev is nested under lead
+        assert len(lead_member.members) == 1
+        dev_member = lead_member.members[0]
+        assert dev_member.card.config.name == "dev-agent"
+        assert dev_member.members == []
+
+
+# ---------------------------------------------------------------------------
+# Headcount preservation
+# ---------------------------------------------------------------------------
+
+
+class TestHeadcount:
+    """to_team_card preserves headcount from TeamMemberSpec."""
+
+    def test_headcount_preserved(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(ep, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker", headcount=5),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert result.members[0].headcount == 5
+
+    def test_default_headcount_is_one(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        worker = make_agent(id="worker", name="worker-agent")
+        catalog = _catalog_from(ep, worker)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert result.entry_point.headcount == 1
+        assert result.members[0].headcount == 1
+
+
+# ---------------------------------------------------------------------------
+# Name and description passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPassthrough:
+    """to_team_card passes name and description through."""
+
+    def test_name_and_description(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            id="my-team",
+            name="My Great Team",
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            message_types=["pydantic.BaseModel"],
+        )
+        team.description = "A team that does great things"
+
+        result = team.to_team_card(catalog)
+
+        assert result.name == "My Great Team"
+        assert result.description == "A team that does great things"
+
+
+# ---------------------------------------------------------------------------
+# Error collection — missing agents
+# ---------------------------------------------------------------------------
+
+
+class TestMissingAgents:
+    """to_team_card collects ALL missing agent errors."""
+
+    def test_single_missing_agent(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="missing-agent"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert len(exc_info.value.errors) == 1
+        assert "missing-agent" in exc_info.value.errors[0]
+
+    def test_multiple_missing_agents(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="ghost-1"),
+                TeamMemberSpec(agent_id="ghost-2"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert len(exc_info.value.errors) == 2
+        error_text = " ".join(exc_info.value.errors)
+        assert "ghost-1" in error_text
+        assert "ghost-2" in error_text
+
+
+# ---------------------------------------------------------------------------
+# Error collection — unresolvable message types
+# ---------------------------------------------------------------------------
+
+
+class TestBadMessageTypes:
+    """to_team_card collects ALL message type resolution errors."""
+
+    def test_unresolvable_message_type(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            message_types=["no.such.module.FakeClass"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert len(exc_info.value.errors) == 1
+        assert "no.such.module.FakeClass" in exc_info.value.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Combined errors — missing agents + bad message types
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedErrors:
+    """to_team_card collects errors from both members and message types."""
+
+    def test_combined_errors(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="missing-1"),
+            ],
+            message_types=["no.such.module.BadClass"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        errors = exc_info.value.errors
+        assert len(errors) == 2
+        error_text = " ".join(errors)
+        assert "missing-1" in error_text
+        assert "no.such.module.BadClass" in error_text
+
+
+# ---------------------------------------------------------------------------
+# Message types resolution — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestMessageTypesResolution:
+    """to_team_card resolves FQCN strings to Python classes."""
+
+    def test_message_types_resolved(self) -> None:
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        from pydantic import BaseModel
+
+        assert result.message_types == [BaseModel]


### PR DESCRIPTION
## Summary

- Implements `TeamEntry.to_team_card(agent_catalog)` that resolves all string IDs into a runtime-ready `TeamCard` with fully resolved `TeamCardMember` objects, Python classes for message types, and extracted entry point
- Adds `akgentic-team` as a dependency to enable `TeamCard`/`TeamCardMember` imports
- 15 tests covering happy path (flat/nested members), error collection (missing agents, bad message types, combined), headcount preservation, name/description passthrough, and edge cases

## Code Review Fixes Applied

| Severity | Issue | Fix |
|----------|-------|-----|
| MEDIUM | Duplicate entry_point silently takes last match | Added `and entry_point_member is None` guard — first match wins |
| MEDIUM | Entry_point-not-in-top-level error path untested | Added `TestEntryPointNotInMembers` test class |
| MEDIUM | Nested missing agent error collection untested | Added `TestNestedMissingAgent` with 2 tests |
| MEDIUM | Unused import + unsorted import block in tests | Applied ruff --fix |

## Verification

- 664 tests pass (661 existing + 3 new)
- ruff check: clean
- mypy: 0 catalog errors (4 pre-existing in akgentic-core)

Closes #85