### PR TITLE
CI Wiring, Environment Variables, and Documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment variables for akgentic-catalog storage backends.
+# Copy to .env and fill in values for your deployment. The catalog library
+# itself does NOT read these — env-var resolution happens at the wiring
+# layer (application startup / infra code). Repository constructors accept
+# a plain connection string directly.
+
+# Nagra / PostgreSQL backend — used by the `[postgres]` extra.
+POSTGRES_SERVER=
+POSTGRES_PORT=5432
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_DB=
+# Full libpq URL; what repository constructors receive as `conn_string`.
+DB_CONN_STRING_PERSISTENCE=
+
+# MongoDB backend — used by the `[mongo]` extra.
+MONGO_URI=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,27 @@ env:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: akgentic
+          POSTGRES_PASSWORD: akgentic
+          POSTGRES_DB: akgentic_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U akgentic"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      POSTGRES_SERVER: localhost
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: akgentic
+      POSTGRES_PASSWORD: akgentic
+      POSTGRES_DB: akgentic_test
+      DB_CONN_STRING_PERSISTENCE: postgresql://akgentic:akgentic@localhost:5432/akgentic_test
     steps:
       - name: Checkout workspace
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ the runtime orchestrator, providing:
 - **Delete protection** preventing removal of entries referenced downstream
 - **Dynamic type resolution** via fully-qualified class names (FQCN),
   enabling custom ToolCard, AgentConfig, and Agent subclasses
-- **Two storage backends** (YAML files and MongoDB) behind a common
-  repository interface
+- **Three storage backends** (YAML files, MongoDB, and PostgreSQL via Nagra)
+  behind a common repository interface
 - **CLI and REST API** for managing catalogs outside of Python code
 
 ```mermaid
@@ -57,12 +57,14 @@ flowchart LR
     subgraph Storage
         YAML[(YAML Files)]
         MONGO[(MongoDB)]
+        POSTGRES[(PostgreSQL)]
     end
     CLI --> TC & OC & AC & MC
     API --> TC & OC & AC & MC
     PY --> TC & OC & AC & MC
     TC & OC & AC & MC --> YAML
     TC & OC & AC & MC --> MONGO
+    TC & OC & AC & MC --> POSTGRES
 ```
 
 ## Installation
@@ -95,6 +97,9 @@ uv sync --extra cli
 
 # MongoDB backend
 uv sync --extra mongo
+
+# PostgreSQL backend (Nagra)
+uv sync --extra postgres
 
 # Everything
 uv sync --all-extras
@@ -209,6 +214,7 @@ flowchart TD
     subgraph "Repositories"
         YR[YAML Repos]
         MR[MongoDB Repos]
+        PR[Postgres Repos]
     end
     subgraph "Services"
         TCS[TemplateCatalog]
@@ -225,9 +231,9 @@ flowchart TD
     TE & OE --> TCS & OCS
     AE --> ACS
     TS --> MCS
-    TCS & OCS --> YR & MR
-    ACS --> YR & MR
-    MCS --> YR & MR
+    TCS & OCS --> YR & MR & PR
+    ACS --> YR & MR & PR
+    MCS --> YR & MR & PR
     CLIBOX & APIBOX & PYBOX --> TCS & OCS & ACS & MCS
 ```
 
@@ -368,6 +374,62 @@ config = MongoCatalogConfig(
 )
 repo = MongoTemplateCatalogRepository(config)
 ```
