### PR TITLE
Nagra Repositories for Templates and Tools

### DIFF
--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -1,10 +1,149 @@
-"""Scaffold for shared JSONB predicate builders used by the Nagra repositories.
+"""Shared JSONB predicate builders for the Nagra-backed Postgres repositories.
 
-The real predicate helpers land in stories 15.2 and 15.3 — this module is
-deliberately left empty so the package directory structure is in place and
-downstream imports can stabilise without premature coupling.
+Each builder returns a ``(sql_fragment, params)`` tuple where:
+
+* ``sql_fragment`` is a raw SQL condition string using ``%s`` as the psycopg
+  placeholder marker — the same marker Nagra's Transaction uses when it hands
+  a statement to psycopg under the hood. No user-supplied value is ever
+  interpolated into the fragment text; every variable appears as ``%s`` and is
+  passed through ``params``.
+* ``params`` is the list of bound values in argument order.
+
+The module exposes per-field helpers (``template_id_predicate``, ``tool_name_predicate``,
+etc.) plus two compose helpers (``build_template_where`` / ``build_tool_where``)
+that walk the non-None fields of a query model and AND-combine the per-field
+predicates. Story 15.3 will extend the same module with agent / team builders.
+
+Implements ADR-006 §4 predicate table for Template and Tool queries. See the
+ToolEntry nested-path note: because ``ToolEntry.model_dump()`` places ``name``
+and ``description`` inside a nested ``tool`` object, the JSONB path uses
+``data->'tool'->>'name'`` (not the top-level ``data->>'name'`` shown in the
+ADR table).
 """
 
 from __future__ import annotations
 
-# Predicate builders arrive in stories 15.2 / 15.3 — intentionally empty scaffold.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from akgentic.catalog.models.queries import TemplateQuery, ToolQuery
+
+__all__ = [
+    "build_template_where",
+    "build_tool_where",
+    "template_id_predicate",
+    "template_placeholder_predicate",
+    "tool_description_predicate",
+    "tool_id_predicate",
+    "tool_name_predicate",
+    "tool_tool_class_predicate",
+]
+
+
+# --- Per-field predicate builders (Template) ---
+
+
+def template_id_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->>'id' = %s`` predicate for an exact-id match."""
+    return "data->>'id' = %s", [value]
+
+
+def template_placeholder_predicate(value: str) -> tuple[str, list[object]]:
+    """Build JSONB key-existence predicate on the ``placeholders`` array.
+
+    Uses the Postgres ``?`` operator (does the right-hand text exist as a
+    top-level key in the left-hand JSONB?). Against a JSON array of strings,
+    this returns true when the value equals one of the array's string
+    elements — matching ``placeholder in entry.placeholders`` semantics of the
+    YAML and Mongo backends.
+
+    The ``?`` operator is only defined for ``jsonb`` (not plain ``json``);
+    the ``data`` column is declared as ``JSON`` in ``schema.toml`` (story
+    15.1 invariant), so the value is cast to ``jsonb`` at query time.
+    """
+    return "(data->'placeholders')::jsonb ? %s", [value]
+
+
+# --- Per-field predicate builders (Tool) ---
+
+
+def tool_id_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->>'id' = %s`` predicate for an exact-id match."""
+    return "data->>'id' = %s", [value]
+
+
+def tool_tool_class_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->>'tool_class' = %s`` predicate for an exact class-path match."""
+    return "data->>'tool_class' = %s", [value]
+
+
+def tool_name_predicate(value: str) -> tuple[str, list[object]]:
+    """Build a case-insensitive substring predicate on the tool's display name.
+
+    The JSONB path is ``data->'tool'->>'name'`` because ``ToolEntry.model_dump()``
+    nests ``name`` under a ``tool`` object — matching the Mongo backend's
+    ``tool.name`` filter. The parameter is wrapped with ``%`` characters so
+    the ILIKE operator performs substring matching.
+    """
+    return "data->'tool'->>'name' ILIKE %s", [f"%{value}%"]
+
+
+def tool_description_predicate(value: str) -> tuple[str, list[object]]:
+    """Build a case-insensitive substring predicate on the tool's description.
+
+    Uses the same nested JSONB path convention as :func:`tool_name_predicate`.
+    """
+    return "data->'tool'->>'description' ILIKE %s", [f"%{value}%"]
+
+
+# --- Compose helpers ---
+
+
+def _combine(
+    fragments: list[tuple[str, list[object]]],
+) -> tuple[str | None, list[object]]:
+    """AND-combine a list of ``(fragment, params)`` pairs.
+
+    Returns ``(None, [])`` when the input list is empty so callers can fall
+    back to a bare SELECT without an empty WHERE clause.
+    """
+    if not fragments:
+        return None, []
+    clauses = [frag for frag, _ in fragments]
+    params: list[object] = []
+    for _, param_list in fragments:
+        params.extend(param_list)
+    where_sql = " AND ".join(clauses)
+    return where_sql, params
+
+
+def build_template_where(query: TemplateQuery) -> tuple[str | None, list[object]]:
+    """Build the WHERE-clause fragment for a :class:`TemplateQuery`.
+
+    Returns ``(None, [])`` when no fields are set (callers issue a bare SELECT).
+    Otherwise returns ``(sql_fragment, params)`` with all fields AND-combined.
+    """
+    fragments: list[tuple[str, list[object]]] = []
+    if query.id is not None:
+        fragments.append(template_id_predicate(query.id))
+    if query.placeholder is not None:
+        fragments.append(template_placeholder_predicate(query.placeholder))
+    return _combine(fragments)
+
+
+def build_tool_where(query: ToolQuery) -> tuple[str | None, list[object]]:
+    """Build the WHERE-clause fragment for a :class:`ToolQuery`.
+
+    Returns ``(None, [])`` when no fields are set (callers issue a bare SELECT).
+    Otherwise returns ``(sql_fragment, params)`` with all fields AND-combined.
+    """
+    fragments: list[tuple[str, list[object]]] = []
+    if query.id is not None:
+        fragments.append(tool_id_predicate(query.id))
+    if query.tool_class is not None:
+        fragments.append(tool_tool_class_predicate(query.tool_class))
+    if query.name is not None:
+        fragments.append(tool_name_predicate(query.name))
+    if query.description is not None:
+        fragments.append(tool_description_predicate(query.description))
+    return _combine(fragments)

