### PR TITLE
Rename TeamEntry.profiles to agent_profiles and wire resolution (ADR-005)

### DIFF
--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -523,8 +523,8 @@ def validate_cmd(
             for member_id in all_member_ids:
                 if member_id not in agent_ids_set:
                     errors.append(f"Team '{team.id}': member agent '{member_id}' not found")
-            # Check profiles
-            for profile_id in team.profiles:
+            # Check agent_profiles
+            for profile_id in team.agent_profiles:
                 if profile_id not in agent_ids_set:
                     errors.append(f"Team '{team.id}': profile agent '{profile_id}' not found")
             # Check message_types

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -13,6 +13,7 @@ from akgentic.catalog.models.agent import (
     _ToolCatalogProtocol,
 )
 from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.core.agent_card import AgentCard
 from akgentic.core.utils.deserializer import import_class
 from akgentic.team.models import TeamCard, TeamCardMember
 
@@ -76,7 +77,7 @@ class TeamEntry(BaseModel):
     members: list[TeamMemberSpec] = Field(
         min_length=1, description="Team composition tree — agents instantiated at startup"
     )
-    profiles: list[str] = Field(
+    agent_profiles: list[str] = Field(
         default=[], description="AgentEntry.ids available for runtime hiring, not instantiated"
     )
     description: str = Field(
@@ -110,11 +111,19 @@ class TeamEntry(BaseModel):
                 errors.append(f"Agent '{spec.agent_id}' not found in catalog")
                 # Still recurse children to collect all errors
                 TeamEntry._resolve_members(
-                    spec.members, agent_catalog, errors, tool_catalog, template_catalog,
+                    spec.members,
+                    agent_catalog,
+                    errors,
+                    tool_catalog,
+                    template_catalog,
                 )
                 continue
             children = TeamEntry._resolve_members(
-                spec.members, agent_catalog, errors, tool_catalog, template_catalog,
+                spec.members,
+                agent_catalog,
+                errors,
+                tool_catalog,
+                template_catalog,
             )
             # Use fully resolved card (tools + templates) when catalogs are available
             if tool_catalog is not None and template_catalog is not None:
@@ -165,7 +174,11 @@ class TeamEntry(BaseModel):
 
         # 1. Resolve members tree
         resolved_pairs = self._resolve_members(
-            self.members, agent_catalog, errors, tool_catalog, template_catalog,
+            self.members,
+            agent_catalog,
+            errors,
+            tool_catalog,
+            template_catalog,
         )
 
         # 2. Resolve message types (collect errors, don't fail fast)
@@ -174,6 +187,14 @@ class TeamEntry(BaseModel):
             resolved_message_types = self.resolve_message_types()
         except CatalogValidationError as e:
             errors.extend(e.errors)
+
+        # 2b. Resolve agent_profiles to AgentCard list (ADR-005)
+        resolved_profiles = self._resolve_agent_profiles(
+            agent_catalog,
+            errors,
+            tool_catalog,
+            template_catalog,
+        )
 
         # 3. Raise all collected errors
         if errors:
@@ -199,7 +220,46 @@ class TeamEntry(BaseModel):
             entry_point=entry_point_member,
             members=remaining_members,
             message_types=resolved_message_types,
+            agent_profiles=resolved_profiles,
         )
+
+    def _resolve_agent_profiles(
+        self,
+        agent_catalog: _AgentCatalogProtocol,
+        errors: list[str],
+        tool_catalog: _ToolCatalogProtocol | None = None,
+        template_catalog: _TemplateCatalogProtocol | None = None,
+    ) -> list[AgentCard]:
+        """Resolve self.agent_profiles to a flat list of AgentCard.
+
+        Mirrors the error-collection pattern in ``_resolve_members``: missing
+        agents and downstream resolution failures append to ``errors`` and the
+        method returns whatever was successfully resolved (the caller is
+        responsible for raising once all collection is done).
+
+        Args:
+            agent_catalog: Catalog service providing agent lookups.
+            errors: Accumulator for error messages (mutated in place).
+            tool_catalog: Optional tool catalog for resolving tool_ids to ToolCards.
+            template_catalog: Optional template catalog for resolving @-refs.
+
+        Returns:
+            List of resolved AgentCard objects in catalog-declared order.
+        """
+        resolved: list[AgentCard] = []
+        for agent_id in self.agent_profiles:
+            entry: AgentEntry | None = agent_catalog.get(agent_id)
+            if entry is None:
+                errors.append(f"Profile agent '{agent_id}' not found in catalog")
+                continue
+            if tool_catalog is not None and template_catalog is not None:
+                try:
+                    resolved.append(entry.to_agent_card(tool_catalog, template_catalog))
+                except CatalogValidationError as e:
+                    errors.extend(e.errors)
+                continue
+            resolved.append(entry.card)
+        return resolved
 
     def resolve_entry_point(self, agent_catalog: _AgentCatalogProtocol) -> AgentEntry:
         """Resolve entry_point id to the full AgentEntry from the catalog.

--- a/src/akgentic/catalog/models/team.py
+++ b/src/akgentic/catalog/models/team.py
@@ -158,17 +158,27 @@ class TeamEntry(BaseModel):
         (tools populated, prompt templates expanded).  Without them, the raw
         ``entry.card`` is used (tools may be empty, templates unresolved).
 
+        ``self.agent_profiles`` is resolved to a flat ``list[AgentCard]`` on the
+        returned ``TeamCard``. Each profile id is looked up in ``agent_catalog``
+        and either fully resolved (when tool + template catalogs are provided)
+        or populated from the raw ``entry.card``. Missing profile agents and
+        downstream resolution failures are collected into the same errors list
+        as member/message-type errors; see ADR-005.
+
         Args:
             agent_catalog: Catalog service providing agent lookups.
             tool_catalog: Optional tool catalog for resolving tool_ids to ToolCards.
             template_catalog: Optional template catalog for resolving @-refs.
 
         Returns:
-            A TeamCard with fully resolved members, entry_point, and message_types.
+            A TeamCard with fully resolved members, entry_point, message_types,
+            and agent_profiles.
 
         Raises:
-            CatalogValidationError: If any agents are missing or message types
-                cannot be resolved. Collects ALL errors before raising.
+            CatalogValidationError: If any agents (members or profiles) are
+                missing, message types cannot be resolved, or profile
+                ``to_agent_card`` resolution fails. Collects ALL errors before
+                raising.
         """
         errors: list[str] = []
 

--- a/src/akgentic/catalog/services/agent_catalog.py
+++ b/src/akgentic/catalog/services/agent_catalog.py
@@ -265,7 +265,7 @@ class AgentCatalog:
                     errors.append(
                         f"Team '{team.id}' references agent '{id}' in members — cannot delete"
                     )
-                if id in team.profiles:
+                if id in team.agent_profiles:
                     errors.append(
                         f"Team '{team.id}' references agent '{id}' in profiles — cannot delete"
                     )

--- a/src/akgentic/catalog/services/team_catalog.py
+++ b/src/akgentic/catalog/services/team_catalog.py
@@ -90,8 +90,8 @@ class TeamCatalog:
             if self._agent_catalog.get(agent_id) is None:
                 errors.append(f"Agent '{agent_id}' not found in AgentCatalog")
 
-        # AC3: Every agent_id in profiles must exist in AgentCatalog
-        for agent_id in entry.profiles:
+        # AC3: Every agent_id in agent_profiles must exist in AgentCatalog
+        for agent_id in entry.agent_profiles:
             if self._agent_catalog.get(agent_id) is None:
                 errors.append(f"Profile agent '{agent_id}' not found in AgentCatalog")
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -60,7 +60,7 @@ def team_data(
         "entry_point": entry_point,
         "message_types": ["akgentic.core.messages.UserMessage"],
         "members": members or [{"agent_id": entry_point, "headcount": 1}],
-        "profiles": [],
+        "agent_profiles": [],
         "description": description,
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def make_team(
     name: str = "Test Team",
     entry_point: str = "agent-1",
     members: _list[TeamMemberSpec] | None = None,
-    profiles: _list[str] | None = None,
+    agent_profiles: _list[str] | None = None,
     message_types: _list[str] | None = None,
 ) -> TeamEntry:
     """Create a TeamEntry for testing with optional members and config."""
@@ -94,7 +94,7 @@ def make_team(
         entry_point=entry_point,
         message_types=message_types or ["akgentic.core.messages.UserMessage"],
         members=default_members,
-        profiles=profiles or [],
+        agent_profiles=agent_profiles or [],
     )
 
 

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -318,8 +318,8 @@ class TestRoundTripTeamEntry:
         assert restored.entry_point == "lead"
         assert restored.description == "A multi-level research team"
 
-    def test_profiles_and_message_types_survive_round_trip(self) -> None:
-        """profiles list and message_types FQCN strings preserved."""
+    def test_agent_profiles_and_message_types_survive_round_trip(self) -> None:
+        """agent_profiles list and message_types FQCN strings preserved."""
         original = TeamEntry(
             id="dev-team",
             name="Development Team",
@@ -331,7 +331,7 @@ class TestRoundTripTeamEntry:
             members=[
                 TeamMemberSpec(agent_id="manager", headcount=1, members=[]),
             ],
-            profiles=["designer", "tester", "devops"],
+            agent_profiles=["designer", "tester", "devops"],
             description="A development team with hiring pool",
         )
         dumped = original.model_dump()
@@ -341,7 +341,7 @@ class TestRoundTripTeamEntry:
             "akgentic.core.agent_state.BaseState",
             "akgentic.core.agent_config.BaseConfig",
         ]
-        assert restored.profiles == ["designer", "tester", "devops"]
+        assert restored.agent_profiles == ["designer", "tester", "devops"]
         assert restored.id == "dev-team"
         assert restored.name == "Development Team"
 

--- a/tests/models/test_team_entry.py
+++ b/tests/models/test_team_entry.py
@@ -85,9 +85,9 @@ class TestTeamEntry:
         assert team.message_types == ["pydantic.BaseModel"]
         assert len(team.members) == 1
 
-    def test_defaults_profiles_empty_list(self) -> None:
+    def test_defaults_agent_profiles_empty_list(self) -> None:
         team = self._make_team_entry()
-        assert team.profiles == []
+        assert team.agent_profiles == []
 
     def test_defaults_description_empty_string(self) -> None:
         team = self._make_team_entry()
@@ -122,9 +122,9 @@ class TestTeamEntry:
         team = self._make_team_entry(members=[l0])
         assert team.members[0].members[0].members[0].members[0].agent_id == "intern"
 
-    def test_profiles_accepts_strings(self) -> None:
-        team = self._make_team_entry(profiles=["extra-agent-1", "extra-agent-2"])
-        assert team.profiles == ["extra-agent-1", "extra-agent-2"]
+    def test_agent_profiles_accepts_strings(self) -> None:
+        team = self._make_team_entry(agent_profiles=["extra-agent-1", "extra-agent-2"])
+        assert team.agent_profiles == ["extra-agent-1", "extra-agent-2"]
 
     def test_custom_description(self) -> None:
         team = self._make_team_entry(description="A great team")

--- a/tests/models/test_team_entry_to_team_card.py
+++ b/tests/models/test_team_entry_to_team_card.py
@@ -575,6 +575,135 @@ class TestTemplateResolution:
         assert prompt.template == "@sys-prompt"
 
 
+# ---------------------------------------------------------------------------
+# Agent profiles resolution (ADR-005)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentProfilesResolution:
+    """to_team_card resolves agent_profiles to a flat list of AgentCard."""
+
+    def test_raw_resolution_happy_path(self) -> None:
+        """AC3: Without tool/template catalogs, profiles resolve to raw entry.card."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        expert = make_agent(id="expert", name="expert-agent")
+        assistant = make_agent(id="assistant", name="assistant-agent")
+        catalog = _catalog_from(ep, expert, assistant)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            agent_profiles=["expert", "assistant"],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert len(result.agent_profiles) == 2
+        assert result.agent_profiles[0].config.name == "expert-agent"
+        assert result.agent_profiles[1].config.name == "assistant-agent"
+
+    def test_fully_resolved_with_tool_and_template_catalogs(self) -> None:
+        """AC4: With both catalogs, profiles use entry.to_agent_card (tools populated)."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        expert = make_agent(id="expert", name="expert-agent", tool_ids=["search-1"])
+        agent_catalog = _catalog_from(ep, expert)
+
+        tool = make_tool(id="search-1")
+        tool_catalog = StubToolCatalog({"search-1": tool})
+        template_catalog = StubTemplateCatalog({})
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            agent_profiles=["expert"],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        assert len(result.agent_profiles) == 1
+        expert_card = result.agent_profiles[0]
+        tools = getattr(expert_card.config, "tools", [])
+        assert len(tools) == 1
+        assert tools[0].name == "search"
+
+    def test_missing_profile_agent_collected_as_error(self) -> None:
+        """AC5: Missing profile agent → exact error string collected."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            agent_profiles=["missing-agent"],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        assert "Profile agent 'missing-agent' not found in catalog" in exc_info.value.errors
+
+    def test_combined_member_and_profile_errors(self) -> None:
+        """AC6: Both member and profile errors collected in a single CatalogValidationError."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[
+                TeamMemberSpec(agent_id="proxy"),
+                TeamMemberSpec(agent_id="missing-member"),
+            ],
+            agent_profiles=["missing-profile"],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(catalog)
+
+        errors = exc_info.value.errors
+        assert any("missing-member" in e for e in errors)
+        assert any("Profile agent 'missing-profile' not found in catalog" in e for e in errors)
+
+    def test_empty_agent_profiles_passthrough(self) -> None:
+        """AC7: Empty agent_profiles → empty list, no error, no lookup."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        catalog = _catalog_from(ep)
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        result = team.to_team_card(catalog)
+
+        assert result.agent_profiles == []
+
+    def test_fully_resolved_path_collects_to_agent_card_errors(self) -> None:
+        """AC8: When entry.to_agent_card raises, the error is collected, not raised."""
+        ep = make_agent(id="proxy", name="proxy-agent")
+        bad_agent = make_agent(id="bad-agent", name="bad-agent", tool_ids=["nonexistent-tool"])
+        agent_catalog = _catalog_from(ep, bad_agent)
+
+        tool_catalog = StubToolCatalog({})  # empty — tool lookup fails
+        template_catalog = StubTemplateCatalog({})
+
+        team = make_team(
+            entry_point="proxy",
+            members=[TeamMemberSpec(agent_id="proxy")],
+            agent_profiles=["bad-agent"],
+            message_types=["pydantic.BaseModel"],
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            team.to_team_card(agent_catalog, tool_catalog, template_catalog)
+
+        assert any("nonexistent-tool" in e for e in exc_info.value.errors)
+
+
 class TestResolutionErrorCollection:
     """to_team_card collects tool/template resolution errors without failing fast."""
 

--- a/tests/repositories/test_yaml_team_repo.py
+++ b/tests/repositories/test_yaml_team_repo.py
@@ -28,7 +28,7 @@ def _team_dict(
         "entry_point": entry_point,
         "message_types": ["akgentic.agent.AgentMessage"],
         "members": members,
-        "profiles": [],
+        "agent_profiles": [],
     }
 
 

--- a/tests/services/test_agent_catalog.py
+++ b/tests/services/test_agent_catalog.py
@@ -49,9 +49,7 @@ class TestValidateCreateDuplicateId:
 class TestValidateCreateToolRefs:
     """AC1: Tool reference validation."""
 
-    def test_valid_tool_ids(
-        self, catalog: AgentCatalog, tool_catalog: ToolCatalog
-    ) -> None:
+    def test_valid_tool_ids(self, catalog: AgentCatalog, tool_catalog: ToolCatalog) -> None:
         tool_catalog.create(make_tool("search-1"))
         entry = make_agent("agent-1", tool_ids=["search-1"])
         errors = catalog.validate_create(entry)
@@ -92,17 +90,13 @@ class TestValidateCreateTemplateRefs:
         assert len(errors) == 1
         assert "Template '@nonexistent' not found" in errors[0]
 
-    def test_missing_params(
-        self, catalog: AgentCatalog, template_catalog: TemplateCatalog
-    ) -> None:
+    def test_missing_params(self, catalog: AgentCatalog, template_catalog: TemplateCatalog) -> None:
         template_catalog.create(make_template("sys-prompt"))
         entry = make_agent("agent-1", template_ref="@sys-prompt", params={})
         errors = catalog.validate_create(entry)
         assert any("missing params" in e for e in errors)
 
-    def test_extra_params(
-        self, catalog: AgentCatalog, template_catalog: TemplateCatalog
-    ) -> None:
+    def test_extra_params(self, catalog: AgentCatalog, template_catalog: TemplateCatalog) -> None:
         template_catalog.create(make_template("sys-prompt"))
         entry = make_agent(
             "agent-1",
@@ -112,9 +106,7 @@ class TestValidateCreateTemplateRefs:
         errors = catalog.validate_create(entry)
         assert any("extra params" in e for e in errors)
 
-    def test_non_catalog_ref_template_skips_validation(
-        self, catalog: AgentCatalog
-    ) -> None:
+    def test_non_catalog_ref_template_skips_validation(self, catalog: AgentCatalog) -> None:
         entry = make_agent("agent-1", template_ref="You are a helpful assistant")
         errors = catalog.validate_create(entry)
         assert errors == []
@@ -174,9 +166,7 @@ class TestCreate:
         assert result == "agent-1"
         assert catalog.get("agent-1") is not None
 
-    def test_create_raises_on_validation_errors(
-        self, catalog: AgentCatalog
-    ) -> None:
+    def test_create_raises_on_validation_errors(self, catalog: AgentCatalog) -> None:
         entry = make_agent("agent-1", tool_ids=["nonexistent"])
         with pytest.raises(CatalogValidationError, match="not found"):
             catalog.create(entry)
@@ -275,7 +265,7 @@ class TestValidateDelete:
         team = make_team(
             "team-1",
             members=[{"agent_id": "other-agent"}],
-            profiles=["agent-1"],
+            agent_profiles=["agent-1"],
         )
         catalog.team_catalog = MockTeamCatalog([team])
         errors = catalog.validate_delete("agent-1")
@@ -293,10 +283,12 @@ class TestValidateDelete:
         catalog.create(make_agent("nested-agent"))
         team = make_team(
             "team-1",
-            members=[{
-                "agent_id": "outer-agent",
-                "members": [{"agent_id": "nested-agent"}],
-            }],
+            members=[
+                {
+                    "agent_id": "outer-agent",
+                    "members": [{"agent_id": "nested-agent"}],
+                }
+            ],
         )
         catalog.team_catalog = MockTeamCatalog([team])
         errors = catalog.validate_delete("nested-agent")
@@ -316,9 +308,7 @@ class TestDelete:
         with pytest.raises(EntryNotFoundError, match="not found"):
             catalog.delete("nonexistent")
 
-    def test_delete_routing_dependency_raises(
-        self, catalog: AgentCatalog
-    ) -> None:
+    def test_delete_routing_dependency_raises(self, catalog: AgentCatalog) -> None:
         catalog.create(make_agent("target", name="target-name"))
         catalog.create(make_agent("router", name="router-name", routes_to=["target-name"]))
         with pytest.raises(CatalogValidationError, match="cannot delete"):
@@ -403,9 +393,7 @@ class TestBaseConfigAgentService:
         assert result == "human-proxy"
         assert catalog.get("human-proxy") is not None
 
-    def test_validate_baseconfig_agent_skips_template_check(
-        self, catalog: AgentCatalog
-    ) -> None:
+    def test_validate_baseconfig_agent_skips_template_check(self, catalog: AgentCatalog) -> None:
         """BaseConfig agent has no prompt — template validation is skipped."""
         entry = self._make_baseconfig_agent()
         errors = catalog.validate_create(entry)

--- a/tests/services/test_team_catalog.py
+++ b/tests/services/test_team_catalog.py
@@ -92,10 +92,12 @@ class TestValidateCreateEntryPoint:
         team = make_team(
             "team-1",
             entry_point="agent-2",
-            members=[TeamMemberSpec(
-                agent_id="agent-1",
-                members=[TeamMemberSpec(agent_id="agent-2")],
-            )],
+            members=[
+                TeamMemberSpec(
+                    agent_id="agent-1",
+                    members=[TeamMemberSpec(agent_id="agent-2")],
+                )
+            ],
         )
         errors = catalog.validate_create(team)
         assert not any("Entry point" in e for e in errors)
@@ -126,10 +128,12 @@ class TestValidateCreateMemberAgents:
         team = make_team(
             "team-1",
             entry_point="agent-1",
-            members=[TeamMemberSpec(
-                agent_id="agent-1",
-                members=[TeamMemberSpec(agent_id="nonexistent")],
-            )],
+            members=[
+                TeamMemberSpec(
+                    agent_id="agent-1",
+                    members=[TeamMemberSpec(agent_id="nonexistent")],
+                )
+            ],
         )
         errors = catalog.validate_create(team)
         assert any("Agent 'nonexistent' not found in AgentCatalog" in e for e in errors)
@@ -142,7 +146,7 @@ class TestValidateCreateProfiles:
         team = make_team(
             "team-1",
             members=[TeamMemberSpec(agent_id="agent-1")],
-            profiles=["nonexistent"],
+            agent_profiles=["nonexistent"],
         )
         errors = catalog.validate_create(team)
         assert any("Profile agent 'nonexistent' not found in AgentCatalog" in e for e in errors)
@@ -151,7 +155,7 @@ class TestValidateCreateProfiles:
         team = make_team(
             "team-1",
             members=[TeamMemberSpec(agent_id="agent-1")],
-            profiles=["agent-2"],
+            agent_profiles=["agent-2"],
         )
         errors = catalog.validate_create(team)
         assert errors == []
@@ -185,7 +189,7 @@ class TestValidateCreateMultipleErrors:
             "team-1",
             entry_point="missing-ep",
             members=[TeamMemberSpec(agent_id="nonexistent-member")],
-            profiles=["nonexistent-profile"],
+            agent_profiles=["nonexistent-profile"],
             message_types=["bad.module.FakeClass"],
         )
         errors = catalog.validate_create(team)
@@ -238,7 +242,9 @@ class TestCrudDelegation:
     def test_list_delegates(self, catalog: TeamCatalog) -> None:
         catalog.create(make_team("team-1"))
         team2 = make_team(
-            "team-2", entry_point="agent-2", members=[TeamMemberSpec(agent_id="agent-2")],
+            "team-2",
+            entry_point="agent-2",
+            members=[TeamMemberSpec(agent_id="agent-2")],
         )
         catalog.create(team2)
         result = catalog.list()
@@ -273,7 +279,9 @@ class TestUpdate:
     def test_update_id_mismatch_raises(self, catalog: TeamCatalog) -> None:
         catalog.create(make_team("team-1"))
         mismatched = make_team(
-            "team-2", entry_point="agent-2", members=[TeamMemberSpec(agent_id="agent-2")],
+            "team-2",
+            entry_point="agent-2",
+            members=[TeamMemberSpec(agent_id="agent-2")],
         )
         with pytest.raises(CatalogValidationError, match="does not match"):
             catalog.update("team-1", mismatched)
@@ -399,7 +407,7 @@ class TestDownstreamWiringAgentDeleteByTeamProfile:
         team = make_team(
             "team-1",
             members=[TeamMemberSpec(agent_id="agent-1")],
-            profiles=["agent-2"],
+            agent_profiles=["agent-2"],
         )
         catalog.create(team)
         agent_catalog.team_catalog = catalog


### PR DESCRIPTION
## Summary

Implements ADR-005. Two-part change shipped atomically to avoid a broken intermediate state:

- **Mechanical rename**: `TeamEntry.profiles` -> `agent_profiles` (aligns with `TeamCard.agent_profiles`). 4 source files + 7 test files migrated.
- **Functional wiring**: `TeamEntry.to_team_card()` now resolves `agent_profiles` via a new private helper `_resolve_agent_profiles`, mirroring the `_resolve_members` error-collection pattern (ADR-004). Previously profiles were silently dropped.

### Implementation Highlights

- New helper `TeamEntry._resolve_agent_profiles(agent_catalog, errors, tool_catalog, template_catalog)` returns `list[AgentCard]` and collects errors rather than failing fast.
- Missing profile agents produce `"Profile agent '<id>' not found in catalog"` (short form, matching `_resolve_members`).
- When both tool + template catalogs are provided, profiles use `entry.to_agent_card(...)` and downstream `CatalogValidationError` is collected (no fallback to raw card, per ADR-005).
- Service-layer error wording preserved (AC2): `"Profile agent 'X' not found in AgentCatalog"` in `TeamCatalog._validate_entry` and `"in profiles -- cannot delete"` in `AgentCatalog.validate_delete` are unchanged.
- Combined member + profile errors collected into a single `CatalogValidationError` (exhaustive, not fail-fast).

### Tests

- New `TestAgentProfilesResolution` class (6 tests) in `tests/models/test_team_entry_to_team_card.py` covering AC3-AC8: raw resolution, fully-resolved path, missing agent, combined errors, empty passthrough, and `to_agent_card` error collection.
- All existing tests migrated from `profiles` to `agent_profiles` kwargs, method names, and YAML keys.

### Quality

- 676 tests pass (was 670; +6 new tests).
- ruff + mypy strict clean.
- coverage 92.29% overall (gate 80%); `models/team.py` at 100% line + branch.
- CI green (run 24182004765).

### Code Review (Rex)

- 1 MEDIUM finding fixed: `to_team_card()` public docstring extended to document `agent_profiles` resolution behavior (Raises clause and Returns section updated). Applied in the second commit on this branch.
- 2 LOW findings noted, not fixed: profile-in-members overlap not tested (not required by ACs); `examples/` and `README.md` still reference old `profiles:` key (explicitly out-of-scope per story Dev Notes; scheduled tech-writer follow-up).

### Out of scope (follow-ups)

- Root-repo `src/catalog/teams/agent-team.yaml` still uses `profiles:` (separate root-repo PR required per Golden Rule #4).
- Catalog submodule examples and docs (`examples/03_team_entries.py`, `examples/03-team-entries.md`, `README.md`) still reference the old field name -- tech-writer follow-up.

Closes #89