+
+### PostgreSQL (Nagra)
+
+A PostgreSQL backend built on [Nagra](https://pypi.org/project/nagra/). Each
+catalog type maps to a dedicated table with a two-column schema: `id TEXT`
+(primary key) and `data JSONB` (the full `model_dump()` payload). The JSONB
+shape keeps the catalog entries fully queryable at the SQL layer without
+requiring promoted columns or bespoke migrations.
+
+Install the `postgres` extra:
+
+```bash
+uv sync --extra postgres
+# or: uv add "akgentic-catalog[postgres]"
+```
+
+**Environment variables.** The backend follows the V1 Akgentic conventions
+so existing operator `.env` files work without translation:
+
+| Variable | Purpose |
+|---|---|
+| `POSTGRES_SERVER` | Database host |
+| `POSTGRES_PORT` | Database port (typically `5432`) |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `POSTGRES_DB` | Database name |
+| `DB_CONN_STRING_PERSISTENCE` | Full libpq URL; the value the repositories receive as `conn_string` |
+
+Repository constructors take `conn_string` directly as a positional
+argument — env-var reading happens at the wiring layer (application
+startup / infra code), **not** inside the repository constructors. This
+keeps the storage layer decoupled from process-level configuration.
+
+**Schema initialisation.** Call `init_db(conn_string)` once per deployment
+(at application startup or in a deploy hook). The call is idempotent — it
+creates any missing tables and is safe to re-run. Repository constructors
+do **not** call `init_db` implicitly.
+
+```python
+from akgentic.catalog.repositories.postgres import (
+    NagraTemplateCatalogRepository,
+    init_db,
+)
+
+conn_string = "postgresql://akgentic:akgentic@localhost:5432/akgentic"
+
+# One-time (idempotent) schema creation — run at deploy time.
+init_db(conn_string)
+
+# Construct repositories with the same conn_string.
+repo = NagraTemplateCatalogRepository(conn_string)
+```
+
+Schema evolution is handled as a redeploy concern — the backend does not
+adopt a migration framework. Drop-and-recreate semantics or manual `ALTER
+TABLE` statements are the expected evolution path.
 
 ## Service Layer
 

--- a/tests/repositories/postgres/test_ci_env_wiring.py
+++ b/tests/repositories/postgres/test_ci_env_wiring.py
@@ -1,0 +1,73 @@
+"""CI environment-variable wiring tests for the Nagra/Postgres backend.
+
+Two tests live here:
+
+* ``test_db_conn_string_persistence_reachable``: the CI positive-path test.
+  When ``DB_CONN_STRING_PERSISTENCE`` is set in the environment (the GHA
+  ``quality`` job exposes it at the job level via the service container
+  credentials), open a :class:`nagra.Transaction` against it and run a
+  trivial ``SELECT 1`` round-trip. Skips cleanly when the env var is NOT
+  set so local runs without CI env continue to pass.
+* ``test_repo_constructor_does_not_read_env``: a regression guard. Repo
+  constructors must take ``conn_string`` as a plain string argument —
+  env-var reading happens at the wiring layer (app startup / infra), not
+  in the repo constructor. Monkeypatches ``os.environ`` to ``{}`` and
+  confirms construction still succeeds and stores the provided string.
+
+Module-level ``pytest.importorskip`` ensures the module is skipped
+cleanly on runners without the ``[postgres]`` extra installed — mirrors
+the conftest's gating so the new test is safe in every environment.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+
+def test_db_conn_string_persistence_reachable() -> None:
+    """Positive-path CI test: connect via DB_CONN_STRING_PERSISTENCE and run SELECT 1.
+
+    This is the single behavioural invariant for Story 15.4 AC #6 — that
+    the env-var plumbing set up at the CI job level (sourced from the
+    postgres:16-alpine service container credentials) points at a live,
+    reachable database. Skips when the env var is absent so local runs
+    without CI env continue to pass.
+    """
+    conn_string = os.environ.get("DB_CONN_STRING_PERSISTENCE")
+    if not conn_string:
+        pytest.skip("DB_CONN_STRING_PERSISTENCE not set — CI-only test")
+
+    from nagra import Transaction
+
+    with Transaction(conn_string) as trn:
+        cursor = trn.execute("SELECT 1")
+        row = cursor.fetchone()
+
+    assert row is not None
+    assert row[0] == 1
+
+
+def test_repo_constructor_does_not_read_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC #13 regression guard: repo constructors must not read os.environ.
+
+    Monkeypatch ``os.environ`` to an empty mapping and construct a
+    :class:`NagraTemplateCatalogRepository` with a syntactically valid but
+    unreachable connection string. Construction must succeed (``__init__``
+    only stores the string and calls ``_ensure_schema_loaded``) and the
+    stored conn string must equal the constructor argument verbatim.
+    """
+    from akgentic.catalog.repositories.postgres.template_repo import (
+        NagraTemplateCatalogRepository,
+    )
+
+    monkeypatch.setattr(os, "environ", {})
+
+    conn_string = "postgresql://nonexistent:0/nope"
+    repo = NagraTemplateCatalogRepository(conn_string)
+
+    assert repo._conn_string == conn_string


### PR DESCRIPTION
## Summary

Closes Epic 15 by wiring the Nagra/Postgres backend into the CI pipeline, documenting the V1 environment-variable conventions, and surfacing the `[postgres]` extra in the package README alongside YAML and MongoDB. No runtime-code changes — CI config, docs, and one new env-wiring test only.

## What changed

- **CI** — `.github/workflows/ci.yml` gains a `postgres:16-alpine` service container (health-checked with `pg_isready`) and a job-level `env:` block exposing the six V1 variables (`POSTGRES_SERVER`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `DB_CONN_STRING_PERSISTENCE`) so the pytest step has them available. `uv sync --all-packages --all-extras` already pulls the `[postgres]` extra — no install-step changes.
- **Tests** — `tests/repositories/postgres/test_ci_env_wiring.py` adds two behavioural tests: a CI positive-path round-trip (`Transaction(DB_CONN_STRING_PERSISTENCE) + SELECT 1`) that skips cleanly when the env var is absent, and a regression guard asserting repo constructors never read `os.environ`.
- **README** — "Three storage backends" prose + `POSTGRES` nodes in both Mermaid diagrams; `# PostgreSQL backend (Nagra)` entry under Optional Extras; full `### PostgreSQL (Nagra)` Storage Backends subsection with install snippet, env-var table, constructor-takes-`conn_string` note, `init_db` idempotent usage, `NagraTemplateCatalogRepository` example, JSONB-shape note, and redeploy-for-schema-evolution note.
- **`.env.example`** — new file at the submodule root documenting all six Postgres vars plus `MONGO_URI` for parity.

## Review results

- 760 passed, 1 skipped (the new CI-env reachability test — designed skip when `DB_CONN_STRING_PERSISTENCE` is absent locally)
- Coverage 93.26 % (unchanged vs 15.3 baseline)
- `ruff check packages/akgentic-catalog/src/` clean
- `mypy --strict packages/akgentic-catalog/src/` clean (53 files)
- CI green on the feat/100 branch

Stacked on #99 — base branch is `feat/98-nagra-agent-team-repos`.

Closes #100
Relates to Epic 15
