### PR TITLE
Search-Semantics Parity — ILIKE Escaping and Top-Level Re-Export Symmetry

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -81,6 +81,25 @@ except ImportError:
     pass
 
 try:
+    from akgentic.catalog.repositories.postgres import (
+        NagraAgentCatalogRepository,
+        NagraTeamCatalogRepository,
+        NagraTemplateCatalogRepository,
+        NagraToolCatalogRepository,
+        init_db,
+    )
+
+    __all__ += [
+        "NagraAgentCatalogRepository",
+        "NagraTeamCatalogRepository",
+        "NagraTemplateCatalogRepository",
+        "NagraToolCatalogRepository",
+        "init_db",
+    ]
+except ImportError:
+    pass
+
+try:
     from akgentic.catalog.api import (
         ErrorResponse,
         add_exception_handlers,

--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -66,11 +66,6 @@ def _escape_ilike(value: str) -> str:
     escape character. For behavioural parity with the Mongo backend — which
     uses ``re.escape`` so user-supplied special characters match literally —
     escape these three characters before wrapping the value in ``%...%``.
-
-    Note: story 15.2's ``tool_name_predicate`` / ``tool_description_predicate``
-    do NOT escape. 15.3 opts for correctness (Option A in the story Dev Notes)
-    since the behaviour matches the Mongo backend one-for-one; harmonising
-    15.2 is a follow-up out of scope for this story.
     """
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
@@ -135,17 +130,26 @@ def tool_name_predicate(value: str) -> tuple[str, list[object]]:
     The JSONB path is ``data->'tool'->>'name'`` because ``ToolEntry.model_dump()``
     nests ``name`` under a ``tool`` object — matching the Mongo backend's
     ``tool.name`` filter. The parameter is wrapped with ``%`` characters so
-    the ILIKE operator performs substring matching.
+    the ILIKE operator performs substring matching. User-supplied
+    metacharacters (``%``, ``_``, ``\\``) are escaped via :func:`_escape_ilike`
+    so they match literally — parity with the Mongo backend's ``re.escape``.
     """
-    return "data->'tool'->>'name' ILIKE %s", [f"%{value}%"]
+    return (
+        "data->'tool'->>'name' ILIKE %s ESCAPE '\\'",
+        [f"%{_escape_ilike(value)}%"],
+    )
 
 
 def tool_description_predicate(value: str) -> tuple[str, list[object]]:
     """Build a case-insensitive substring predicate on the tool's description.
 
-    Uses the same nested JSONB path convention as :func:`tool_name_predicate`.
+    Uses the same nested JSONB path convention as :func:`tool_name_predicate`
+    and the same literal-metacharacter escaping via :func:`_escape_ilike`.
     """
-    return "data->'tool'->>'description' ILIKE %s", [f"%{value}%"]
+    return (
+        "data->'tool'->>'description' ILIKE %s ESCAPE '\\'",
+        [f"%{_escape_ilike(value)}%"],
+    )
 
 
 # --- Compose helpers ---
@@ -230,7 +234,10 @@ def agent_description_predicate(value: str) -> tuple[str, list[object]]:
     user-supplied wildcards match literally (parity with Mongo's
     ``re.escape``). See :func:`_escape_ilike`.
     """
-    return "data->'card'->>'description' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+    return (
+        "data->'card'->>'description' ILIKE %s ESCAPE '\\'",
+        [f"%{_escape_ilike(value)}%"],
+    )
 
 
 # --- Per-field predicate builders (Team) ---
@@ -244,11 +251,15 @@ def team_id_predicate(value: str) -> tuple[str, list[object]]:
 def team_name_predicate(value: str) -> tuple[str, list[object]]:
     """Build a case-insensitive substring predicate on the team's name.
 
-    Uses ``data->>'name' ILIKE %s``. Escapes ``%``, ``_``, ``\\`` in the value
-    so user-supplied wildcards match literally (parity with the Mongo backend
-    which uses ``re.escape(query.name)``). See :func:`_escape_ilike`.
+    Uses ``data->>'name' ILIKE %s ESCAPE '\\'``. Escapes ``%``, ``_``, ``\\``
+    in the value so user-supplied wildcards match literally (parity with the
+    Mongo backend which uses ``re.escape(query.name)``). See
+    :func:`_escape_ilike`.
     """
-    return "data->>'name' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+    return (
+        "data->>'name' ILIKE %s ESCAPE '\\'",
+        [f"%{_escape_ilike(value)}%"],
+    )
 
 
 def team_description_predicate(value: str) -> tuple[str, list[object]]:
@@ -257,7 +268,10 @@ def team_description_predicate(value: str) -> tuple[str, list[object]]:
     Same convention as :func:`team_name_predicate` — metacharacters escaped
     for literal-substring parity with the Mongo backend.
     """
-    return "data->>'description' ILIKE %s", [f"%{_escape_ilike(value)}%"]
+    return (
+        "data->>'description' ILIKE %s ESCAPE '\\'",
+        [f"%{_escape_ilike(value)}%"],
+    )
 
 
 def build_agent_where(query: AgentQuery) -> tuple[str | None, list[object]]:

--- a/tests/repositories/postgres/test_queries.py
+++ b/tests/repositories/postgres/test_queries.py
@@ -1,0 +1,113 @@
+"""Behavioural tests for ILIKE predicate literal-wildcard escaping.
+
+Exercises the Mongo-parity semantics introduced by Story 15.5: user-supplied
+``%`` and ``_`` characters in ``ToolQuery.name`` / ``ToolQuery.description``
+MUST match literally rather than act as SQL wildcards. Tests run end-to-end
+through :class:`NagraToolCatalogRepository` against the session-scoped
+testcontainer — no assertions on the generated SQL string shape, so future
+SQL refactors do not break the tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from akgentic.catalog.models.queries import ToolQuery  # noqa: E402
+from akgentic.catalog.repositories.postgres.tool_repo import (  # noqa: E402
+    NagraToolCatalogRepository,
+)
+from tests.conftest import make_tool  # noqa: E402
+
+
+@pytest.fixture
+def repo(postgres_clean_tables: str) -> NagraToolCatalogRepository:
+    """Fresh repo backed by the per-test-truncated Postgres container."""
+    return NagraToolCatalogRepository(postgres_clean_tables)
+
+
+def test_tool_name_literal_percent_wildcard_is_escaped(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """A literal ``%`` in the query matches a literal ``%`` in the tool name."""
+    repo.create(make_tool(id="t1", name="100%_fast"))
+    repo.create(make_tool(id="t2", name="100x_fast"))
+    repo.create(make_tool(id="t3", name="plain"))
+
+    # Literal percent in query: only t1 matches
+    results = repo.search(ToolQuery(name="100%"))
+    assert {e.id for e in results} == {"t1"}
+
+
+def test_tool_name_literal_underscore_wildcard_is_escaped(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """A literal ``_`` in the query matches a literal ``_`` in the tool name."""
+    repo.create(make_tool(id="t1", name="my_tool"))
+    repo.create(make_tool(id="t2", name="myxtool"))
+    repo.create(make_tool(id="t3", name="unrelated"))
+
+    results = repo.search(ToolQuery(name="my_tool"))
+    assert {e.id for e in results} == {"t1"}
+
+
+def test_tool_description_literal_percent_wildcard_is_escaped(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """A literal ``%`` in the description query matches only a literal ``%``."""
+    repo.create(
+        make_tool(id="t1", name="a", description="rate: 100% success"),
+    )
+    repo.create(
+        make_tool(id="t2", name="b", description="rate: 100x success"),
+    )
+    repo.create(
+        make_tool(id="t3", name="c", description="something entirely different"),
+    )
+
+    results = repo.search(ToolQuery(description="100%"))
+    assert {e.id for e in results} == {"t1"}
+
+
+def test_tool_description_literal_underscore_wildcard_is_escaped(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """A literal ``_`` in the description query matches only a literal ``_``."""
+    repo.create(
+        make_tool(id="t1", name="a", description="uses my_tool internally"),
+    )
+    repo.create(
+        make_tool(id="t2", name="b", description="uses myxtool internally"),
+    )
+    repo.create(
+        make_tool(id="t3", name="c", description="plain text only"),
+    )
+
+    results = repo.search(ToolQuery(description="my_tool"))
+    assert {e.id for e in results} == {"t1"}
+
+
+def test_tool_name_happy_path_substring(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """Regression: plain wildcard-free substring search still matches everywhere."""
+    repo.create(make_tool(id="t1", name="json-parser"))
+    repo.create(make_tool(id="t2", name="JSON Formatter"))
+    repo.create(make_tool(id="t3", name="csv-reader"))
+
+    results = repo.search(ToolQuery(name="json"))
+    assert {e.id for e in results} == {"t1", "t2"}
+
+
+def test_tool_description_happy_path_substring(
+    repo: NagraToolCatalogRepository,
+) -> None:
+    """Regression: plain wildcard-free description search still matches case-insensitively."""
+    repo.create(make_tool(id="t1", name="a", description="Search the web for data"))
+    repo.create(make_tool(id="t2", name="b", description="Perform calculations"))
+    repo.create(make_tool(id="t3", name="c", description="Deep WEB crawler"))
+
+    results = repo.search(ToolQuery(description="web"))
+    assert {e.id for e in results} == {"t1", "t3"}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,70 @@
+"""Smoke tests for the top-level ``akgentic.catalog`` public API surface.
+
+Verifies that:
+
+1. Importing ``akgentic.catalog`` succeeds regardless of whether optional
+   backend extras are installed (the ``[postgres]`` and Mongo extras are
+   gated by ``try/except ImportError`` blocks).
+2. When the ``[postgres]`` extra IS installed, the four Nagra repositories
+   and ``init_db`` are re-exported from the top-level package.
+3. When ``pymongo`` is available, the existing Mongo re-exports remain
+   untouched — a regression guard against Story 15.5 accidentally altering
+   the Mongo block.
+
+The module imports cleanly without any optional extra — Nagra / Mongo test
+bodies use function-level ``pytest.importorskip`` so the file itself stays
+importable on minimal environments.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_top_level_package_imports_without_postgres_extra() -> None:
+    """Importing ``akgentic.catalog`` must never raise, even without extras."""
+    import akgentic.catalog
+
+    # Sanity: the unconditional exports are always present.
+    assert hasattr(akgentic.catalog, "TemplateEntry")
+    assert hasattr(akgentic.catalog, "YamlTemplateCatalogRepository")
+
+
+def test_nagra_repositories_reexported_when_extra_installed() -> None:
+    """When ``nagra`` is available, all five Nagra names re-export correctly."""
+    pytest.importorskip("nagra")
+
+    from akgentic.catalog import (
+        NagraAgentCatalogRepository,
+        NagraTeamCatalogRepository,
+        NagraTemplateCatalogRepository,
+        NagraToolCatalogRepository,
+        init_db,
+    )
+    from akgentic.catalog.repositories import postgres as pg_pkg
+
+    assert NagraAgentCatalogRepository is pg_pkg.NagraAgentCatalogRepository
+    assert NagraTeamCatalogRepository is pg_pkg.NagraTeamCatalogRepository
+    assert NagraTemplateCatalogRepository is pg_pkg.NagraTemplateCatalogRepository
+    assert NagraToolCatalogRepository is pg_pkg.NagraToolCatalogRepository
+    assert init_db is pg_pkg.init_db
+
+
+def test_mongo_reexports_still_present() -> None:
+    """Regression guard: the Mongo re-export block is untouched."""
+    pytest.importorskip("pymongo")
+
+    from akgentic.catalog import (
+        MongoAgentCatalogRepository,
+        MongoCatalogConfig,
+        MongoTeamCatalogRepository,
+        MongoTemplateCatalogRepository,
+        MongoToolCatalogRepository,
+    )
+
+    # Types should resolve to actual classes, not None / sentinels.
+    assert MongoAgentCatalogRepository is not None
+    assert MongoCatalogConfig is not None
+    assert MongoTeamCatalogRepository is not None
+    assert MongoTemplateCatalogRepository is not None
+    assert MongoToolCatalogRepository is not None


### PR DESCRIPTION
## Summary

Closes two Epic-15 spec-compliance follow-ups flagged by the 2026-04-20 review:

- **ILIKE metacharacter escaping parity**: unifies all five ILIKE predicates (two tool, one agent, two team) to emit `<path> ILIKE %s ESCAPE '\'` with `_escape_ilike` applied to the bound value. User-supplied `%` / `_` / `\` now match literally across all four catalog types, matching the Mongo backend's `re.escape` semantics.
- **Top-level re-export symmetry**: adds a Nagra `try/except ImportError` block in `akgentic/catalog/__init__.py` mirroring the existing Mongo block. The four Nagra repositories and `init_db` are now importable via `from akgentic.catalog import ...` when the `[postgres]` extra is installed; package import continues to succeed without the extra.

## Changes

- Modified: `src/akgentic/catalog/repositories/postgres/_queries.py` — escape both tool predicates, append explicit `ESCAPE '\'` to all five ILIKE fragments, drop stale 15.2 follow-up note from `_escape_ilike` docstring.
- Modified: `src/akgentic/catalog/__init__.py` — Nagra re-export block between Mongo and API blocks.
- Added: `tests/repositories/postgres/test_queries.py` — six behavioural tests for literal `%` / `_` matching on tool name and description plus happy-path substring regressions.
- Added: `tests/test_public_api.py` — three smoke tests for top-level re-export surface (unconditional import, Nagra re-export parity, Mongo regression).

## Test Results

- `ruff check src/` clean; `mypy --strict src/` clean (53 files).
- Full catalog suite: 769 passed, 1 skipped, coverage 93.27% (matches 15.4 baseline).
- CI green on the branch.

Closes #102