--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -23,7 +23,8 @@ ADR table).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TemplateQuery, ToolQuery
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 __all__ = [
     "build_template_where",
     "build_tool_where",
+    "decode_jsonb_column",
     "template_id_predicate",
     "template_placeholder_predicate",
     "tool_description_predicate",
@@ -38,6 +40,23 @@ __all__ = [
     "tool_name_predicate",
     "tool_tool_class_predicate",
 ]
+
+
+# --- JSONB column decoding (shared across repos) ---
+
+
+def decode_jsonb_column(raw: object) -> dict[str, object]:
+    """Normalise a JSONB column value to a Python dict.
+
+    psycopg 3 decodes JSONB columns to native Python objects by default, but
+    some driver configurations (or the plain ``JSON`` column type) return a
+    JSON string. Handle both so hydration is robust regardless of the adapter
+    wiring. Shared by ``template_repo`` and ``tool_repo`` (and by story 15.3's
+    agent / team repos) to keep the JSONB↔dict contract in one place.
+    """
+    if isinstance(raw, str):
+        return cast("dict[str, object]", json.loads(raw))
+    return cast("dict[str, object]", raw)
 
 
 # --- Per-field predicate builders (Template) ---

--- a/src/akgentic/catalog/repositories/postgres/template_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/template_repo.py
@@ -1,13 +1,27 @@
-"""Nagra-backed template repository (stub — CRUD arrives in story 15.2)."""
+"""Nagra/Postgres-backed repository for template catalog entries.
+
+Implements ADR-006 §2 (per-method Transaction ownership), §3 (two-column
+JSONB table shape), §4 (predicate table — Template rows), and §8 (error
+handling parity with the Mongo backend). All SQL text is assembled from the
+fragment builders in :mod:`_queries`; raw user input is never interpolated
+into SQL text — every variable is passed through as a psycopg ``%s`` bound
+parameter.
+"""
 
 from __future__ import annotations
 
 import builtins
+import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from nagra import Transaction  # type: ignore[import-untyped]
+from psycopg.errors import UniqueViolation
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
+from akgentic.catalog.repositories.postgres._queries import build_template_where
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TemplateQuery
@@ -20,9 +34,9 @@ _list = builtins.list  # repository's list() method shadows the built-in
 class NagraTemplateCatalogRepository(TemplateCatalogRepository):
     """Nagra/Postgres-backed template catalog repository.
 
-    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
-    land in story 15.2. The constructor calls :func:`_ensure_schema_loaded`
-    so instantiation is always safe once ``nagra`` is available.
+    Each method opens and closes its own ``Transaction(self._conn_string)``
+    so callers never see a transaction object. The constructor performs no
+    I/O beyond loading the shared Nagra schema (idempotent).
     """
 
     def __init__(self, conn_string: str) -> None:
@@ -38,25 +52,145 @@ class NagraTemplateCatalogRepository(TemplateCatalogRepository):
         logger.info("NagraTemplateCatalogRepository initialised")
 
     def create(self, template_entry: TemplateEntry) -> str:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Persist a new template entry.
+
+        Inserts a row into ``template_entries`` with ``id = template_entry.id``
+        and ``data = template_entry.model_dump()``. Translates psycopg's
+        ``UniqueViolation`` to :class:`CatalogValidationError` so callers see
+        the same exception type as the YAML and Mongo backends emit on a
+        duplicate id.
+
+        Args:
+            template_entry: The template entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        data_json = json.dumps(template_entry.model_dump())
+        try:
+            with Transaction(self._conn_string) as trn:
+                trn.execute(
+                    "INSERT INTO template_entries (id, data) VALUES (%s, %s)",
+                    (template_entry.id, data_json),
+                )
+        except UniqueViolation:
+            raise CatalogValidationError(
+                [f"Entry with id '{template_entry.id}' already exists"]
+            )
+        logger.debug("Created template entry with id=%s", template_entry.id)
+        return template_entry.id
 
     def get(self, id: str) -> TemplateEntry | None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Retrieve a template entry by id.
+
+        Args:
+            id: The template entry id.
+
+        Returns:
+            The template entry, or ``None`` if no row matches.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM template_entries WHERE id = %s",
+                (id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            logger.debug("Template entry not found: id=%s", id)
+            return None
+        return TemplateEntry.model_validate(self._decode_data(row[0]))
 
     def list(self) -> _list[TemplateEntry]:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Return every template entry (order unspecified)."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute("SELECT data FROM template_entries")
+            rows = cursor.fetchall()
+        entries = [TemplateEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        logger.debug("Listed %d template entries", len(entries))
+        return entries
 
     def search(self, query: TemplateQuery) -> _list[TemplateEntry]:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Filter templates by AND-ing all non-None query fields.
+
+        Delegates predicate construction to
+        :func:`_queries.build_template_where`. When the helper signals "no
+        filter" (an empty query), issues a bare ``SELECT`` — equivalent to
+        :meth:`list`.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching template entries (order unspecified).
+        """
+        where_sql, params = build_template_where(query)
+        if where_sql is None:
+            sql = "SELECT data FROM template_entries"
+        else:
+            sql = f"SELECT data FROM template_entries WHERE {where_sql}"
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(sql, tuple(params))
+            rows = cursor.fetchall()
+        results = [TemplateEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        logger.debug("Search returned %d template entries", len(results))
+        return results
 
     def update(self, id: str, template_entry: TemplateEntry) -> None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Update an existing template entry.
+
+        Args:
+            id: The id of the entry to update.
+            template_entry: The new entry data.
+
+        Raises:
+            CatalogValidationError: If ``template_entry.id`` does not match ``id``.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if template_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{template_entry.id}'"]
+            )
+        data_json = json.dumps(template_entry.model_dump())
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "UPDATE template_entries SET data = %s WHERE id = %s",
+                (data_json, id),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated template entry with id=%s", id)
 
     def delete(self, id: str) -> None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Delete a template entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "DELETE FROM template_entries WHERE id = %s",
+                (id,),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted template entry with id=%s", id)
+
+    @staticmethod
+    def _decode_data(raw: object) -> dict[str, object]:
+        """Normalise a JSONB column value to a Python dict.
+
+        psycopg 3 decodes JSONB columns to native Python objects by default,
+        but some driver configurations return a JSON string. Handle both so
+        hydration is robust regardless of the adapter wiring.
+        """
+        if isinstance(raw, str):
+            return cast("dict[str, object]", json.loads(raw))
+        return cast("dict[str, object]", raw)

--- a/src/akgentic/catalog/repositories/postgres/template_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/template_repo.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import builtins
 import json
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from nagra import Transaction  # type: ignore[import-untyped]
 from psycopg.errors import UniqueViolation
@@ -21,7 +21,10 @@ from psycopg.errors import UniqueViolation
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.repositories.base import TemplateCatalogRepository
-from akgentic.catalog.repositories.postgres._queries import build_template_where
+from akgentic.catalog.repositories.postgres._queries import (
+    build_template_where,
+    decode_jsonb_column,
+)
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TemplateQuery
@@ -101,14 +104,14 @@ class NagraTemplateCatalogRepository(TemplateCatalogRepository):
         if row is None:
             logger.debug("Template entry not found: id=%s", id)
             return None
-        return TemplateEntry.model_validate(self._decode_data(row[0]))
+        return TemplateEntry.model_validate(decode_jsonb_column(row[0]))
 
     def list(self) -> _list[TemplateEntry]:
         """Return every template entry (order unspecified)."""
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute("SELECT data FROM template_entries")
             rows = cursor.fetchall()
-        entries = [TemplateEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        entries = [TemplateEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
         logger.debug("Listed %d template entries", len(entries))
         return entries
 
@@ -134,7 +137,7 @@ class NagraTemplateCatalogRepository(TemplateCatalogRepository):
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute(sql, tuple(params))
             rows = cursor.fetchall()
-        results = [TemplateEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        results = [TemplateEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
         logger.debug("Search returned %d template entries", len(results))
         return results
 
@@ -182,15 +185,3 @@ class NagraTemplateCatalogRepository(TemplateCatalogRepository):
         if row_count == 0:
             raise EntryNotFoundError(f"Entry with id '{id}' not found")
         logger.debug("Deleted template entry with id=%s", id)
-
-    @staticmethod
-    def _decode_data(raw: object) -> dict[str, object]:
-        """Normalise a JSONB column value to a Python dict.
-
-        psycopg 3 decodes JSONB columns to native Python objects by default,
-        but some driver configurations return a JSON string. Handle both so
-        hydration is robust regardless of the adapter wiring.
-        """
-        if isinstance(raw, str):
-            return cast("dict[str, object]", json.loads(raw))
-        return cast("dict[str, object]", raw)

--- a/src/akgentic/catalog/repositories/postgres/tool_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/tool_repo.py
@@ -1,13 +1,24 @@
-"""Nagra-backed tool repository (stub — CRUD arrives in story 15.2)."""
+"""Nagra/Postgres-backed repository for tool catalog entries.
+
+Implements ADR-006 §2 (per-method Transaction ownership), §3 (two-column
+JSONB table shape), §4 (predicate table — Tool rows, adjusted for the nested
+``tool`` JSON path), and §8 (error handling parity with the Mongo backend).
+"""
 
 from __future__ import annotations
 
 import builtins
+import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from nagra import Transaction  # type: ignore[import-untyped]
+from psycopg.errors import UniqueViolation
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
+from akgentic.catalog.repositories.postgres._queries import build_tool_where
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import ToolQuery
@@ -20,9 +31,9 @@ _list = builtins.list  # repository's list() method shadows the built-in
 class NagraToolCatalogRepository(ToolCatalogRepository):
     """Nagra/Postgres-backed tool catalog repository.
 
-    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
-    land in story 15.2. The constructor calls :func:`_ensure_schema_loaded`
-    so instantiation is always safe once ``nagra`` is available.
+    Each method opens and closes its own ``Transaction(self._conn_string)``
+    so callers never see a transaction object. The constructor performs no
+    I/O beyond loading the shared Nagra schema (idempotent).
     """
 
     def __init__(self, conn_string: str) -> None:
@@ -38,25 +49,142 @@ class NagraToolCatalogRepository(ToolCatalogRepository):
         logger.info("NagraToolCatalogRepository initialised")
 
     def create(self, tool_entry: ToolEntry) -> str:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Persist a new tool entry.
+
+        Translates psycopg's ``UniqueViolation`` to :class:`CatalogValidationError`
+        so callers see the same exception type as the YAML and Mongo backends
+        emit on a duplicate id.
+
+        Args:
+            tool_entry: The tool entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        data_json = json.dumps(tool_entry.model_dump())
+        try:
+            with Transaction(self._conn_string) as trn:
+                trn.execute(
+                    "INSERT INTO tool_entries (id, data) VALUES (%s, %s)",
+                    (tool_entry.id, data_json),
+                )
+        except UniqueViolation:
+            raise CatalogValidationError(
+                [f"Entry with id '{tool_entry.id}' already exists"]
+            )
+        logger.debug("Created tool entry with id=%s", tool_entry.id)
+        return tool_entry.id
 
     def get(self, id: str) -> ToolEntry | None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Retrieve a tool entry by id.
+
+        Args:
+            id: The tool entry id.
+
+        Returns:
+            The tool entry, or ``None`` if no row matches.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM tool_entries WHERE id = %s",
+                (id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            logger.debug("Tool entry not found: id=%s", id)
+            return None
+        return ToolEntry.model_validate(self._decode_data(row[0]))
 
     def list(self) -> _list[ToolEntry]:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Return every tool entry (order unspecified)."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute("SELECT data FROM tool_entries")
+            rows = cursor.fetchall()
+        entries = [ToolEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        logger.debug("Listed %d tool entries", len(entries))
+        return entries
 
     def search(self, query: ToolQuery) -> _list[ToolEntry]:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Filter tools by AND-ing all non-None query fields.
+
+        Delegates predicate construction to :func:`_queries.build_tool_where`.
+        When the helper signals "no filter" (an empty query), issues a bare
+        ``SELECT`` — equivalent to :meth:`list`.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching tool entries (order unspecified).
+        """
+        where_sql, params = build_tool_where(query)
+        if where_sql is None:
+            sql = "SELECT data FROM tool_entries"
+        else:
+            sql = f"SELECT data FROM tool_entries WHERE {where_sql}"
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(sql, tuple(params))
+            rows = cursor.fetchall()
+        results = [ToolEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        logger.debug("Search returned %d tool entries", len(results))
+        return results
 
     def update(self, id: str, tool_entry: ToolEntry) -> None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Update an existing tool entry.
+
+        Args:
+            id: The id of the entry to update.
+            tool_entry: The new entry data.
+
+        Raises:
+            CatalogValidationError: If ``tool_entry.id`` does not match ``id``.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if tool_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{tool_entry.id}'"]
+            )
+        data_json = json.dumps(tool_entry.model_dump())
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "UPDATE tool_entries SET data = %s WHERE id = %s",
+                (data_json, id),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated tool entry with id=%s", id)
 
     def delete(self, id: str) -> None:
-        """Scaffolded — real CRUD arrives in story 15.2."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Delete a tool entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "DELETE FROM tool_entries WHERE id = %s",
+                (id,),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted tool entry with id=%s", id)
+
+    @staticmethod
+    def _decode_data(raw: object) -> dict[str, object]:
+        """Normalise a JSONB column value to a Python dict.
+
+        psycopg 3 decodes JSONB columns to native Python objects by default,
+        but some driver configurations return a JSON string. Handle both so
+        hydration is robust regardless of the adapter wiring.
+        """
+        if isinstance(raw, str):
+            return cast("dict[str, object]", json.loads(raw))
+        return cast("dict[str, object]", raw)

--- a/src/akgentic/catalog/repositories/postgres/tool_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/tool_repo.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import builtins
 import json
 import logging
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from nagra import Transaction  # type: ignore[import-untyped]
 from psycopg.errors import UniqueViolation
@@ -18,7 +18,10 @@ from psycopg.errors import UniqueViolation
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import ToolCatalogRepository
-from akgentic.catalog.repositories.postgres._queries import build_tool_where
+from akgentic.catalog.repositories.postgres._queries import (
+    build_tool_where,
+    decode_jsonb_column,
+)
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import ToolQuery
@@ -96,14 +99,14 @@ class NagraToolCatalogRepository(ToolCatalogRepository):
         if row is None:
             logger.debug("Tool entry not found: id=%s", id)
             return None
-        return ToolEntry.model_validate(self._decode_data(row[0]))
+        return ToolEntry.model_validate(decode_jsonb_column(row[0]))
 
     def list(self) -> _list[ToolEntry]:
         """Return every tool entry (order unspecified)."""
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute("SELECT data FROM tool_entries")
             rows = cursor.fetchall()
-        entries = [ToolEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        entries = [ToolEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
         logger.debug("Listed %d tool entries", len(entries))
         return entries
 
@@ -128,7 +131,7 @@ class NagraToolCatalogRepository(ToolCatalogRepository):
         with Transaction(self._conn_string) as trn:
             cursor = trn.execute(sql, tuple(params))
             rows = cursor.fetchall()
-        results = [ToolEntry.model_validate(self._decode_data(r[0])) for r in rows]
+        results = [ToolEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
         logger.debug("Search returned %d tool entries", len(results))
         return results
 
@@ -176,15 +179,3 @@ class NagraToolCatalogRepository(ToolCatalogRepository):
         if row_count == 0:
             raise EntryNotFoundError(f"Entry with id '{id}' not found")
         logger.debug("Deleted tool entry with id=%s", id)
-
-    @staticmethod
-    def _decode_data(raw: object) -> dict[str, object]:
-        """Normalise a JSONB column value to a Python dict.
-
-        psycopg 3 decodes JSONB columns to native Python objects by default,
-        but some driver configurations return a JSON string. Handle both so
-        hydration is robust regardless of the adapter wiring.
-        """
-        if isinstance(raw, str):
-            return cast("dict[str, object]", json.loads(raw))
-        return cast("dict[str, object]", raw)

--- a/tests/repositories/postgres/test_nagra_template_repo.py
+++ b/tests/repositories/postgres/test_nagra_template_repo.py
@@ -9,8 +9,6 @@ that makes the whole module skip cleanly when the Postgres extras are absent.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 pytest.importorskip("nagra")
@@ -25,9 +23,6 @@ from akgentic.catalog.repositories.postgres.template_repo import (  # noqa: E402
     NagraTemplateCatalogRepository,
 )
 from tests.conftest import make_template  # noqa: E402
-
-if TYPE_CHECKING:
-    pass
 
 
 @pytest.fixture

--- a/tests/repositories/postgres/test_nagra_template_repo.py
+++ b/tests/repositories/postgres/test_nagra_template_repo.py
@@ -1,0 +1,182 @@
+"""Behavioural tests for :class:`NagraTemplateCatalogRepository`.
+
+Mirrors the Mongo suite at ``tests/repositories/mongo/test_mongo_template_repo.py``
+so that the Nagra backend honours the same CRUD and search contract. Every
+test requests the per-test truncation fixture ``postgres_clean_tables`` from
+the sibling ``conftest.py`` — which also carries the ``pytest.importorskip``
+that makes the whole module skip cleanly when the Postgres extras are absent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.catalog.models.errors import (  # noqa: E402
+    CatalogValidationError,
+    EntryNotFoundError,
+)
+from akgentic.catalog.models.queries import TemplateQuery  # noqa: E402
+from akgentic.catalog.repositories.postgres.template_repo import (  # noqa: E402
+    NagraTemplateCatalogRepository,
+)
+from tests.conftest import make_template  # noqa: E402
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def repo(postgres_clean_tables: str) -> NagraTemplateCatalogRepository:
+    """Fresh repo backed by the per-test-truncated Postgres container."""
+    return NagraTemplateCatalogRepository(postgres_clean_tables)
+
+
+class TestCreateAndGet:
+    """create + get round-trip and duplicate-id handling."""
+
+    def test_create_and_get_round_trip(self, repo: NagraTemplateCatalogRepository) -> None:
+        entry = make_template(id="tpl-1", template="Hello {name}, you are {role}.")
+        created_id = repo.create(entry)
+        assert created_id == "tpl-1"
+
+        retrieved = repo.get("tpl-1")
+        assert retrieved is not None
+        assert retrieved.id == "tpl-1"
+        assert retrieved.template == "Hello {name}, you are {role}."
+        # placeholders is a computed field derived from the template body —
+        # the round trip through JSONB must preserve it.
+        assert set(retrieved.placeholders) == {"name", "role"}
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        entry = make_template(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """list() enumerates all rows."""
+
+    def test_list_empty(self, repo: NagraTemplateCatalogRepository) -> None:
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: NagraTemplateCatalogRepository) -> None:
+        repo.create(make_template(id="tpl-a", template="Template {a}"))
+        repo.create(make_template(id="tpl-b", template="Template {b}"))
+        repo.create(make_template(id="tpl-c", template="Template {c}"))
+
+        results = repo.list()
+        assert len(results) == 3
+        assert {e.id for e in results} == {"tpl-a", "tpl-b", "tpl-c"}
+
+
+class TestSearch:
+    """search() predicate builders behave like the Mongo backend."""
+
+    def test_search_by_id_hit_and_miss(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        repo.create(make_template(id="tpl-1", template="A {x}"))
+        repo.create(make_template(id="tpl-2", template="B {y}"))
+
+        hit = repo.search(TemplateQuery(id="tpl-1"))
+        assert len(hit) == 1
+        assert hit[0].id == "tpl-1"
+
+        miss = repo.search(TemplateQuery(id="tpl-missing"))
+        assert miss == []
+
+    def test_search_by_placeholder_containment(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        repo.create(make_template(id="tpl-1", template="Hello {name}, welcome to {place}."))
+        repo.create(make_template(id="tpl-2", template="Dear {title} {name},"))
+        repo.create(make_template(id="tpl-3", template="System {role} prompt"))
+
+        results = repo.search(TemplateQuery(placeholder="name"))
+        assert {e.id for e in results} == {"tpl-1", "tpl-2"}
+
+        assert repo.search(TemplateQuery(placeholder="nope")) == []
+
+    def test_search_multiple_anded_fields(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        repo.create(make_template(id="tpl-1", template="Hello {name}, {role}."))
+        repo.create(make_template(id="tpl-2", template="Hey {name}!"))
+
+        both_match = repo.search(TemplateQuery(id="tpl-1", placeholder="name"))
+        assert len(both_match) == 1
+        assert both_match[0].id == "tpl-1"
+
+        id_ok_placeholder_missing = repo.search(
+            TemplateQuery(id="tpl-2", placeholder="role")
+        )
+        assert id_ok_placeholder_missing == []
+
+    def test_search_no_filters_returns_all(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        repo.create(make_template(id="tpl-1"))
+        repo.create(make_template(id="tpl-2"))
+
+        results = repo.search(TemplateQuery())
+        assert len(results) == 2
+
+
+class TestUpdate:
+    """update() replaces rows and enforces id contract."""
+
+    def test_update_existing_entry(self, repo: NagraTemplateCatalogRepository) -> None:
+        repo.create(make_template(id="tpl-1", template="Old {x}"))
+
+        updated = make_template(id="tpl-1", template="New {y} template")
+        repo.update("tpl-1", updated)
+
+        retrieved = repo.get("tpl-1")
+        assert retrieved is not None
+        assert retrieved.template == "New {y} template"
+        assert "y" in retrieved.placeholders
+
+    def test_update_nonexistent_raises_not_found(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", make_template(id="ghost"))
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        repo.create(make_template(id="tpl-1"))
+        mismatched = make_template(id="tpl-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("tpl-1", mismatched)
+
+
+class TestDelete:
+    """delete() removes rows and surfaces EntryNotFoundError."""
+
+    def test_delete_existing_entry(self, repo: NagraTemplateCatalogRepository) -> None:
+        repo.create(make_template(id="tpl-1"))
+        assert repo.get("tpl-1") is not None
+
+        repo.delete("tpl-1")
+        assert repo.get("tpl-1") is None
+
+    def test_delete_nonexistent_raises_not_found(
+        self, repo: NagraTemplateCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")

--- a/tests/repositories/postgres/test_nagra_tool_repo.py
+++ b/tests/repositories/postgres/test_nagra_tool_repo.py
@@ -6,8 +6,6 @@ so the Nagra backend honours the same CRUD and search contract.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
 pytest.importorskip("nagra")
@@ -22,9 +20,6 @@ from akgentic.catalog.repositories.postgres.tool_repo import (  # noqa: E402
     NagraToolCatalogRepository,
 )
 from tests.conftest import make_tool  # noqa: E402
-
-if TYPE_CHECKING:
-    pass
 
 
 @pytest.fixture

--- a/tests/repositories/postgres/test_nagra_tool_repo.py
+++ b/tests/repositories/postgres/test_nagra_tool_repo.py
@@ -1,0 +1,232 @@
+"""Behavioural tests for :class:`NagraToolCatalogRepository`.
+
+Mirrors the Mongo suite at ``tests/repositories/mongo/test_mongo_tool_repo.py``
+so the Nagra backend honours the same CRUD and search contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.catalog.models.errors import (  # noqa: E402
+    CatalogValidationError,
+    EntryNotFoundError,
+)
+from akgentic.catalog.models.queries import ToolQuery  # noqa: E402
+from akgentic.catalog.repositories.postgres.tool_repo import (  # noqa: E402
+    NagraToolCatalogRepository,
+)
+from tests.conftest import make_tool  # noqa: E402
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def repo(postgres_clean_tables: str) -> NagraToolCatalogRepository:
+    """Fresh repo backed by the per-test-truncated Postgres container."""
+    return NagraToolCatalogRepository(postgres_clean_tables)
+
+
+class TestCreateAndGet:
+    """create + get round-trip and duplicate-id handling."""
+
+    def test_create_and_get_round_trip(self, repo: NagraToolCatalogRepository) -> None:
+        entry = make_tool(
+            id="tool-1",
+            name="Search",
+            description="Web search tool",
+        )
+        created_id = repo.create(entry)
+        assert created_id == "tool-1"
+
+        retrieved = repo.get("tool-1")
+        assert retrieved is not None
+        assert retrieved.id == "tool-1"
+        assert retrieved.tool_class == "akgentic.tool.search.SearchTool"
+        assert retrieved.tool.name == "Search"
+        assert retrieved.tool.description == "Web search tool"
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        entry = make_tool(id="dup-1")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: NagraToolCatalogRepository) -> None:
+        assert repo.get("nonexistent") is None
+
+
+class TestList:
+    """list() enumerates all rows."""
+
+    def test_list_empty(self, repo: NagraToolCatalogRepository) -> None:
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: NagraToolCatalogRepository) -> None:
+        repo.create(make_tool(id="tool-a", name="Alpha"))
+        repo.create(make_tool(id="tool-b", name="Beta"))
+        repo.create(make_tool(id="tool-c", name="Gamma"))
+
+        results = repo.list()
+        assert {e.id for e in results} == {"tool-a", "tool-b", "tool-c"}
+
+
+class TestSearch:
+    """search() predicate builders behave like the Mongo backend."""
+
+    def test_search_by_id_hit_and_miss(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="t1", name="Alpha"))
+        repo.create(make_tool(id="t2", name="Beta"))
+
+        hit = repo.search(ToolQuery(id="t1"))
+        assert len(hit) == 1
+        assert hit[0].id == "t1"
+
+        assert repo.search(ToolQuery(id="t-missing")) == []
+
+    def test_search_by_tool_class_hit_and_miss(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="t1", tool_class="akgentic.tool.search.SearchTool"))
+        repo.create(
+            make_tool(
+                id="t2",
+                tool_class="akgentic.tool.planning.PlanningTool",
+                name="planner",
+                description="Planning tool",
+            )
+        )
+
+        hit = repo.search(ToolQuery(tool_class="akgentic.tool.planning.PlanningTool"))
+        assert len(hit) == 1
+        assert hit[0].id == "t2"
+
+        assert repo.search(ToolQuery(tool_class="missing.Class")) == []
+
+    def test_search_by_name_case_insensitive_substring(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="t1", name="Web Search Tool"))
+        repo.create(make_tool(id="t2", name="Calculator"))
+        repo.create(make_tool(id="t3", name="Advanced SEARCH Engine"))
+
+        results = repo.search(ToolQuery(name="search"))
+        assert {e.id for e in results} == {"t1", "t3"}
+
+        assert repo.search(ToolQuery(name="nothing-like-this")) == []
+
+    def test_search_by_description_case_insensitive_substring(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="t1", description="Search the web for information"))
+        repo.create(make_tool(id="t2", description="Perform calculations"))
+        repo.create(make_tool(id="t3", description="Deep WEB crawler"))
+
+        results = repo.search(ToolQuery(description="web"))
+        assert {e.id for e in results} == {"t1", "t3"}
+
+        assert repo.search(ToolQuery(description="nothing")) == []
+
+    def test_search_no_filters_returns_all(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="t1"))
+        repo.create(make_tool(id="t2"))
+
+        results = repo.search(ToolQuery())
+        assert len(results) == 2
+
+    def test_search_multiple_anded_fields(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(
+            make_tool(
+                id="t1",
+                tool_class="akgentic.tool.planning.PlanningTool",
+                name="Plan Search",
+                description="Search via planning",
+            )
+        )
+        repo.create(
+            make_tool(
+                id="t2",
+                tool_class="akgentic.tool.planning.PlanningTool",
+                name="Plan Calculator",
+                description="Calculate via planning",
+            )
+        )
+        repo.create(
+            make_tool(
+                id="t3",
+                tool_class="akgentic.tool.search.SearchTool",
+                name="Tavily Search",
+                description="Search the web",
+            )
+        )
+
+        # tool_class AND name — only t1 matches both
+        results = repo.search(
+            ToolQuery(
+                tool_class="akgentic.tool.planning.PlanningTool",
+                name="search",
+            )
+        )
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+
+class TestUpdate:
+    """update() replaces rows and enforces id contract."""
+
+    def test_update_existing_entry(self, repo: NagraToolCatalogRepository) -> None:
+        repo.create(make_tool(id="tool-1", name="Old Name", description="Old desc"))
+
+        updated = make_tool(id="tool-1", name="New Name", description="New desc")
+        repo.update("tool-1", updated)
+
+        retrieved = repo.get("tool-1")
+        assert retrieved is not None
+        assert retrieved.tool.name == "New Name"
+        assert retrieved.tool.description == "New desc"
+
+    def test_update_nonexistent_raises_not_found(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", make_tool(id="ghost"))
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        repo.create(make_tool(id="tool-1"))
+        mismatched = make_tool(id="tool-2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("tool-1", mismatched)
+
+
+class TestDelete:
+    """delete() removes rows and surfaces EntryNotFoundError."""
+
+    def test_delete_existing_entry(self, repo: NagraToolCatalogRepository) -> None:
+        repo.create(make_tool(id="tool-1"))
+        assert repo.get("tool-1") is not None
+
+        repo.delete("tool-1")
+        assert repo.get("tool-1") is None
+
+    def test_delete_nonexistent_raises_not_found(
+        self, repo: NagraToolCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")


### PR DESCRIPTION
## Summary

Implements `NagraTemplateCatalogRepository` and `NagraToolCatalogRepository` on the Postgres skeleton from story 15.1. Each CRUD and `search()` method owns its own `Transaction(conn_string)`. All JSONB predicates are built in `_queries.py` with bound `%s` parameters — no string interpolation. Nested `data->'tool'->>'name'` / `description` JSONB paths align with `ToolEntry.model_dump()`'s nested shape (matches the Mongo backend's `tool.name` filter).

## Implementation highlights

- `_queries.py`: per-field predicate builders for Template (`id`, `placeholder`) and Tool (`id`, `tool_class`, `name` ILIKE, `description` ILIKE) plus `build_template_where` / `build_tool_where` compose helpers. Added `decode_jsonb_column` shared JSONB→dict helper so story 15.3 can reuse it.
- `template_repo.py` / `tool_repo.py`: full CRUD + search. Duplicate-id detection catches `psycopg.errors.UniqueViolation` and re-raises `CatalogValidationError` with the Mongo-parity "already exists" wording. Row counts via `cursor.native_cursor.rowcount` drive `EntryNotFoundError` on missing-row update/delete.
- `placeholders` predicate casts the traversed JSON path to `jsonb` (`(data->'placeholders')::jsonb ? %s`) because `schema.toml` declares `data` as `JSON`; the `?` key-existence operator is only defined on `jsonb`. Scope-gate leaves `schema.toml` untouched.

## Tests

- `test_nagra_template_repo.py` + `test_nagra_tool_repo.py`: round-trip, per-predicate hit/miss, multi-field AND, full error-path coverage. All use the `postgres_clean_tables` fixture from 15.1.
- Full catalog suite: 718 passed, coverage 92.29 %.
- `ruff check` clean on `src/` and new tests; `mypy` clean on all source files.
- CI green on the branch.

## Base branch

This PR is stacked on #95 (story 15.1). Base: `feat/94-postgres-backend-skeleton`.

Closes #96
