### PR TITLE
fix: remove redundant _id unique index from Mongo repos

### DIFF
--- a/src/akgentic/catalog/repositories/mongo/agent_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/agent_repo.py
@@ -34,14 +34,14 @@ class MongoAgentCatalogRepository(AgentCatalogRepository):
     def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
         """Initialize with a pymongo Collection and ensure indexes.
 
-        Creates indexes on ``_id`` (unique), ``card.role`` (secondary),
-        and ``card.skills`` (multikey for ``$in`` queries).
+        Creates indexes on ``card.role`` (secondary) and ``card.skills``
+        (multikey for ``$in`` queries). ``_id`` is inherently unique.
 
         Args:
             collection: The MongoDB collection for agent entries.
         """
         self._collection = collection
-        self._collection.create_index("_id", unique=True)
+        # _id is inherently unique in MongoDB — no explicit index needed.
         self._collection.create_index("card.role")
         self._collection.create_index("card.skills")
         logger.info(

--- a/src/akgentic/catalog/repositories/mongo/team_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/team_repo.py
@@ -38,8 +38,8 @@ class MongoTeamCatalogRepository(TeamCatalogRepository):
             collection: The MongoDB collection for team entries.
         """
         self._collection = collection
-        self._collection.create_index("_id", unique=True)
-        logger.info("MongoTeamCatalogRepository initialized with index on _id")
+        # _id is inherently unique in MongoDB — no explicit index needed.
+        logger.info("MongoTeamCatalogRepository initialized")
 
     def create(self, team_entry: TeamEntry) -> str:
         """Persist a new team entry.

--- a/src/akgentic/catalog/repositories/mongo/template_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/template_repo.py
@@ -37,8 +37,8 @@ class MongoTemplateCatalogRepository(TemplateCatalogRepository):
             collection: The MongoDB collection for template entries.
         """
         self._collection = collection
-        self._collection.create_index("_id", unique=True)
-        logger.info("MongoTemplateCatalogRepository initialized with index on _id")
+        # _id is inherently unique in MongoDB — no explicit index needed.
+        logger.info("MongoTemplateCatalogRepository initialized")
 
     def create(self, template_entry: TemplateEntry) -> str:
         """Persist a new template entry.

--- a/src/akgentic/catalog/repositories/mongo/tool_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/tool_repo.py
@@ -38,8 +38,8 @@ class MongoToolCatalogRepository(ToolCatalogRepository):
             collection: The MongoDB collection for tool entries.
         """
         self._collection = collection
-        self._collection.create_index("_id", unique=True)
-        logger.info("MongoToolCatalogRepository initialized with index on _id")
+        # _id is inherently unique in MongoDB — no explicit index needed.
+        logger.info("MongoToolCatalogRepository initialized")
 
     def create(self, tool_entry: ToolEntry) -> str:
         """Persist a new tool entry.


### PR DESCRIPTION
## Summary
- Remove `create_index("_id", unique=True)` from all 4 MongoDB catalog repositories
- MongoDB's `_id` has a built-in unique index; explicitly setting `unique=True` on it fails on newer MongoDB versions with `OperationFailure`
- Affects: `MongoAgentCatalogRepository`, `MongoTeamCatalogRepository`, `MongoTemplateCatalogRepository`, `MongoToolCatalogRepository`

Relates to #91

## Test plan
- [x] Ruff lint passes
- [x] Existing Mongo repo tests pass