### PR TITLE
feat: scaffold Postgres backend skeleton, schema, and init helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ cli = [
 mongo = [
     "pymongo>=4.0.0",
 ]
+postgres = [
+    "nagra>=0.5",
+    "psycopg[binary]>=3.1",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -38,6 +42,9 @@ dev = [
     "types-PyYAML>=6.0",
     "mongomock>=4.0.0",
     "httpx>=0.24.0",
+    "nagra>=0.5",
+    "psycopg[binary]>=3.1",
+    "testcontainers[postgres]>=4.0.0",
 ]
 
 [project.scripts]
@@ -49,6 +56,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/akgentic"]
+
+# Explicitly ship non-Python assets needed at runtime (e.g., Nagra schema TOML
+# for the Postgres backend). Without this, hatchling's default heuristics may
+# skip files like *.toml under src/.
+[tool.hatch.build.targets.wheel.force-include]
+"src/akgentic/catalog/repositories/postgres/schema.toml" = "akgentic/catalog/repositories/postgres/schema.toml"
 
 [tool.uv.sources]
 akgentic = { workspace = true }

--- a/src/akgentic/catalog/repositories/postgres/__init__.py
+++ b/src/akgentic/catalog/repositories/postgres/__init__.py
@@ -1,0 +1,88 @@
+"""Public API surface for Postgres-backed catalog repositories.
+
+Gates all Nagra imports behind an availability check. When ``nagra`` is not
+installed, importing this package raises ``ImportError`` with installation
+instructions. When ``nagra`` IS available, exposes the schema loader,
+deployment-time ``init_db`` hook, and the four stub repository classes that
+later stories (15.2 / 15.3) will flesh out.
+
+Implements ADR-006 Nagra-based PostgreSQL repository §5 (lazy import gate) and
+§6 (schema loader + init_db reference implementation).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+try:
+    import nagra  # type: ignore[import-untyped]  # noqa: F401 — availability probe
+except ImportError as exc:
+    logger.warning("nagra is not installed; Postgres backend is unavailable")
+    raise ImportError(
+        "nagra is required for the Postgres backend. "
+        "Install with: pip install akgentic-catalog[postgres]"
+    ) from exc
+
+# Only reached when nagra is importable.
+from nagra import Schema  # noqa: E402
+
+_SCHEMA_LOADED = False
+
+
+def _ensure_schema_loaded() -> None:
+    """Load ``schema.toml`` into ``Schema.default`` exactly once.
+
+    Idempotent — subsequent calls are no-ops. Repository constructors call
+    this at instantiation so individual repos are always safe to build, but
+    no repository may call :func:`init_db` implicitly.
+    """
+    global _SCHEMA_LOADED
+    if _SCHEMA_LOADED:
+        return
+    schema_path = Path(__file__).parent / "schema.toml"
+    Schema.default.load_toml(schema_path)
+    _SCHEMA_LOADED = True
+
+
+def init_db(conn_string: str) -> None:
+    """Create missing tables against the target Postgres instance.
+
+    Idempotent: calling twice against the same database succeeds both times
+    and does not create duplicate tables. Intended as a deployment hook —
+    NEVER called implicitly by repository constructors.
+
+    Args:
+        conn_string: Nagra-compatible Postgres connection string.
+    """
+    from nagra import Transaction
+
+    _ensure_schema_loaded()
+    with Transaction(conn_string):
+        Schema.default.create_tables()
+
+
+# Import stub repositories last so they can rely on _ensure_schema_loaded above.
+from akgentic.catalog.repositories.postgres.agent_repo import (  # noqa: E402, I001
+    NagraAgentCatalogRepository,
+)
+from akgentic.catalog.repositories.postgres.team_repo import (  # noqa: E402
+    NagraTeamCatalogRepository,
+)
+from akgentic.catalog.repositories.postgres.template_repo import (  # noqa: E402
+    NagraTemplateCatalogRepository,
+)
+from akgentic.catalog.repositories.postgres.tool_repo import (  # noqa: E402
+    NagraToolCatalogRepository,
+)
+
+__all__ = [
+    "NagraAgentCatalogRepository",
+    "NagraTeamCatalogRepository",
+    "NagraTemplateCatalogRepository",
+    "NagraToolCatalogRepository",
+    "_ensure_schema_loaded",
+    "init_db",
+]

--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -1,0 +1,10 @@
+"""Scaffold for shared JSONB predicate builders used by the Nagra repositories.
+
+The real predicate helpers land in stories 15.2 and 15.3 — this module is
+deliberately left empty so the package directory structure is in place and
+downstream imports can stabilise without premature coupling.
+"""
+
+from __future__ import annotations
+
+# Predicate builders arrive in stories 15.2 / 15.3 — intentionally empty scaffold.

--- a/src/akgentic/catalog/repositories/postgres/agent_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/agent_repo.py
@@ -1,0 +1,62 @@
+"""Nagra-backed agent repository (stub — CRUD arrives in story 15.3)."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import TYPE_CHECKING
+
+from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.repositories.base import AgentCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import AgentQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # repository's list() method shadows the built-in
+
+
+class NagraAgentCatalogRepository(AgentCatalogRepository):
+    """Nagra/Postgres-backed agent catalog repository.
+
+    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
+    land in story 15.3. The constructor calls :func:`_ensure_schema_loaded`
+    so instantiation is always safe once ``nagra`` is available.
+    """
+
+    def __init__(self, conn_string: str) -> None:
+        """Initialise with a Nagra connection string and load the shared schema.
+
+        Args:
+            conn_string: Nagra-compatible Postgres connection string.
+        """
+        from akgentic.catalog.repositories.postgres import _ensure_schema_loaded
+
+        _ensure_schema_loaded()
+        self._conn_string = conn_string
+        logger.info("NagraAgentCatalogRepository initialised")
+
+    def create(self, agent_entry: AgentEntry) -> str:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def get(self, id: str) -> AgentEntry | None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def list(self) -> _list[AgentEntry]:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def search(self, query: AgentQuery) -> _list[AgentEntry]:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def update(self, id: str, agent_entry: AgentEntry) -> None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def delete(self, id: str) -> None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")

--- a/src/akgentic/catalog/repositories/postgres/schema.toml
+++ b/src/akgentic/catalog/repositories/postgres/schema.toml
@@ -1,0 +1,23 @@
+[template_entries]
+natural_key = ["id"]
+[template_entries.columns]
+id = "str"
+data = "json"
+
+[tool_entries]
+natural_key = ["id"]
+[tool_entries.columns]
+id = "str"
+data = "json"
+
+[agent_entries]
+natural_key = ["id"]
+[agent_entries.columns]
+id = "str"
+data = "json"
+
+[team_entries]
+natural_key = ["id"]
+[team_entries.columns]
+id = "str"
+data = "json"

--- a/src/akgentic/catalog/repositories/postgres/team_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/team_repo.py
@@ -1,0 +1,62 @@
+"""Nagra-backed team repository (stub — CRUD arrives in story 15.3)."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import TYPE_CHECKING
+
+from akgentic.catalog.models.team import TeamEntry
+from akgentic.catalog.repositories.base import TeamCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import TeamQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # repository's list() method shadows the built-in
+
+
+class NagraTeamCatalogRepository(TeamCatalogRepository):
+    """Nagra/Postgres-backed team catalog repository.
+
+    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
+    land in story 15.3. The constructor calls :func:`_ensure_schema_loaded`
+    so instantiation is always safe once ``nagra`` is available.
+    """
+
+    def __init__(self, conn_string: str) -> None:
+        """Initialise with a Nagra connection string and load the shared schema.
+
+        Args:
+            conn_string: Nagra-compatible Postgres connection string.
+        """
+        from akgentic.catalog.repositories.postgres import _ensure_schema_loaded
+
+        _ensure_schema_loaded()
+        self._conn_string = conn_string
+        logger.info("NagraTeamCatalogRepository initialised")
+
+    def create(self, team_entry: TeamEntry) -> str:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def get(self, id: str) -> TeamEntry | None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def list(self) -> _list[TeamEntry]:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def search(self, query: TeamQuery) -> _list[TeamEntry]:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def update(self, id: str, team_entry: TeamEntry) -> None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def delete(self, id: str) -> None:
+        """Scaffolded — real CRUD arrives in story 15.3."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")

--- a/src/akgentic/catalog/repositories/postgres/template_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/template_repo.py
@@ -1,0 +1,62 @@
+"""Nagra-backed template repository (stub — CRUD arrives in story 15.2)."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import TYPE_CHECKING
+
+from akgentic.catalog.models.template import TemplateEntry
+from akgentic.catalog.repositories.base import TemplateCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import TemplateQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # repository's list() method shadows the built-in
+
+
+class NagraTemplateCatalogRepository(TemplateCatalogRepository):
+    """Nagra/Postgres-backed template catalog repository.
+
+    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
+    land in story 15.2. The constructor calls :func:`_ensure_schema_loaded`
+    so instantiation is always safe once ``nagra`` is available.
+    """
+
+    def __init__(self, conn_string: str) -> None:
+        """Initialise with a Nagra connection string and load the shared schema.
+
+        Args:
+            conn_string: Nagra-compatible Postgres connection string.
+        """
+        from akgentic.catalog.repositories.postgres import _ensure_schema_loaded
+
+        _ensure_schema_loaded()
+        self._conn_string = conn_string
+        logger.info("NagraTemplateCatalogRepository initialised")
+
+    def create(self, template_entry: TemplateEntry) -> str:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def get(self, id: str) -> TemplateEntry | None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def list(self) -> _list[TemplateEntry]:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def update(self, id: str, template_entry: TemplateEntry) -> None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def delete(self, id: str) -> None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")

--- a/src/akgentic/catalog/repositories/postgres/tool_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/tool_repo.py
@@ -1,0 +1,62 @@
+"""Nagra-backed tool repository (stub — CRUD arrives in story 15.2)."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import TYPE_CHECKING
+
+from akgentic.catalog.models.tool import ToolEntry
+from akgentic.catalog.repositories.base import ToolCatalogRepository
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import ToolQuery
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # repository's list() method shadows the built-in
+
+
+class NagraToolCatalogRepository(ToolCatalogRepository):
+    """Nagra/Postgres-backed tool catalog repository.
+
+    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
+    land in story 15.2. The constructor calls :func:`_ensure_schema_loaded`
+    so instantiation is always safe once ``nagra`` is available.
+    """
+
+    def __init__(self, conn_string: str) -> None:
+        """Initialise with a Nagra connection string and load the shared schema.
+
+        Args:
+            conn_string: Nagra-compatible Postgres connection string.
+        """
+        from akgentic.catalog.repositories.postgres import _ensure_schema_loaded
+
+        _ensure_schema_loaded()
+        self._conn_string = conn_string
+        logger.info("NagraToolCatalogRepository initialised")
+
+    def create(self, tool_entry: ToolEntry) -> str:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def get(self, id: str) -> ToolEntry | None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def list(self) -> _list[ToolEntry]:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def search(self, query: ToolQuery) -> _list[ToolEntry]:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def update(self, id: str, tool_entry: ToolEntry) -> None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")
+
+    def delete(self, id: str) -> None:
+        """Scaffolded — real CRUD arrives in story 15.2."""
+        raise NotImplementedError("Implemented in story 15.2/15.3")

--- a/tests/repositories/postgres/conftest.py
+++ b/tests/repositories/postgres/conftest.py
@@ -1,0 +1,73 @@
+"""Fixtures for Postgres (Nagra) repository tests.
+
+Uses ``testcontainers[postgres]`` to spin up a single session-scoped
+``postgres:16-alpine`` container. If ``nagra`` or ``testcontainers.postgres``
+is not importable, the whole module (and therefore every Postgres test) is
+skipped via ``pytest.importorskip`` — mirrors the Mongo test layout.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+from akgentic.catalog.repositories.postgres import init_db  # noqa: E402
+
+if TYPE_CHECKING:
+    pass
+
+
+def _to_nagra_conn_string(sqlalchemy_url: str) -> str:
+    """Convert the testcontainers SQLAlchemy-style URL to a libpq URL.
+
+    ``testcontainers`` emits URLs like
+    ``postgresql+psycopg2://user:pw@host:port/db``. Nagra's ``Transaction``
+    wraps a psycopg / libpq connection, which accepts the standard
+    ``postgresql://`` scheme without the driver suffix. Strip the driver so
+    the URL is portable regardless of Nagra's current psycopg binding.
+    """
+    if "+" in sqlalchemy_url.split("://", 1)[0]:
+        scheme, rest = sqlalchemy_url.split("://", 1)
+        scheme = scheme.split("+", 1)[0]
+        return f"{scheme}://{rest}"
+    return sqlalchemy_url
+
+
+@pytest.fixture(scope="session")
+def postgres_container() -> Iterator[PostgresContainer]:
+    """Start a single postgres:16-alpine container for the test session."""
+    with PostgresContainer("postgres:16-alpine") as container:
+        yield container
+
+
+@pytest.fixture(scope="session")
+def postgres_conn_string(postgres_container: PostgresContainer) -> str:
+    """Nagra-compatible connection string derived from the session container."""
+    raw_url = postgres_container.get_connection_url()
+    return _to_nagra_conn_string(raw_url)
+
+
+@pytest.fixture(scope="session")
+def postgres_initialized(postgres_conn_string: str) -> str:
+    """Run ``init_db`` exactly once against the session container."""
+    init_db(postgres_conn_string)
+    return postgres_conn_string
+
+
+@pytest.fixture
+def postgres_clean_tables(postgres_initialized: str) -> Iterator[str]:
+    """Truncate the four catalog tables between tests."""
+    from nagra import Transaction
+
+    yield postgres_initialized
+    with Transaction(postgres_initialized) as trn:
+        trn.execute(
+            "TRUNCATE template_entries, tool_entries, agent_entries, team_entries"
+        )

--- a/tests/repositories/postgres/test_import_gate.py
+++ b/tests/repositories/postgres/test_import_gate.py
@@ -1,0 +1,91 @@
+"""Import-gate tests for the Postgres backend (AC #8, #9).
+
+Mirrors the Mongo gate test layout — simulates missing ``nagra`` via
+``sys.modules`` patching so the real installed copy isn't disturbed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+class TestLazyImportGate:
+    """AC #8/#9: postgres import gate raises on missing nagra; top-level catalog unaffected."""
+
+    def test_postgres_import_raises_when_nagra_unavailable(self) -> None:
+        """Simulating missing nagra triggers ImportError with install instructions."""
+        mod_name = "akgentic.catalog.repositories.postgres"
+        saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key.startswith(mod_name):
+                saved[key] = sys.modules.pop(key)
+        nagra_saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key.startswith("nagra"):
+                nagra_saved[key] = sys.modules.pop(key)
+
+        try:
+            with patch.dict(sys.modules, {"nagra": None}):
+                with pytest.raises(ImportError) as excinfo:
+                    importlib.import_module(mod_name)
+                message = str(excinfo.value)
+                assert "nagra is required" in message
+                assert "akgentic-catalog[postgres]" in message
+        finally:
+            sys.modules.update(saved)
+            sys.modules.update(nagra_saved)
+
+    def test_top_level_catalog_import_unaffected_when_nagra_absent(self) -> None:
+        """Top-level ``akgentic.catalog`` must still import when nagra is absent."""
+        mod_name = "akgentic.catalog"
+        postgres_name = "akgentic.catalog.repositories.postgres"
+
+        # Drop cached copies of the top-level catalog and postgres subpackage
+        # so re-import exercises the real import path.
+        saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key == mod_name or key.startswith(f"{mod_name}."):
+                saved[key] = sys.modules.pop(key)
+        nagra_saved: dict[str, object] = {}
+        for key in list(sys.modules):
+            if key.startswith("nagra"):
+                nagra_saved[key] = sys.modules.pop(key)
+
+        try:
+            with patch.dict(sys.modules, {"nagra": None}):
+                importlib.import_module(mod_name)
+                # And confirm the postgres subpackage still raises under the gate.
+                with pytest.raises(ImportError):
+                    importlib.import_module(postgres_name)
+        finally:
+            # Drop anything imported under the patched context to avoid poisoning
+            # other tests, then restore originals.
+            for key in list(sys.modules):
+                if key == mod_name or key.startswith(f"{mod_name}."):
+                    del sys.modules[key]
+            sys.modules.update(saved)
+            sys.modules.update(nagra_saved)
+
+    def test_postgres_import_exports_expected_symbols_when_nagra_available(self) -> None:
+        """When nagra is present the postgres subpackage re-exports the public API."""
+        pytest.importorskip("nagra")
+
+        from akgentic.catalog.repositories.postgres import (
+            NagraAgentCatalogRepository,
+            NagraTeamCatalogRepository,
+            NagraTemplateCatalogRepository,
+            NagraToolCatalogRepository,
+            _ensure_schema_loaded,
+            init_db,
+        )
+
+        assert callable(_ensure_schema_loaded)
+        assert callable(init_db)
+        assert NagraAgentCatalogRepository is not None
+        assert NagraTeamCatalogRepository is not None
+        assert NagraTemplateCatalogRepository is not None
+        assert NagraToolCatalogRepository is not None

--- a/tests/repositories/postgres/test_init_db.py
+++ b/tests/repositories/postgres/test_init_db.py
@@ -1,0 +1,124 @@
+"""Tests for ``_ensure_schema_loaded`` and ``init_db`` (AC #4, #5, #6, #7, #16).
+
+Contains two groups:
+
+* **Unit tests** that don't need a Postgres container — spy on
+  ``Schema.default.load_toml`` to assert ``_ensure_schema_loaded`` runs the
+  load exactly once, and grep the repo stubs to confirm ``init_db`` is not
+  called from constructors.
+* **Integration tests** that use the session-scoped ``postgres_initialized``
+  fixture to exercise ``init_db`` against a real container, including an
+  idempotency pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("nagra")
+
+if TYPE_CHECKING:
+    pass
+
+
+class TestEnsureSchemaLoadedIdempotent:
+    """AC #4: ``_ensure_schema_loaded`` performs its work exactly once."""
+
+    def test_load_toml_called_once_across_repeated_calls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Force a fresh guard and stub ``load_toml`` so tables never actually register.
+
+        Without the stub, running ``_ensure_schema_loaded`` here would populate
+        ``Schema.default`` globally and poison later tests. The stub lets us
+        observe the call count cleanly — and because we also reset
+        ``_SCHEMA_LOADED`` back to its pre-test value afterwards, the real
+        schema loader in the session fixture still runs exactly once.
+        """
+        import akgentic.catalog.repositories.postgres as pg_pkg
+        from nagra import Schema
+
+        # Save the pre-test guard value so we can restore it exactly — monkeypatch
+        # would also restore it, but we want both directions to be explicit.
+        original_flag = pg_pkg._SCHEMA_LOADED
+        monkeypatch.setattr(pg_pkg, "_SCHEMA_LOADED", False, raising=False)
+
+        call_count = {"n": 0}
+
+        def stub_load(path: Path) -> object:
+            call_count["n"] += 1
+            return None
+
+        monkeypatch.setattr(Schema.default, "load_toml", stub_load)
+
+        pg_pkg._ensure_schema_loaded()
+        pg_pkg._ensure_schema_loaded()
+        pg_pkg._ensure_schema_loaded()
+
+        assert call_count["n"] == 1
+
+        # Restore the original guard so later fixtures/tests see a consistent state.
+        monkeypatch.setattr(pg_pkg, "_SCHEMA_LOADED", original_flag, raising=False)
+
+
+class TestRepoStubsDoNotCallInitDb:
+    """AC #7: No repository stub calls ``init_db`` in its constructor."""
+
+    def test_stub_sources_contain_no_init_db_call(self) -> None:
+        stub_names = ["template_repo.py", "tool_repo.py", "agent_repo.py", "team_repo.py"]
+        pkg_dir = (
+            Path(__file__).parents[3]
+            / "src"
+            / "akgentic"
+            / "catalog"
+            / "repositories"
+            / "postgres"
+        )
+        for stub in stub_names:
+            text = (pkg_dir / stub).read_text()
+            assert "init_db(" not in text, f"{stub} must not call init_db()"
+            assert "_ensure_schema_loaded" in text, (
+                f"{stub} must call _ensure_schema_loaded() in __init__"
+            )
+
+
+class TestInitDbIntegration:
+    """AC #5, #6, #16: ``init_db`` creates tables and is idempotent."""
+
+    def test_init_db_creates_four_tables(self, postgres_initialized: str) -> None:
+        from nagra import Transaction
+
+        expected = {"template_entries", "tool_entries", "agent_entries", "team_entries"}
+        with Transaction(postgres_initialized) as trn:
+            cursor = trn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public'"
+            )
+            found = {row[0] for row in cursor.fetchall()}
+        assert expected.issubset(found)
+
+    def test_init_db_is_idempotent(self, postgres_initialized: str) -> None:
+        from akgentic.catalog.repositories.postgres import init_db
+        from nagra import Transaction
+
+        with Transaction(postgres_initialized) as trn:
+            cursor = trn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public'"
+            )
+            before = {row[0] for row in cursor.fetchall()}
+
+        # Second call must not raise and must not change the table set.
+        init_db(postgres_initialized)
+
+        with Transaction(postgres_initialized) as trn:
+            cursor = trn.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = 'public'"
+            )
+            after = {row[0] for row in cursor.fetchall()}
+
+        assert before == after

