### PR TITLE
fix: resolve tools and templates in to_team_card() member resolution

### DIFF
--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -7,7 +7,11 @@ from typing import Any, Protocol
 from pydantic import BaseModel, Field
 
 from akgentic.catalog.models._types import NonEmptyStr
-from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.agent import (
+    AgentEntry,
+    _TemplateCatalogProtocol,
+    _ToolCatalogProtocol,
+)
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.core.utils.deserializer import import_class
 from akgentic.team.models import TeamCard, TeamCardMember
@@ -84,6 +88,8 @@ class TeamEntry(BaseModel):
         specs: list[TeamMemberSpec],
         agent_catalog: _AgentCatalogProtocol,
         errors: list[str],
+        tool_catalog: _ToolCatalogProtocol | None = None,
+        template_catalog: _TemplateCatalogProtocol | None = None,
     ) -> list[tuple[str, TeamCardMember]]:
         """Recursively resolve TeamMemberSpec list to (agent_id, TeamCardMember) pairs.
 
@@ -91,6 +97,8 @@ class TeamEntry(BaseModel):
             specs: Member specifications to resolve.
             agent_catalog: Catalog service providing agent lookups.
             errors: Accumulator for error messages (mutated in place).
+            tool_catalog: Optional tool catalog for resolving tool_ids to ToolCards.
+            template_catalog: Optional template catalog for resolving @-refs.
 
         Returns:
             List of (agent_id, TeamCardMember) tuples for successfully resolved members.
@@ -101,25 +109,50 @@ class TeamEntry(BaseModel):
             if entry is None:
                 errors.append(f"Agent '{spec.agent_id}' not found in catalog")
                 # Still recurse children to collect all errors
-                TeamEntry._resolve_members(spec.members, agent_catalog, errors)
+                TeamEntry._resolve_members(
+                    spec.members, agent_catalog, errors, tool_catalog, template_catalog,
+                )
                 continue
-            children = TeamEntry._resolve_members(spec.members, agent_catalog, errors)
+            children = TeamEntry._resolve_members(
+                spec.members, agent_catalog, errors, tool_catalog, template_catalog,
+            )
+            # Use fully resolved card (tools + templates) when catalogs are available
+            if tool_catalog is not None and template_catalog is not None:
+                try:
+                    card = entry.to_agent_card(tool_catalog, template_catalog)
+                except CatalogValidationError as e:
+                    errors.extend(e.errors)
+                    card = entry.card
+            else:
+                card = entry.card
             member = TeamCardMember(
-                card=entry.card,
+                card=card,
                 headcount=spec.headcount,
                 members=[m for _, m in children],
             )
             resolved.append((spec.agent_id, member))
         return resolved
 
-    def to_team_card(self, agent_catalog: _AgentCatalogProtocol) -> TeamCard:
+    def to_team_card(
+        self,
+        agent_catalog: _AgentCatalogProtocol,
+        tool_catalog: _ToolCatalogProtocol | None = None,
+        template_catalog: _TemplateCatalogProtocol | None = None,
+    ) -> TeamCard:
         """Resolve all string IDs into a runtime-ready TeamCard.
 
         Converts the catalog-level TeamEntry (string IDs, FQCN message types)
         into a runtime-ready TeamCard (resolved AgentCards, Python classes).
 
+        When ``tool_catalog`` and ``template_catalog`` are provided, each
+        member's ``AgentCard`` is fully resolved via ``AgentEntry.to_agent_card``
+        (tools populated, prompt templates expanded).  Without them, the raw
+        ``entry.card`` is used (tools may be empty, templates unresolved).
+
         Args:
             agent_catalog: Catalog service providing agent lookups.
+            tool_catalog: Optional tool catalog for resolving tool_ids to ToolCards.
+            template_catalog: Optional template catalog for resolving @-refs.
 
         Returns:
             A TeamCard with fully resolved members, entry_point, and message_types.
@@ -131,7 +164,9 @@ class TeamEntry(BaseModel):
         errors: list[str] = []
 
         # 1. Resolve members tree
-        resolved_pairs = self._resolve_members(self.members, agent_catalog, errors)
+        resolved_pairs = self._resolve_members(
+            self.members, agent_catalog, errors, tool_catalog, template_catalog,
+        )
 
         # 2. Resolve message types (collect errors, don't fail fast)
         resolved_message_types: list[type] = []

--- a/tests/models/test_team_entry_to_team_card.py
+++ b/tests/models/test_team_entry_to_team_card.py
@@ -8,7 +8,9 @@ from akgentic.team.models import TeamCard, TeamCardMember
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.models.team import TeamMemberSpec
-from tests.conftest import make_agent, make_team
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.models.tool import ToolEntry
+from tests.conftest import make_agent, make_team, make_template, make_tool
 
 
 class StubAgentCatalog:
@@ -19,6 +21,26 @@ class StubAgentCatalog:
 
     def get(self, agent_id: str) -> AgentEntry | None:
         return self._entries.get(agent_id)
