### PR TITLE
fix: remove tailing slashes from API routes for consistency

### DIFF
--- a/src/akgentic/catalog/api/agent_router.py
+++ b/src/akgentic/catalog/api/agent_router.py
@@ -40,7 +40,7 @@ def _get_catalog() -> AgentCatalog:
     return _catalog
 
 
-@router.post("/", response_model=AgentEntry, status_code=201)
+@router.post("", response_model=AgentEntry, status_code=201)
 async def create_agent(entry: AgentEntry) -> AgentEntry:
     """Create a new agent entry."""
     logger.debug("POST /api/agents — creating %s", entry.id)
@@ -48,7 +48,7 @@ async def create_agent(entry: AgentEntry) -> AgentEntry:
     return entry
 
 
-@router.get("/", response_model=list[AgentEntry])
+@router.get("", response_model=list[AgentEntry])
 async def list_agents() -> list[AgentEntry]:
     """List all agent entries."""
     logger.debug("GET /api/agents — listing all")

--- a/src/akgentic/catalog/api/team_router.py
+++ b/src/akgentic/catalog/api/team_router.py
@@ -40,7 +40,7 @@ def _get_catalog() -> TeamCatalog:
     return _catalog
 
 
-@router.post("/", response_model=TeamEntry, status_code=201)
+@router.post("", response_model=TeamEntry, status_code=201)
 async def create_team(entry: TeamEntry) -> TeamEntry:
     """Create a new team entry."""
     logger.debug("POST /api/teams — creating %s", entry.id)
@@ -48,7 +48,7 @@ async def create_team(entry: TeamEntry) -> TeamEntry:
     return entry
 
 
-@router.get("/", response_model=list[TeamEntry])
+@router.get("", response_model=list[TeamEntry])
 async def list_teams() -> list[TeamEntry]:
     """List all team entries."""
     logger.debug("GET /api/teams — listing all")

--- a/src/akgentic/catalog/api/template_router.py
+++ b/src/akgentic/catalog/api/template_router.py
@@ -40,7 +40,7 @@ def _get_catalog() -> TemplateCatalog:
     return _catalog
 
 
-@router.post("/", response_model=TemplateEntry, status_code=201)
+@router.post("", response_model=TemplateEntry, status_code=201)
 async def create_template(entry: TemplateEntry) -> TemplateEntry:
     """Create a new template entry."""
     logger.debug("POST /api/templates — creating %s", entry.id)
@@ -48,7 +48,7 @@ async def create_template(entry: TemplateEntry) -> TemplateEntry:
     return entry
 
 
-@router.get("/", response_model=list[TemplateEntry])
+@router.get("", response_model=list[TemplateEntry])
 async def list_templates() -> list[TemplateEntry]:
     """List all template entries."""
     logger.debug("GET /api/templates — listing all")

--- a/src/akgentic/catalog/api/tool_router.py
+++ b/src/akgentic/catalog/api/tool_router.py
@@ -40,7 +40,7 @@ def _get_catalog() -> ToolCatalog:
     return _catalog
 
 
-@router.post("/", response_model=ToolEntry, status_code=201)
+@router.post("", response_model=ToolEntry, status_code=201)
 async def create_tool(entry: ToolEntry) -> ToolEntry:
     """Create a new tool entry."""
     logger.debug("POST /api/tools — creating %s", entry.id)
@@ -48,7 +48,7 @@ async def create_tool(entry: ToolEntry) -> ToolEntry:
     return entry
 
 
-@router.get("/", response_model=list[ToolEntry])
+@router.get("", response_model=list[ToolEntry])
 async def list_tools() -> list[ToolEntry]:
     """List all tool entries."""
     logger.debug("GET /api/tools — listing all")

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -42,10 +42,10 @@ class TestCreateAppYaml:
         assert app.title == "Akgentic Org API"
         # Should have 4 routers registered (templates, tools, agents, teams)
         route_paths = {r.path for r in app.routes if hasattr(r, "path")}
-        assert "/api/templates/" in route_paths
-        assert "/api/tools/" in route_paths
-        assert "/api/agents/" in route_paths
-        assert "/api/teams/" in route_paths
+        assert "/api/templates" in route_paths
+        assert "/api/tools" in route_paths
+        assert "/api/agents" in route_paths
+        assert "/api/teams" in route_paths
 
     def test_crud_round_trip(self, tmp_path: Path) -> None:
         """Create a TemplateEntry via POST, retrieve via GET, verify round-trip."""


### PR DESCRIPTION
## Summary

- Remove trailing slashes from `POST /` and `GET /` route decorators across all four CRUD routers (agent, team, template, tool)
- FastAPI with trailing-slash routes causes 307 redirects when clients call without the slash, breaking some HTTP clients and adding unnecessary latency