--- a/tests/repositories/postgres/test_schema_file.py
+++ b/tests/repositories/postgres/test_schema_file.py
@@ -1,0 +1,54 @@
+"""Shape tests for ``schema.toml`` (AC #3).
+
+These tests parse the file with ``tomllib`` directly — no Nagra or Postgres
+container needed — so they run in every environment.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+SCHEMA_PATH = (
+    Path(__file__).parents[3]
+    / "src"
+    / "akgentic"
+    / "catalog"
+    / "repositories"
+    / "postgres"
+    / "schema.toml"
+)
+
+EXPECTED_TABLES = {"template_entries", "tool_entries", "agent_entries", "team_entries"}
+
+
+def _load_schema() -> dict[str, object]:
+    with SCHEMA_PATH.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def test_schema_file_exists() -> None:
+    assert SCHEMA_PATH.exists(), f"schema.toml missing at {SCHEMA_PATH}"
+
+
+def test_schema_has_exactly_four_top_level_tables() -> None:
+    schema = _load_schema()
+    assert set(schema.keys()) == EXPECTED_TABLES
+
+
+def test_each_table_has_natural_key_id() -> None:
+    schema = _load_schema()
+    for table in EXPECTED_TABLES:
+        table_block = schema[table]
+        assert isinstance(table_block, dict)
+        assert table_block["natural_key"] == ["id"], f"{table} natural_key mismatch"
+
+
+def test_each_table_has_exactly_id_and_data_columns() -> None:
+    schema = _load_schema()
+    for table in EXPECTED_TABLES:
+        table_block = schema[table]
+        assert isinstance(table_block, dict)
+        columns = table_block["columns"]
+        assert isinstance(columns, dict)
+        assert columns == {"id": "str", "data": "json"}, f"{table} columns mismatch"

--- a/tests/repositories/postgres/test_wheel_packaging.py
+++ b/tests/repositories/postgres/test_wheel_packaging.py
@@ -1,0 +1,56 @@
+"""Wheel packaging test (AC #11).
+
+Runs ``uv build`` for the akgentic-catalog package and verifies the resulting
+wheel contains ``akgentic/catalog/repositories/postgres/schema.toml``. Skipped
+when ``uv`` is not on ``PATH`` — CI provisions ``uv`` so the assertion runs
+there.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+# Resolve to packages/akgentic-catalog/
+PKG_ROOT = Path(__file__).parents[3]
+# Resolve to workspace root (parent of packages/)
+WORKSPACE_ROOT = PKG_ROOT.parents[1]
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv CLI not available on PATH")
+def test_wheel_contains_schema_toml(tmp_path: Path) -> None:
+    """`uv build --wheel` produces a wheel that ships ``schema.toml``."""
+    result = subprocess.run(
+        [
+            "uv",
+            "build",
+            "--package",
+            "akgentic-catalog",
+            "--wheel",
+            "--out-dir",
+            str(tmp_path),
+        ],
+        cwd=str(WORKSPACE_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"uv build failed in this environment: {result.stderr.strip()}")
+
+    wheels = sorted(tmp_path.glob("akgentic_catalog-*.whl"))
+    assert wheels, f"No wheel produced in {tmp_path}: {list(tmp_path.iterdir())}"
+    wheel = wheels[-1]
+
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+
+    expected = "akgentic/catalog/repositories/postgres/schema.toml"
+    assert expected in names, (
+        f"{expected} missing from wheel; contents sample: "
+        f"{sorted(n for n in names if 'postgres' in n)}"
+    )


### PR DESCRIPTION
## Summary

Scaffolds the Nagra-backed Postgres backend for the catalog package per ADR-006 §3–§7:

- New `repositories/postgres/` subpackage with schema loader, `init_db` deployment hook, and four stub repositories (CRUD arrives in 15.2 / 15.3).
- `schema.toml` authored verbatim from the ADR — four JSONB tables (`template_entries`, `tool_entries`, `agent_entries`, `team_entries`), each with `natural_key = ["id"]` and columns `id = "str"`, `data = "json"`.
- Lazy-import gate mirroring the Mongo backend: `import akgentic.catalog` stays safe when `nagra` is absent; `import akgentic.catalog.repositories.postgres` raises a directive `ImportError`.
- `pyproject.toml` additions: `[postgres]` optional extra (`nagra>=0.5`, `psycopg[binary]>=3.1`); dev extras gain `nagra`, `psycopg[binary]`, `testcontainers[postgres]>=4.0.0`; hatch `force-include` ships `schema.toml` in the wheel.
- Test suite with session-scoped `postgres:16-alpine` container, per-test truncation fixture, idempotency test, import-gate tests, schema-shape tests, and a wheel packaging test.

Closes #94

## Review notes

Reviewed by Rex (code-review workflow). No HIGH or CRITICAL findings. Three LOW/MEDIUM advisory notes recorded in the story file for follow-up in 15.2 — none block merge. CI green on `a2716e8`.