+
+
+class StubToolCatalog:
+    """Minimal tool catalog stub satisfying _ToolCatalogProtocol."""
+
+    def __init__(self, entries: dict[str, ToolEntry]) -> None:
+        self._entries = entries
+
+    def get(self, tool_id: str) -> ToolEntry | None:
+        return self._entries.get(tool_id)
+
+
+class StubTemplateCatalog:
+    """Minimal template catalog stub satisfying _TemplateCatalogProtocol."""
+
+    def __init__(self, entries: dict[str, TemplateEntry]) -> None:
+        self._entries = entries
+
+    def get(self, template_id: str) -> TemplateEntry | None:
+        return self._entries.get(template_id)
 
 
 def _catalog_from(*agents: AgentEntry) -> StubAgentCatalog:
@@ -434,3 +456,173 @@ class TestNestedMissingAgent:
         error_text = " ".join(errors)
         assert "ghost-top" in error_text
         assert "ghost-child" in error_text
+
+
+# ---------------------------------------------------------------------------
+# Tool and template resolution via to_team_card
+# ---------------------------------------------------------------------------
+
+
+class TestToolResolution:
+    """to_team_card resolves tools when tool_catalog and template_catalog are provided."""
+
+    def test_tools_resolved_when_catalogs_provided(self) -> None:
+        agent = make_agent(id="worker", name="worker-agent", tool_ids=["search-1"])
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        tool = make_tool(id="search-1")
+        tool_catalog = StubToolCatalog({"search-1": tool})
+        template_catalog = StubTemplateCatalog({})
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        worker_card = result.members[0].card
+        tools = getattr(worker_card.config, "tools", [])
+        assert len(tools) == 1
+        assert tools[0].name == "search"
+
+    def test_tools_empty_without_catalogs(self) -> None:
+        agent = make_agent(id="worker", name="worker-agent", tool_ids=["search-1"])
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        # Without tool/template catalogs, falls back to raw card (empty tools)
+        result = team.to_team_card(agent_catalog)
+
+        worker_card = result.members[0].card
+        tools = getattr(worker_card.config, "tools", [])
+        assert tools == []
+
+
+class TestTemplateResolution:
+    """to_team_card resolves prompt templates when catalogs are provided."""
+
+    def test_template_resolved_when_catalogs_provided(self) -> None:
+        agent = make_agent(
+            id="worker",
+            name="worker-agent",
+            template_ref="@sys-prompt",
+            params={"role": "expert", "instructions": "Be helpful."},
+        )
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        template = make_template(id="sys-prompt", template="You are {role}. {instructions}")
+        tool_catalog = StubToolCatalog({})
+        template_catalog = StubTemplateCatalog({"sys-prompt": template})
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        worker_card = result.members[0].card
+        prompt = getattr(worker_card.config, "prompt", None)
+        assert prompt is not None
+        assert prompt.template == "You are {role}. {instructions}"
+        assert "@" not in prompt.template
+
+    def test_template_unresolved_without_catalogs(self) -> None:
+        agent = make_agent(
+            id="worker",
+            name="worker-agent",
+            template_ref="@sys-prompt",
+            params={"role": "expert", "instructions": "Be helpful."},
+        )
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        # Without catalogs, template stays as @-reference
+        result = team.to_team_card(agent_catalog)
+
+        worker_card = result.members[0].card
+        prompt = getattr(worker_card.config, "prompt", None)
+        assert prompt is not None
+        assert prompt.template == "@sys-prompt"
+
+
+class TestResolutionErrorCollection:
+    """to_team_card collects tool/template resolution errors without failing fast."""
+
+    def test_missing_tool_collected_as_error(self) -> None:
+        agent = make_agent(id="worker", name="worker-agent", tool_ids=["missing-tool"])
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        tool_catalog = StubToolCatalog({})  # empty — tool not found
+        template_catalog = StubTemplateCatalog({})
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        assert any("missing-tool" in e for e in exc_info.value.errors)
+
+    def test_missing_template_collected_as_error(self) -> None:
+        agent = make_agent(
+            id="worker",
+            name="worker-agent",
+            template_ref="@nonexistent",
+            params={"role": "test"},
+        )
+        ep = make_agent(id="proxy", name="proxy-agent")
+        agent_catalog = _catalog_from(ep, agent)
+
+        tool_catalog = StubToolCatalog({})
+        template_catalog = StubTemplateCatalog({})  # empty — template not found
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="worker"),
+            ],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        assert any("nonexistent" in e for e in exc_info.value.errors)


### PR DESCRIPTION
## Summary

- `_resolve_members()` used `entry.card` (raw AgentCard with empty tools and literal `@team-prompt` strings) instead of calling `entry.to_agent_card()` for fully resolved cards
- `to_team_card()` and `_resolve_members()` now accept optional `tool_catalog` and `template_catalog` — when provided, each member's AgentCard is fully resolved (tools populated, prompt templates expanded)
- Backward compatible: catalogs default to `None`, preserving existing call sites
- 6 new tests covering tool resolution, template resolution, and error collection; all 670 existing tests pass

Closes #87