### PR TITLE
Nagra Repositories for Agents and Teams

### DIFF
--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -27,12 +27,26 @@ import json
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from akgentic.catalog.models.queries import TemplateQuery, ToolQuery
+    from akgentic.catalog.models.queries import (
+        AgentQuery,
+        TeamQuery,
+        TemplateQuery,
+        ToolQuery,
+    )
 
 __all__ = [
+    "agent_description_predicate",
+    "agent_id_predicate",
+    "agent_role_predicate",
+    "agent_skills_predicate",
+    "build_agent_where",
+    "build_team_where",
     "build_template_where",
     "build_tool_where",
     "decode_jsonb_column",
+    "team_description_predicate",
+    "team_id_predicate",
+    "team_name_predicate",
     "template_id_predicate",
     "template_placeholder_predicate",
     "tool_description_predicate",
@@ -40,6 +54,25 @@ __all__ = [
     "tool_name_predicate",
     "tool_tool_class_predicate",
 ]
+
+
+# --- ILIKE metacharacter escaping ---
+
+
+def _escape_ilike(value: str) -> str:
+    """Escape ``%``, ``_``, and ``\\`` in a string for literal ILIKE matching.
+
+    PG's ILIKE treats ``%`` and ``_`` as wildcards and ``\\`` as its default
+    escape character. For behavioural parity with the Mongo backend — which
+    uses ``re.escape`` so user-supplied special characters match literally —
+    escape these three characters before wrapping the value in ``%...%``.
+
+    Note: story 15.2's ``tool_name_predicate`` / ``tool_description_predicate``
+    do NOT escape. 15.3 opts for correctness (Option A in the story Dev Notes)
+    since the behaviour matches the Mongo backend one-for-one; harmonising
+    15.2 is a follow-up out of scope for this story.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 # --- JSONB column decoding (shared across repos) ---
@@ -147,6 +180,127 @@ def build_template_where(query: TemplateQuery) -> tuple[str | None, list[object]
         fragments.append(template_id_predicate(query.id))
     if query.placeholder is not None:
         fragments.append(template_placeholder_predicate(query.placeholder))
+    return _combine(fragments)
+
+
+# --- Per-field predicate builders (Agent) ---
+
+
+def agent_id_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->>'id' = %s`` predicate for an exact agent id match."""
+    return "data->>'id' = %s", [value]
+
+
+def agent_role_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->'card'->>'role' = %s`` predicate for an exact role match.
+
+    ``AgentEntry.card`` is a nested ``AgentCard``, so ``role`` lives under the
+    nested ``card`` object in the JSONB document — matching the Mongo
+    backend's ``card.role`` filter.
+    """
+    return "data->'card'->>'role' = %s", [value]
+
+
+def agent_skills_predicate(value: list[str]) -> tuple[str, list[object]]:
+    """Build a JSONB ANY-match predicate over ``card.skills`` using ``?|``.
+
+    PG's ``?|`` operator takes a left JSONB value and a right ``text[]`` and
+    returns true when any element of the array exists as a top-level string
+    element of the JSONB array. psycopg 3 adapts Python ``list[str]`` to
+    ``text[]``; the explicit ``%s::text[]`` cast makes the binding robust
+    regardless of how Nagra's ``Transaction`` surfaces the parameter shape.
+
+    The ``?|`` operator is only defined for ``jsonb``; the ``data`` column is
+    declared as ``JSON`` in ``schema.toml`` (story 15.1 invariant), so the
+    traversed path is cast to ``jsonb`` at query time (same pattern as
+    :func:`template_placeholder_predicate`).
+
+    Semantic parity: matches the Mongo backend's ``{"card.skills": {"$in": query.skills}}``
+    — a team matches when ANY of the queried skills is in the agent's skill list.
+    """
+    return "(data->'card'->'skills')::jsonb ?| %s::text[]", [value]
+
+
+def agent_description_predicate(value: str) -> tuple[str, list[object]]:
+    """Build a case-insensitive substring predicate on the agent's description.
+
+    Uses ``data->'card'->>'description' ILIKE %s`` — the description lives
+    under the nested ``card`` object (matching the Mongo backend's
+    ``card.description`` filter). Escapes ``%``, ``_``, ``\\`` in the value so
+    user-supplied wildcards match literally (parity with Mongo's
+    ``re.escape``). See :func:`_escape_ilike`.
+    """
+    return "data->'card'->>'description' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+
+
+# --- Per-field predicate builders (Team) ---
+
+
+def team_id_predicate(value: str) -> tuple[str, list[object]]:
+    """Build ``data->>'id' = %s`` predicate for an exact team id match."""
+    return "data->>'id' = %s", [value]
+
+
+def team_name_predicate(value: str) -> tuple[str, list[object]]:
+    """Build a case-insensitive substring predicate on the team's name.
+
+    Uses ``data->>'name' ILIKE %s``. Escapes ``%``, ``_``, ``\\`` in the value
+    so user-supplied wildcards match literally (parity with the Mongo backend
+    which uses ``re.escape(query.name)``). See :func:`_escape_ilike`.
+    """
+    return "data->>'name' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+
+
+def team_description_predicate(value: str) -> tuple[str, list[object]]:
+    """Build a case-insensitive substring predicate on the team's description.
+
+    Same convention as :func:`team_name_predicate` — metacharacters escaped
+    for literal-substring parity with the Mongo backend.
+    """
+    return "data->>'description' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+
+
+def build_agent_where(query: AgentQuery) -> tuple[str | None, list[object]]:
+    """Build the WHERE-clause fragment for a :class:`AgentQuery`.
+
+    Returns ``(None, [])`` when no fields are set (callers issue a bare SELECT).
+    Otherwise returns ``(sql_fragment, params)`` with all fields AND-combined.
+    All parameters are bound — the ``skills`` list is passed as a single
+    parameter so psycopg adapts it to the PG ``text[]`` type expected by
+    ``?|``.
+    """
+    fragments: list[tuple[str, list[object]]] = []
+    if query.id is not None:
+        fragments.append(agent_id_predicate(query.id))
+    if query.role is not None:
+        fragments.append(agent_role_predicate(query.role))
+    if query.skills is not None:
+        fragments.append(agent_skills_predicate(query.skills))
+    if query.description is not None:
+        fragments.append(agent_description_predicate(query.description))
+    return _combine(fragments)
+
+
+def build_team_where(query: TeamQuery) -> tuple[str | None, list[object]]:
+    """Build the WHERE-clause fragment for a :class:`TeamQuery`.
+
+    Walks ``id``, ``name``, and ``description`` only — ``agent_id`` is
+    deliberately NOT handled here. It is applied as a Python post-filter by
+    :class:`NagraTeamCatalogRepository` via
+    :func:`akgentic.catalog.models.team.agent_in_members` so the recursive
+    member tree is walked (matching the Mongo backend's behaviour). See
+    story 15.3 Dev Notes §"The ``agent_id`` predicate — ADR vs. Mongo reality".
+
+    Returns ``(None, [])`` when no server-side fields are set (callers issue
+    a bare SELECT).
+    """
+    fragments: list[tuple[str, list[object]]] = []
+    if query.id is not None:
+        fragments.append(team_id_predicate(query.id))
+    if query.name is not None:
+        fragments.append(team_name_predicate(query.name))
+    if query.description is not None:
+        fragments.append(team_description_predicate(query.description))
     return _combine(fragments)
 
 

--- a/src/akgentic/catalog/repositories/postgres/agent_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/agent_repo.py
@@ -1,13 +1,29 @@
-"""Nagra-backed agent repository (stub — CRUD arrives in story 15.3)."""
+"""Nagra/Postgres-backed repository for agent catalog entries.
+
+Implements ADR-006 §2 (per-method Transaction ownership), §3 (two-column
+JSONB table shape), §4 (predicate table — Agent rows), and §8 (error
+handling parity with the Mongo backend). All SQL predicate construction is
+delegated to :mod:`_queries`; raw user input is never interpolated into SQL
+text — every variable is passed through as a psycopg ``%s`` bound parameter.
+"""
 
 from __future__ import annotations
 
 import builtins
+import json
 import logging
 from typing import TYPE_CHECKING
 
+from nagra import Transaction  # type: ignore[import-untyped]
+from psycopg.errors import UniqueViolation
+
 from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.repositories.base import AgentCatalogRepository
+from akgentic.catalog.repositories.postgres._queries import (
+    build_agent_where,
+    decode_jsonb_column,
+)
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import AgentQuery
@@ -20,9 +36,9 @@ _list = builtins.list  # repository's list() method shadows the built-in
 class NagraAgentCatalogRepository(AgentCatalogRepository):
     """Nagra/Postgres-backed agent catalog repository.
 
-    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
-    land in story 15.3. The constructor calls :func:`_ensure_schema_loaded`
-    so instantiation is always safe once ``nagra`` is available.
+    Each method opens and closes its own ``Transaction(self._conn_string)``
+    so callers never see a transaction object. The constructor performs no
+    I/O beyond loading the shared Nagra schema (idempotent).
     """
 
     def __init__(self, conn_string: str) -> None:
@@ -38,25 +54,132 @@ class NagraAgentCatalogRepository(AgentCatalogRepository):
         logger.info("NagraAgentCatalogRepository initialised")
 
     def create(self, agent_entry: AgentEntry) -> str:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Persist a new agent entry.
+
+        Inserts a row into ``agent_entries`` with ``id = agent_entry.id`` and
+        ``data = agent_entry.model_dump()``. Translates psycopg's
+        ``UniqueViolation`` to :class:`CatalogValidationError` so callers see
+        the same exception type as the YAML and Mongo backends emit on a
+        duplicate id.
+
+        Args:
+            agent_entry: The agent entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        data_json = json.dumps(agent_entry.model_dump())
+        try:
+            with Transaction(self._conn_string) as trn:
+                trn.execute(
+                    "INSERT INTO agent_entries (id, data) VALUES (%s, %s)",
+                    (agent_entry.id, data_json),
+                )
+        except UniqueViolation:
+            raise CatalogValidationError(
+                [f"Entry with id '{agent_entry.id}' already exists"]
+            )
+        logger.debug("Created agent entry with id=%s", agent_entry.id)
+        return agent_entry.id
 
     def get(self, id: str) -> AgentEntry | None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Retrieve an agent entry by id.
+
+        Args:
+            id: The agent entry id.
+
+        Returns:
+            The agent entry, or ``None`` if no row matches.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM agent_entries WHERE id = %s",
+                (id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            logger.debug("Agent entry not found: id=%s", id)
+            return None
+        return AgentEntry.model_validate(decode_jsonb_column(row[0]))
 
     def list(self) -> _list[AgentEntry]:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Return every agent entry (order unspecified)."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute("SELECT data FROM agent_entries")
+            rows = cursor.fetchall()
+        entries = [AgentEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        logger.debug("Listed %d agent entries", len(entries))
+        return entries
 
     def search(self, query: AgentQuery) -> _list[AgentEntry]:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Filter agents by AND-ing all non-None query fields.
+
+        Delegates predicate construction to :func:`_queries.build_agent_where`.
+        When the helper signals "no filter" (an empty query), issues a bare
+        ``SELECT`` — equivalent to :meth:`list`.
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching agent entries (order unspecified).
+        """
+        where_sql, params = build_agent_where(query)
+        if where_sql is None:
+            sql = "SELECT data FROM agent_entries"
+        else:
+            sql = f"SELECT data FROM agent_entries WHERE {where_sql}"
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(sql, tuple(params))
+            rows = cursor.fetchall()
+        results = [AgentEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        logger.debug("Search returned %d agent entries", len(results))
+        return results
 
     def update(self, id: str, agent_entry: AgentEntry) -> None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Update an existing agent entry.
+
+        Args:
+            id: The id of the entry to update.
+            agent_entry: The new entry data.
+
+        Raises:
+            CatalogValidationError: If ``agent_entry.id`` does not match ``id``.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if agent_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{agent_entry.id}'"]
+            )
+        data_json = json.dumps(agent_entry.model_dump())
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "UPDATE agent_entries SET data = %s WHERE id = %s",
+                (data_json, id),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated agent entry with id=%s", id)
 
     def delete(self, id: str) -> None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Delete an agent entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "DELETE FROM agent_entries WHERE id = %s",
+                (id,),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted agent entry with id=%s", id)

--- a/src/akgentic/catalog/repositories/postgres/team_repo.py
+++ b/src/akgentic/catalog/repositories/postgres/team_repo.py
@@ -1,13 +1,29 @@
-"""Nagra-backed team repository (stub — CRUD arrives in story 15.3)."""
+"""Nagra/Postgres-backed repository for team catalog entries.
+
+Implements ADR-006 §2 (per-method Transaction ownership), §3 (two-column
+JSONB table shape), §4 (predicate table — Team rows, with the ``agent_id``
+field implemented as a Python post-filter rather than a SQL predicate for
+behavioural parity with the Mongo backend's recursive tree walk), and §8
+(error handling parity with the Mongo backend).
+"""
 
 from __future__ import annotations
 
 import builtins
+import json
 import logging
 from typing import TYPE_CHECKING
 
-from akgentic.catalog.models.team import TeamEntry
+from nagra import Transaction  # type: ignore[import-untyped]
+from psycopg.errors import UniqueViolation
+
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.team import TeamEntry, agent_in_members
 from akgentic.catalog.repositories.base import TeamCatalogRepository
+from akgentic.catalog.repositories.postgres._queries import (
+    build_team_where,
+    decode_jsonb_column,
+)
 
 if TYPE_CHECKING:
     from akgentic.catalog.models.queries import TeamQuery
@@ -20,9 +36,9 @@ _list = builtins.list  # repository's list() method shadows the built-in
 class NagraTeamCatalogRepository(TeamCatalogRepository):
     """Nagra/Postgres-backed team catalog repository.
 
-    Scaffolded in story 15.1 — CRUD methods raise ``NotImplementedError`` and
-    land in story 15.3. The constructor calls :func:`_ensure_schema_loaded`
-    so instantiation is always safe once ``nagra`` is available.
+    Each method opens and closes its own ``Transaction(self._conn_string)``
+    so callers never see a transaction object. The constructor performs no
+    I/O beyond loading the shared Nagra schema (idempotent).
     """
 
     def __init__(self, conn_string: str) -> None:
@@ -38,25 +54,143 @@ class NagraTeamCatalogRepository(TeamCatalogRepository):
         logger.info("NagraTeamCatalogRepository initialised")
 
     def create(self, team_entry: TeamEntry) -> str:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Persist a new team entry.
+
+        Translates psycopg's ``UniqueViolation`` to :class:`CatalogValidationError`
+        so callers see the same exception type as the YAML and Mongo backends
+        emit on a duplicate id.
+
+        Args:
+            team_entry: The team entry to create.
+
+        Returns:
+            The id of the created entry.
+
+        Raises:
+            CatalogValidationError: If an entry with the same id already exists.
+        """
+        data_json = json.dumps(team_entry.model_dump())
+        try:
+            with Transaction(self._conn_string) as trn:
+                trn.execute(
+                    "INSERT INTO team_entries (id, data) VALUES (%s, %s)",
+                    (team_entry.id, data_json),
+                )
+        except UniqueViolation:
+            raise CatalogValidationError(
+                [f"Entry with id '{team_entry.id}' already exists"]
+            )
+        logger.debug("Created team entry with id=%s", team_entry.id)
+        return team_entry.id
 
     def get(self, id: str) -> TeamEntry | None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Retrieve a team entry by id.
+
+        Args:
+            id: The team entry id.
+
+        Returns:
+            The team entry, or ``None`` if no row matches.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "SELECT data FROM team_entries WHERE id = %s",
+                (id,),
+            )
+            row = cursor.fetchone()
+        if row is None:
+            logger.debug("Team entry not found: id=%s", id)
+            return None
+        return TeamEntry.model_validate(decode_jsonb_column(row[0]))
 
     def list(self) -> _list[TeamEntry]:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Return every team entry (order unspecified)."""
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute("SELECT data FROM team_entries")
+            rows = cursor.fetchall()
+        entries = [TeamEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
+        logger.debug("Listed %d team entries", len(entries))
+        return entries
 
     def search(self, query: TeamQuery) -> _list[TeamEntry]:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Filter teams by AND-ing all non-None query fields.
+
+        Applies server-side predicates (``id``, ``name``, ``description``) via
+        :func:`_queries.build_team_where`, then post-filters the hydrated
+        result set on ``agent_id`` via
+        :func:`akgentic.catalog.models.team.agent_in_members` so the recursive
+        member tree is walked — matching the Mongo backend's behaviour.
+
+        A top-level-only JSONB containment predicate (e.g.
+        ``data->'members' @> '[{"agent_id": ...}]'::jsonb``) would miss
+        ``agent_id`` values nested inside sub-team ``members`` and is therefore
+        incorrect; see story 15.3 Dev Notes §"The ``agent_id`` predicate —
+        ADR vs. Mongo reality".
+
+        Args:
+            query: Query with optional filter fields.
+
+        Returns:
+            Matching team entries (order unspecified).
+        """
+        where_sql, params = build_team_where(query)
+        if where_sql is None:
+            sql = "SELECT data FROM team_entries"
+        else:
+            sql = f"SELECT data FROM team_entries WHERE {where_sql}"
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(sql, tuple(params))
+            rows = cursor.fetchall()
+        results = [TeamEntry.model_validate(decode_jsonb_column(r[0])) for r in rows]
+
+        # Python post-filter for agent_id — walks the recursive member tree.
+        if query.agent_id is not None:
+            results = [t for t in results if agent_in_members(query.agent_id, t.members)]
+
+        logger.debug("Search returned %d team entries", len(results))
+        return results
 
     def update(self, id: str, team_entry: TeamEntry) -> None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Update an existing team entry.
+
+        Args:
+            id: The id of the entry to update.
+            team_entry: The new entry data.
+
+        Raises:
+            CatalogValidationError: If ``team_entry.id`` does not match ``id``.
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        if team_entry.id != id:
+            raise CatalogValidationError(
+                [f"Entry id mismatch: expected '{id}', got '{team_entry.id}'"]
+            )
+        data_json = json.dumps(team_entry.model_dump())
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "UPDATE team_entries SET data = %s WHERE id = %s",
+                (data_json, id),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Updated team entry with id=%s", id)
 
     def delete(self, id: str) -> None:
-        """Scaffolded — real CRUD arrives in story 15.3."""
-        raise NotImplementedError("Implemented in story 15.2/15.3")
+        """Delete a team entry by id.
+
+        Args:
+            id: The id of the entry to delete.
+
+        Raises:
+            EntryNotFoundError: If no entry with the given id exists.
+        """
+        with Transaction(self._conn_string) as trn:
+            cursor = trn.execute(
+                "DELETE FROM team_entries WHERE id = %s",
+                (id,),
+            )
+            row_count = cursor.native_cursor.rowcount
+        if row_count == 0:
+            raise EntryNotFoundError(f"Entry with id '{id}' not found")
+        logger.debug("Deleted team entry with id=%s", id)

--- a/tests/repositories/postgres/test_nagra_agent_repo.py
+++ b/tests/repositories/postgres/test_nagra_agent_repo.py
@@ -1,0 +1,274 @@
+"""Behavioural tests for :class:`NagraAgentCatalogRepository`.
+
+Mirrors the Mongo suite at ``tests/repositories/mongo/test_mongo_agent_repo.py``
+so that the Nagra backend honours the same CRUD and search contract. Every
+test requests the per-test truncation fixture ``postgres_clean_tables`` from
+the sibling ``conftest.py`` — which also carries the ``pytest.importorskip``
+that makes the whole module skip cleanly when the Postgres extras are absent.
+
+Story 15.3 AC coverage:
+- Round-trip + hydration: ACs #4, #6, #7, #28
+- Predicate builders: ACs #10, #11, #12, #13, #14, #15, #29, #30
+- Error paths: ACs #5, #8, #9, #31
+- Fixture wiring: ACs #32, #33
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.catalog.models.agent import AgentEntry  # noqa: E402
+from akgentic.catalog.models.errors import (  # noqa: E402
+    CatalogValidationError,
+    EntryNotFoundError,
+)
+from akgentic.catalog.models.queries import AgentQuery  # noqa: E402
+from akgentic.catalog.repositories.postgres.agent_repo import (  # noqa: E402
+    NagraAgentCatalogRepository,
+)
+from tests.conftest import make_agent  # noqa: E402
+
+
+def _agent(
+    id: str,
+    role: str = "engineer",
+    description: str = "test agent",
+    skills: list[str] | None = None,
+    name: str = "test-agent",
+) -> AgentEntry:
+    """Build an ``AgentEntry`` with per-field overrides for the card payload."""
+    return AgentEntry(
+        id=id,
+        tool_ids=[],
+        card={
+            "role": role,
+            "description": description,
+            "skills": skills if skills is not None else ["coding"],
+            "agent_class": "akgentic.agent.BaseAgent",
+            "config": {"name": name},
+            "routes_to": [],
+        },
+    )
+
+
+@pytest.fixture
+def repo(postgres_clean_tables: str) -> NagraAgentCatalogRepository:
+    """Fresh repo backed by the per-test-truncated Postgres container."""
+    return NagraAgentCatalogRepository(postgres_clean_tables)
+
+
+class TestCreateAndGet:
+    """create + get round-trip and duplicate-id handling."""
+
+    def test_create_and_get_round_trip(self, repo: NagraAgentCatalogRepository) -> None:
+        # Round-trip a non-trivial AgentEntry through JSONB — AC #28.
+        entry = _agent(
+            id="a1",
+            role="Manager",
+            description="Oversees the research team",
+            skills=["research", "summarize", "coding"],
+            name="manager-bot",
+        )
+        assert repo.create(entry) == "a1"
+
+        retrieved = repo.get("a1")
+        assert retrieved is not None
+        assert retrieved.id == "a1"
+        assert retrieved.card.role == "Manager"
+        assert retrieved.card.description == "Oversees the research team"
+        assert retrieved.card.skills == ["research", "summarize", "coding"]
+        assert retrieved.card.config.name == "manager-bot"
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # AC #5.
+        entry = make_agent(id="dup")
+        repo.create(entry)
+
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(entry)
+
+    def test_get_nonexistent_returns_none(self, repo: NagraAgentCatalogRepository) -> None:
+        # AC #6 miss branch + AC #31.
+        assert repo.get("ghost") is None
+
+
+class TestList:
+    """list() enumerates all rows — AC #7."""
+
+    def test_list_empty(self, repo: NagraAgentCatalogRepository) -> None:
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: NagraAgentCatalogRepository) -> None:
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+        repo.create(make_agent(id="a3"))
+
+        results = repo.list()
+        assert len(results) == 3
+        assert {e.id for e in results} == {"a1", "a2", "a3"}
+
+
+class TestSearch:
+    """search() predicate builders behave like the Mongo backend."""
+
+    def test_search_no_filters_returns_all(self, repo: NagraAgentCatalogRepository) -> None:
+        # AC #10.
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+        assert len(repo.search(AgentQuery())) == 2
+
+    def test_search_by_id_hit_and_miss(self, repo: NagraAgentCatalogRepository) -> None:
+        # AC #11.
+        repo.create(make_agent(id="a1"))
+        repo.create(make_agent(id="a2"))
+
+        hit = repo.search(AgentQuery(id="a1"))
+        assert len(hit) == 1
+        assert hit[0].id == "a1"
+
+        miss = repo.search(AgentQuery(id="missing"))
+        assert miss == []
+
+    def test_search_by_role_exact_match(self, repo: NagraAgentCatalogRepository) -> None:
+        # AC #12.
+        repo.create(_agent(id="a1", role="engineer"))
+        repo.create(_agent(id="a2", role="Manager"))
+        repo.create(_agent(id="a3", role="writer"))
+
+        results = repo.search(AgentQuery(role="Manager"))
+        assert len(results) == 1
+        assert results[0].id == "a2"
+
+    def test_search_by_description_case_insensitive(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # AC #14.
+        repo.create(_agent(id="a1", description="Builds REST APIs"))
+        repo.create(_agent(id="a2", description="Builds CLI tools"))
+
+        results = repo.search(AgentQuery(description="rest"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_search_description_with_wildcard_chars_literal(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # ILIKE metacharacter escape — matches Mongo's re.escape semantics.
+        repo.create(_agent(id="a1", description="rate = 50% off"))
+        repo.create(_agent(id="a2", description="rate = 50 off"))
+
+        results = repo.search(AgentQuery(description="50%"))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_search_multiple_anded_fields(self, repo: NagraAgentCatalogRepository) -> None:
+        # AC #15.
+        repo.create(_agent(id="a1", role="engineer", skills=["research"]))
+        repo.create(_agent(id="a2", role="engineer", skills=["writing"]))
+        repo.create(_agent(id="a3", role="Manager", skills=["research"]))
+
+        results = repo.search(AgentQuery(role="engineer", skills=["research"]))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+
+class TestSearchSkills:
+    """Dedicated coverage of the ``?|`` ANY-match predicate — AC #13, #30."""
+
+    def test_skills_any_match_single_skill(self, repo: NagraAgentCatalogRepository) -> None:
+        # Hit: agent has ["research", "code"], query skills=["research"] → match.
+        repo.create(_agent(id="a1", skills=["research", "code"]))
+        repo.create(_agent(id="a2", skills=["writing"]))
+
+        results = repo.search(AgentQuery(skills=["research"]))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_skills_any_match_not_all(self, repo: NagraAgentCatalogRepository) -> None:
+        # Hit (ANY not ALL): agent has ["research"], query
+        # skills=["research", "summarize"] → match.
+        repo.create(_agent(id="a1", skills=["research"]))
+        repo.create(_agent(id="a2", skills=["unrelated"]))
+
+        results = repo.search(AgentQuery(skills=["research", "summarize"]))
+        assert len(results) == 1
+        assert results[0].id == "a1"
+
+    def test_skills_miss(self, repo: NagraAgentCatalogRepository) -> None:
+        # Miss: agent has ["unrelated"], query skills=["research"] → no match.
+        repo.create(_agent(id="a1", skills=["unrelated"]))
+
+        results = repo.search(AgentQuery(skills=["research"]))
+        assert results == []
+
+    def test_skills_empty_agent_skill_list_miss(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # Edge: agent with empty skills list does NOT match any non-empty query.
+        repo.create(_agent(id="a1", skills=[]))
+
+        results = repo.search(AgentQuery(skills=["research"]))
+        assert results == []
+
+    def test_skills_multi_query_matches_multiple(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        repo.create(_agent(id="a1", skills=["research", "code"]))
+        repo.create(_agent(id="a2", skills=["writing"]))
+        repo.create(_agent(id="a3", skills=["testing", "writing"]))
+
+        results = repo.search(AgentQuery(skills=["writing", "testing"]))
+        assert {e.id for e in results} == {"a2", "a3"}
+
+
+class TestUpdate:
+    """update() replaces rows and enforces id contract — AC #8."""
+
+    def test_update_existing_entry(self, repo: NagraAgentCatalogRepository) -> None:
+        repo.create(make_agent(id="a1", name="old"))
+
+        updated = make_agent(id="a1", name="new")
+        repo.update("a1", updated)
+
+        retrieved = repo.get("a1")
+        assert retrieved is not None
+        assert retrieved.card.config.name == "new"
+
+    def test_update_nonexistent_raises_not_found(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # AC #31.
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", make_agent(id="ghost"))
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # AC #31.
+        repo.create(make_agent(id="a1"))
+        mismatched = make_agent(id="a2")
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("a1", mismatched)
+
+
+class TestDelete:
+    """delete() removes rows and surfaces EntryNotFoundError — AC #9."""
+
+    def test_delete_existing_entry(self, repo: NagraAgentCatalogRepository) -> None:
+        repo.create(make_agent(id="a1"))
+        assert repo.get("a1") is not None
+
+        repo.delete("a1")
+        assert repo.get("a1") is None
+
+    def test_delete_nonexistent_raises_not_found(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # AC #31.
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")

--- a/tests/repositories/postgres/test_nagra_team_repo.py
+++ b/tests/repositories/postgres/test_nagra_team_repo.py
@@ -1,0 +1,310 @@
+"""Behavioural tests for :class:`NagraTeamCatalogRepository`.
+
+Mirrors the Mongo suite at ``tests/repositories/mongo/test_mongo_team_repo.py``
+so that the Nagra backend honours the same CRUD and search contract. Every
+test requests the per-test truncation fixture ``postgres_clean_tables`` from
+the sibling ``conftest.py`` — which also carries the ``pytest.importorskip``
+that makes the whole module skip cleanly when the Postgres extras are absent.
+
+Story 15.3 AC coverage:
+- Round-trip (with a nested member tree): ACs #16, #28
+- Predicate builders: ACs #17, #18, #19, #20, #22, #29
+- ``agent_id`` post-filter, including nested-member case: AC #21
+- Error paths: AC #31
+- Fixture wiring: ACs #32, #33
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.catalog.models.errors import (  # noqa: E402
+    CatalogValidationError,
+    EntryNotFoundError,
+)
+from akgentic.catalog.models.queries import TeamQuery  # noqa: E402
+from akgentic.catalog.models.team import TeamMemberSpec  # noqa: E402
+from akgentic.catalog.repositories.postgres.team_repo import (  # noqa: E402
+    NagraTeamCatalogRepository,
+)
+from tests.conftest import make_team  # noqa: E402
+
+
+@pytest.fixture
+def repo(postgres_clean_tables: str) -> NagraTeamCatalogRepository:
+    """Fresh repo backed by the per-test-truncated Postgres container."""
+    return NagraTeamCatalogRepository(postgres_clean_tables)
+
+
+class TestCreateAndGet:
+    """create + get round-trip with a multi-level member tree — AC #16, #28."""
+
+    def test_create_and_get_round_trip_with_nested_members(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        nested = make_team(
+            id="t1",
+            name="Deep Team",
+            entry_point="director",
+            members=[
+                TeamMemberSpec(
+                    agent_id="director",
+                    headcount=1,
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="manager",
+                            headcount=2,
+                            members=[TeamMemberSpec(agent_id="deep-worker")],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        assert repo.create(nested) == "t1"
+
+        retrieved = repo.get("t1")
+        assert retrieved is not None
+        assert retrieved.id == "t1"
+        assert retrieved.name == "Deep Team"
+        # Hydrated tree deep-equals the original.
+        assert retrieved.members == nested.members
+        assert retrieved.members[0].members[0].headcount == 2
+        assert retrieved.members[0].members[0].members[0].agent_id == "deep-worker"
+
+    def test_create_duplicate_raises_validation_error(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        repo.create(make_team(id="dup"))
+        with pytest.raises(CatalogValidationError, match="already exists"):
+            repo.create(make_team(id="dup"))
+
+    def test_get_nonexistent_returns_none(self, repo: NagraTeamCatalogRepository) -> None:
+        assert repo.get("ghost") is None
+
+
+class TestList:
+    """list() enumerates all rows."""
+
+    def test_list_empty(self, repo: NagraTeamCatalogRepository) -> None:
+        assert repo.list() == []
+
+    def test_list_returns_all_entries(self, repo: NagraTeamCatalogRepository) -> None:
+        repo.create(make_team(id="t1", name="Alpha"))
+        repo.create(make_team(id="t2", name="Beta"))
+        repo.create(make_team(id="t3", name="Gamma"))
+        assert {e.id for e in repo.list()} == {"t1", "t2", "t3"}
+
+
+class TestSearch:
+    """search() predicate builders behave like the Mongo backend."""
+
+    def test_search_no_filters_returns_all(self, repo: NagraTeamCatalogRepository) -> None:
+        # AC #17.
+        repo.create(make_team(id="t1"))
+        repo.create(make_team(id="t2"))
+        assert len(repo.search(TeamQuery())) == 2
+
+    def test_search_by_id(self, repo: NagraTeamCatalogRepository) -> None:
+        # AC #18.
+        repo.create(make_team(id="t1"))
+        repo.create(make_team(id="t2"))
+
+        results = repo.search(TeamQuery(id="t1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+        assert repo.search(TeamQuery(id="missing")) == []
+
+    def test_search_by_name_case_insensitive(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        # AC #19.
+        repo.create(make_team(id="t1", name="Engineering Team"))
+        repo.create(make_team(id="t2", name="Marketing Team"))
+        repo.create(make_team(id="t3", name="ENGINEERING Core"))
+
+        results = repo.search(TeamQuery(name="engineering"))
+        assert {e.id for e in results} == {"t1", "t3"}
+
+    def test_search_by_name_with_wildcard_chars_literal(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        # ILIKE metacharacter escape — parity with Mongo re.escape.
+        repo.create(make_team(id="t1", name="Team (Alpha)"))
+        repo.create(make_team(id="t2", name="Team Alpha"))
+
+        results = repo.search(TeamQuery(name="(Alpha)"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_description_case_insensitive(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        # AC #20.
+        t1 = make_team(id="t1", name="Alpha")
+        t1.description = "Handles backend APIs"
+        t2 = make_team(id="t2", name="Beta")
+        t2.description = "Handles frontend UI"
+        repo.create(t1)
+        repo.create(t2)
+
+        results = repo.search(TeamQuery(description="backend"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+
+class TestSearchAgentIdPostFilter:
+    """Dedicated coverage of the ``agent_id`` Python post-filter — AC #21."""
+
+    def test_search_by_agent_id_flat_members(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        repo.create(
+            make_team(
+                id="t1",
+                name="Team A",
+                members=[
+                    TeamMemberSpec(agent_id="eng-lead"),
+                    TeamMemberSpec(agent_id="dev-1"),
+                ],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t2",
+                name="Team B",
+                members=[TeamMemberSpec(agent_id="pm-lead")],
+            )
+        )
+
+        results = repo.search(TeamQuery(agent_id="dev-1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_agent_id_nested_members_two_levels_deep(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        # The must-not-miss-nested invariant — a top-level-only containment
+        # predicate would miss this.
+        nested = make_team(
+            id="t1",
+            name="Deep Team",
+            entry_point="director",
+            members=[
+                TeamMemberSpec(
+                    agent_id="director",
+                    members=[
+                        TeamMemberSpec(
+                            agent_id="manager",
+                            members=[TeamMemberSpec(agent_id="deep-worker")],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        repo.create(nested)
+        repo.create(make_team(id="t2", name="Flat Team"))
+
+        results = repo.search(TeamQuery(agent_id="deep-worker"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_search_by_agent_id_no_match(self, repo: NagraTeamCatalogRepository) -> None:
+        repo.create(make_team(id="t1"))
+        assert repo.search(TeamQuery(agent_id="nonexistent-agent")) == []
+
+
+class TestSearchMultiField:
+    """Server-side predicates AND'd, then post-filter applied — AC #22."""
+
+    def test_multi_field_and_combined_with_agent_id_post_filter(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        # Server-side narrows to teams whose name contains "engineering";
+        # agent_id post-filter then narrows further.
+        repo.create(
+            make_team(
+                id="t1",
+                name="Engineering Alpha",
+                members=[TeamMemberSpec(agent_id="eng-1")],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t2",
+                name="Engineering Beta",
+                members=[TeamMemberSpec(agent_id="eng-2")],
+            )
+        )
+        repo.create(
+            make_team(
+                id="t3",
+                name="Marketing Alpha",
+                members=[TeamMemberSpec(agent_id="eng-1")],
+            )
+        )
+
+        results = repo.search(TeamQuery(name="engineering", agent_id="eng-1"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+    def test_multi_server_side_fields_only(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        t1 = make_team(id="t1", name="Alpha")
+        t1.description = "Handles backend"
+        t2 = make_team(id="t2", name="Alpha Other")
+        t2.description = "Handles frontend"
+        repo.create(t1)
+        repo.create(t2)
+
+        results = repo.search(TeamQuery(name="Alpha", description="backend"))
+        assert len(results) == 1
+        assert results[0].id == "t1"
+
+
+class TestUpdate:
+    """update() replaces rows and enforces id contract."""
+
+    def test_update_existing_entry(self, repo: NagraTeamCatalogRepository) -> None:
+        repo.create(make_team(id="t1", name="Old"))
+
+        updated = make_team(id="t1", name="New")
+        repo.update("t1", updated)
+
+        retrieved = repo.get("t1")
+        assert retrieved is not None
+        assert retrieved.name == "New"
+
+    def test_update_nonexistent_raises_not_found(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.update("ghost", make_team(id="ghost"))
+
+    def test_update_id_mismatch_raises_validation_error(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        repo.create(make_team(id="t1"))
+        with pytest.raises(CatalogValidationError, match="id mismatch"):
+            repo.update("t1", make_team(id="t2"))
+
+
+class TestDelete:
+    """delete() removes rows and surfaces EntryNotFoundError."""
+
+    def test_delete_existing_entry(self, repo: NagraTeamCatalogRepository) -> None:
+        repo.create(make_team(id="t1"))
+        assert repo.get("t1") is not None
+
+        repo.delete("t1")
+        assert repo.get("t1") is None
+
+    def test_delete_nonexistent_raises_not_found(
+        self, repo: NagraTeamCatalogRepository
+    ) -> None:
+        with pytest.raises(EntryNotFoundError, match="not found"):
+            repo.delete("ghost")


### PR DESCRIPTION
## Summary

Implements the Nagra/Postgres-backed `AgentCatalogRepository` and `TeamCatalogRepository` on top of the scaffold landed in story 15.1 (PR #95) and the Template/Tool repos landed in 15.2 (PR #97).

- **Agent repo**: full CRUD + search with JSONB predicates for `id`, `card.role`, `card.skills` (using the `?|` ANY-match operator with the list bound as a `%s::text[]` parameter), and `card.description` (ILIKE substring).
- **Team repo**: full CRUD + search with server-side JSONB predicates for `id`, `name`, `description` (all ILIKE substring). `agent_id` is applied as a Python post-filter via the recursive `agent_in_members` helper so that nested sub-team members match — mirroring the Mongo backend's behaviour. A top-level-only JSONB containment predicate would miss nested members and is therefore deliberately avoided.
- **`_queries.py`**: extended with Agent + Team predicate builders, `build_agent_where`, `build_team_where`, and a `_escape_ilike` helper that escapes `\`, `%`, `_` so user-supplied wildcards match literally (parity with the Mongo backend's `re.escape`).
- **Transaction ownership**: every repo method opens and closes its own `Transaction(self._conn_string)`; constructors perform no I/O beyond loading the shared schema.
- **Bind-everything invariant**: no user-supplied value is interpolated into SQL text — every variable is a `%s` bound parameter; this story introduces zero JSON-literal interpolation in `_queries.py`.
- **Tests**: 41 new tests under `tests/repositories/postgres/` (20 Agent + 21 Team), including round-trip with a three-level member tree, predicate hit/miss per field, dedicated `?|` ANY-match coverage (hit, hit-any-not-all, miss, empty-skills edge), a nested-member `agent_id` lookup that would defeat any top-level-only predicate, multi-field AND for both repos, ILIKE metacharacter escape tests, and full error-path coverage.

Full catalog suite: 759 passed, coverage 93.26% (well above the 80% gate). CI green on the branch.

Closes #98

Relates to Epic 15 — ADR-006 Nagra/Postgres repository. Stacked on top of PR #97 (15.2).
