### PR TITLE
Wire Postgres backend into create_app and CLI --backend dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,29 @@ Schema evolution is handled as a redeploy concern — the backend does not
 adopt a migration framework. Drop-and-recreate semantics or manual `ALTER
 TABLE` statements are the expected evolution path.
 
+**Wiring from the CLI and REST API.** Both entry points accept Postgres
+directly:
+
+```bash
+# CLI: --backend postgres with explicit conn string (or DB_CONN_STRING_PERSISTENCE env var).
+ak-catalog --backend postgres --postgres-conn-string \
+    "postgresql://akgentic:akgentic@localhost:5432/akgentic" \
+    template list
+```
+
+```python
+# REST API: create_app(backend="postgres", postgres_conn_string=...).
+from akgentic.catalog.api.app import create_app
+
+app = create_app(
+    backend="postgres",
+    postgres_conn_string="postgresql://akgentic:akgentic@localhost:5432/akgentic",
+)
+```
+
+Run `init_db(conn_string)` once per deployment (not called implicitly by
+the wiring helpers). Install the extra with `uv add "akgentic-catalog[postgres]"`.
+
 ## Service Layer
 
 Service-layer catalogs add cross-validation, delete protection, and

--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -1,7 +1,8 @@
 """FastAPI application factory for the Akgentic catalog API.
 
 Provides ``create_app()`` which assembles a fully wired FastAPI application
-with configurable storage backend (YAML files or MongoDB).
+with configurable storage backend (YAML files, MongoDB, or PostgreSQL via
+Nagra).
 """
 
 from __future__ import annotations

--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -37,19 +37,23 @@ logger = logging.getLogger(__name__)
 
 def create_app(
     *,
-    backend: Literal["yaml", "mongodb"] = "yaml",
+    backend: Literal["yaml", "mongodb", "postgres"] = "yaml",
     yaml_base_path: Path | None = None,
     mongo_config: MongoCatalogConfig | None = None,
+    postgres_conn_string: str | None = None,
 ) -> FastAPI:
     """Create a fully wired FastAPI application for the catalog API.
 
     Args:
-        backend: Storage backend to use — ``"yaml"`` for file-based or
-            ``"mongodb"`` for MongoDB.
+        backend: Storage backend to use — ``"yaml"`` for file-based,
+            ``"mongodb"`` for MongoDB, or ``"postgres"`` for Nagra-backed
+            PostgreSQL.
         yaml_base_path: Root directory for YAML catalog files. Required when
             ``backend="yaml"``. Subdirectories are created if absent.
         mongo_config: MongoDB connection configuration. Required when
             ``backend="mongodb"``.
+        postgres_conn_string: Postgres libpq connection URL. Required when
+            ``backend="postgres"``.
 
     Returns:
         A configured FastAPI application with all routers and exception
@@ -72,8 +76,15 @@ def create_app(
         template_catalog, tool_catalog, agent_catalog, team_catalog = _wire_mongodb_backend(
             mongo_config
         )
+    elif backend == "postgres":
+        if postgres_conn_string is None:
+            msg = "postgres_conn_string is required when backend='postgres'"
+            raise ValueError(msg)
+        template_catalog, tool_catalog, agent_catalog, team_catalog = _wire_postgres_backend(
+            postgres_conn_string
+        )
     else:
-        msg = f"Unknown backend: {backend!r}. Must be 'yaml' or 'mongodb'."
+        msg = f"Unknown backend: {backend!r}. Must be 'yaml', 'mongodb', or 'postgres'."
         raise ValueError(msg)
 
     # Wire downstream back-references for delete protection
@@ -125,6 +136,41 @@ def _wire_yaml_backend(
     tool_repo = YamlToolCatalogRepository(base_path / "tools")
     agent_repo = YamlAgentCatalogRepository(base_path / "agents")
     team_repo = YamlTeamCatalogRepository(base_path / "teams")
+
+    # Create services in dependency order
+    template_catalog = TemplateCatalog(template_repo)
+    tool_catalog = ToolCatalog(tool_repo)
+    agent_catalog = AgentCatalog(agent_repo, template_catalog, tool_catalog)
+    team_catalog = TeamCatalog(team_repo, agent_catalog)
+
+    return template_catalog, tool_catalog, agent_catalog, team_catalog
+
+
+def _wire_postgres_backend(
+    conn_string: str,
+) -> tuple[TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog]:
+    """Create catalog services wired with Nagra Postgres repositories.
+
+    Schema creation (``init_db``) is a deployment concern and is NOT called
+    here — repositories instantiate safely without touching the database.
+
+    Args:
+        conn_string: Nagra-compatible Postgres connection string.
+
+    Returns:
+        Tuple of (TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog).
+    """
+    from akgentic.catalog.repositories.postgres import (
+        NagraAgentCatalogRepository,
+        NagraTeamCatalogRepository,
+        NagraTemplateCatalogRepository,
+        NagraToolCatalogRepository,
+    )
+
+    template_repo = NagraTemplateCatalogRepository(conn_string)
+    tool_repo = NagraToolCatalogRepository(conn_string)
+    agent_repo = NagraAgentCatalogRepository(conn_string)
+    team_repo = NagraTeamCatalogRepository(conn_string)
 
     # Create services in dependency order
     template_catalog = TemplateCatalog(template_repo)

--- a/src/akgentic/catalog/cli/_catalog.py
+++ b/src/akgentic/catalog/cli/_catalog.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 def build_catalogs_from_state(
     state: GlobalState,
 ) -> CatalogTuple:
-    """Dispatch to YAML or MongoDB backend based on global state.
+    """Dispatch to the YAML, MongoDB, or Postgres backend based on global state.
 
     Args:
         state: The CLI global state containing backend selection and

--- a/src/akgentic/catalog/cli/_catalog.py
+++ b/src/akgentic/catalog/cli/_catalog.py
@@ -1,8 +1,8 @@
 """Catalog service wiring for the CLI.
 
 Provides ``build_catalogs()`` for YAML backend, ``build_mongo_catalogs()``
-for MongoDB backend, and ``build_catalogs_from_state()`` to dispatch based
-on ``GlobalState.backend``.
+for MongoDB, ``build_postgres_catalogs()`` for Postgres (Nagra), and
+``build_catalogs_from_state()`` to dispatch based on ``GlobalState.backend``.
 """
 
 from __future__ import annotations
@@ -22,7 +22,12 @@ if TYPE_CHECKING:
 # Type alias for the four-catalog tuple returned by all wiring functions
 CatalogTuple = tuple["TemplateCatalog", "ToolCatalog", "AgentCatalog", "TeamCatalog"]
 
-__all__ = ["build_catalogs", "build_catalogs_from_state", "build_mongo_catalogs"]
+__all__ = [
+    "build_catalogs",
+    "build_catalogs_from_state",
+    "build_mongo_catalogs",
+    "build_postgres_catalogs",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,11 @@ def build_catalogs_from_state(
         assert state.mongo_uri is not None, "mongo_uri must be set for mongodb backend"
         assert state.mongo_db is not None, "mongo_db must be set for mongodb backend"
         return build_mongo_catalogs(state.mongo_uri, state.mongo_db)
+    if state.backend == "postgres":
+        assert state.postgres_conn_string is not None, (
+            "postgres_conn_string must be set for postgres backend"
+        )
+        return build_postgres_catalogs(state.postgres_conn_string)
     return build_catalogs(state.catalog_dir)
 
 
@@ -152,4 +162,50 @@ def build_mongo_catalogs(
     agent_catalog.team_catalog = team_catalog
 
     logger.info("Wired catalog services from MongoDB %s", mongo_db)
+    return template_catalog, tool_catalog, agent_catalog, team_catalog
+
+
+def build_postgres_catalogs(
+    conn_string: str,
+) -> CatalogTuple:
+    """Wire all four catalog services from a Postgres backend.
+
+    Imports Nagra dependencies lazily so the YAML backend remains usable
+    without the ``[postgres]`` extra.
+
+    Args:
+        conn_string: Nagra-compatible Postgres connection string.
+
+    Returns:
+        Tuple of (TemplateCatalog, ToolCatalog, AgentCatalog, TeamCatalog).
+    """
+    from akgentic.catalog.repositories.postgres import (
+        NagraAgentCatalogRepository,
+        NagraTeamCatalogRepository,
+        NagraTemplateCatalogRepository,
+        NagraToolCatalogRepository,
+    )
+    from akgentic.catalog.services.agent_catalog import AgentCatalog
+    from akgentic.catalog.services.team_catalog import TeamCatalog
+    from akgentic.catalog.services.template_catalog import TemplateCatalog
+    from akgentic.catalog.services.tool_catalog import ToolCatalog
+
+    template_repo = NagraTemplateCatalogRepository(conn_string)
+    tool_repo = NagraToolCatalogRepository(conn_string)
+    agent_repo = NagraAgentCatalogRepository(conn_string)
+    team_repo = NagraTeamCatalogRepository(conn_string)
+
+    # Create services in dependency order
+    template_catalog = TemplateCatalog(template_repo)
+    tool_catalog = ToolCatalog(tool_repo)
+    agent_catalog = AgentCatalog(agent_repo, template_catalog, tool_catalog)
+    team_catalog = TeamCatalog(team_repo, agent_catalog)
+
+    # Wire downstream back-references for delete protection
+    template_catalog.agent_catalog = agent_catalog
+    tool_catalog.agent_catalog = agent_catalog
+    agent_catalog.team_catalog = team_catalog
+
+    # Log without the conn string — secrets hygiene.
+    logger.info("Wired catalog services from Postgres")
     return template_catalog, tool_catalog, agent_catalog, team_catalog

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -43,6 +43,7 @@ class GlobalState:
     backend: str = "yaml"
     mongo_uri: str | None = None
     mongo_db: str | None = None
+    postgres_conn_string: str | None = None
 
 
 app = typer.Typer(name="ak-catalog", help="Manage Akgentic catalog entries.")
@@ -64,7 +65,7 @@ def main(
     backend: str = typer.Option(
         "yaml",
         "--backend",
-        help="Storage backend: yaml or mongodb.",
+        help="Storage backend: yaml, mongodb, or postgres.",
     ),
     mongo_uri: str | None = typer.Option(
         None,
@@ -78,9 +79,15 @@ def main(
         envvar="MONGO_DB",
         help="MongoDB database name (required when --backend=mongodb).",
     ),
+    postgres_conn_string: str | None = typer.Option(
+        None,
+        "--postgres-conn-string",
+        envvar="DB_CONN_STRING_PERSISTENCE",
+        help="Postgres connection URL (required when --backend=postgres).",
+    ),
 ) -> None:
     """Akgentic catalog CLI -- manage templates, tools, agents, and teams."""
-    valid_backends = ("yaml", "mongodb")
+    valid_backends = ("yaml", "mongodb", "postgres")
     if backend not in valid_backends:
         err_console.print(
             f"[red]Error:[/red] Invalid backend '{backend}'. "
@@ -97,6 +104,14 @@ def main(
             logger.warning("MongoDB validation failed: %s", errors)
             raise typer.Exit(code=1)
 
+    if backend == "postgres":
+        errors = _validate_postgres_options(postgres_conn_string)
+        if errors:
+            for err in errors:
+                err_console.print(f"[red]Error:[/red] {err}")
+            logger.warning("Postgres validation failed: %s", errors)
+            raise typer.Exit(code=1)
+
     ctx.ensure_object(dict)
     ctx.obj = GlobalState(
         catalog_dir=catalog_dir,
@@ -104,6 +119,7 @@ def main(
         backend=backend,
         mongo_uri=mongo_uri,
         mongo_db=mongo_db,
+        postgres_conn_string=postgres_conn_string,
     )
 
 
@@ -127,6 +143,26 @@ def _validate_mongodb_options(
         errors.append("--mongo-uri must start with 'mongodb://' or 'mongodb+srv://'")
     if not mongo_db:
         errors.append("--mongo-db (or MONGO_DB env var) is required when --backend=mongodb")
+    return errors
+
+
+def _validate_postgres_options(
+    postgres_conn_string: str | None,
+) -> list[str]:
+    """Validate Postgres connection options and return error messages.
+
+    Args:
+        postgres_conn_string: Postgres libpq connection URL, or None.
+
+    Returns:
+        List of error message strings (empty if valid).
+    """
+    errors: list[str] = []
+    if not postgres_conn_string:
+        errors.append(
+            "--postgres-conn-string (or DB_CONN_STRING_PERSISTENCE env var) "
+            "is required when --backend=postgres"
+        )
     return errors
 
 

--- a/src/akgentic/catalog/scripts/__init__.py
+++ b/src/akgentic/catalog/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable entry points for deployment-time catalog operations."""

--- a/src/akgentic/catalog/scripts/init_db.py
+++ b/src/akgentic/catalog/scripts/init_db.py
@@ -1,0 +1,65 @@
+"""Init-container entry point that creates missing catalog tables.
+
+Runs :func:`akgentic.catalog.repositories.postgres.init_db` against the
+Postgres instance identified by the ``DB_CONN_STRING_PERSISTENCE``
+environment variable (same variable the ``ak-catalog`` CLI uses).
+
+Intended to be invoked by a Kubernetes initContainer or Nomad prestart
+task before the main server process starts:
+
+    command: ["python", "-m", "akgentic.catalog.scripts.init_db"]
+
+The underlying :func:`init_db` is idempotent, so re-running against an
+already-initialized database is safe — it creates only missing tables.
+
+Exit codes:
+    0 — success (tables created or already present)
+    2 — ``DB_CONN_STRING_PERSISTENCE`` not set
+    1 — any other failure (nagra not installed, connection refused, etc.)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+_ENV_VAR = "DB_CONN_STRING_PERSISTENCE"
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Create catalog tables against the configured Postgres instance.
+
+    Returns:
+        Process exit code — 0 on success, 2 on missing env, 1 on other error.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+    )
+
+    conn_string = os.environ.get(_ENV_VAR)
+    if not conn_string:
+        logger.error("%s is not set; cannot initialize catalog database", _ENV_VAR)
+        return 2
+
+    try:
+        from akgentic.catalog.repositories.postgres import init_db
+    except ImportError as exc:
+        logger.error("Postgres backend unavailable: %s", exc)
+        return 1
+
+    try:
+        init_db(conn_string)
+    except Exception:
+        logger.exception("init_db failed")
+        return 1
+
+    logger.info("Catalog database initialized successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_app_postgres.py
+++ b/tests/api/test_app_postgres.py
@@ -7,8 +7,6 @@ Postgres testcontainer fixtures defined in the package-root
 
 from __future__ import annotations
 
-import importlib.util
-
 import pytest
 
 pytest.importorskip("nagra")
@@ -69,19 +67,8 @@ def test_create_app_postgres_backend_end_to_end(
     assert "tpl-pg-end2end" in ids
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("nagra") is not None,
-    reason=(
-        "Regression guard for no-extra environments; running env has nagra installed."
-    ),
-)
-def test_create_app_postgres_backend_importless_extra() -> None:
-    """AC #7: module import succeeds without the ``[postgres]`` extra installed.
-
-    This test is intentionally inverted — it only runs when ``nagra`` is NOT
-    importable. In CI with the extra installed it skips. The purpose is to
-    guard against regressions in environments that do NOT install the extra.
-    """
-    from akgentic.catalog.api.app import create_app as _create_app
-
-    assert _create_app is not None
+# NOTE: the no-extra module-import regression guard
+# (``test_create_app_postgres_backend_importless_extra``) lives in the sibling
+# file ``test_app_postgres_no_extra.py``. It cannot live in this module because
+# this file gates itself on ``pytest.importorskip("nagra")`` at the top, which
+# would prevent the no-extra guard from ever running in a no-extra environment.

--- a/tests/api/test_app_postgres.py
+++ b/tests/api/test_app_postgres.py
@@ -1,0 +1,87 @@
+"""Integration tests for ``create_app(backend='postgres', ...)``.
+
+Skips cleanly when the ``[postgres]`` extra is absent. Uses the session-scoped
+Postgres testcontainer fixtures defined in the package-root
+``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from akgentic.catalog.api.app import create_app  # noqa: E402
+from akgentic.catalog.repositories.postgres import (  # noqa: E402
+    NagraTemplateCatalogRepository,
+    init_db,
+)
+from tests.conftest import make_template  # noqa: E402
+
+
+def test_create_app_postgres_backend_missing_conn_string_raises() -> None:
+    """AC #3: ``create_app(backend='postgres')`` without conn string raises."""
+    with pytest.raises(ValueError, match="postgres_conn_string is required"):
+        create_app(backend="postgres")
+
+
+def test_create_app_postgres_backend_end_to_end(
+    postgres_conn_string: str,
+) -> None:
+    """AC #4 / AC #14: end-to-end create_app -> Nagra repos -> HTTP round-trip."""
+    # init_db is a deployment-time hook — not called implicitly by wiring.
+    init_db(postgres_conn_string)
+
+    # Truncate before seeding so the test is self-contained.
+    from nagra import Transaction
+
+    with Transaction(postgres_conn_string) as trn:
+        trn.execute(
+            "TRUNCATE template_entries, tool_entries, agent_entries, team_entries"
+        )
+
+    # Seed one TemplateEntry directly via the Nagra repo.
+    template = make_template(id="tpl-pg-end2end", template="Hello {name}")
+    NagraTemplateCatalogRepository(postgres_conn_string).create(template)
+
+    # Build the app via the wiring under test.
+    app = create_app(backend="postgres", postgres_conn_string=postgres_conn_string)
+    assert isinstance(app, FastAPI)
+
+    # Verify routers are registered.
+    route_paths = {r.path for r in app.routes if hasattr(r, "path")}
+    assert "/api/templates" in route_paths
+    assert "/api/tools" in route_paths
+    assert "/api/agents" in route_paths
+    assert "/api/teams" in route_paths
+
+    # Hit the API and confirm the seeded row is reachable through the stack.
+    client = TestClient(app)
+    resp = client.get("/api/templates/")
+    assert resp.status_code == 200
+    ids = [entry["id"] for entry in resp.json()]
+    assert "tpl-pg-end2end" in ids
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("nagra") is not None,
+    reason=(
+        "Regression guard for no-extra environments; running env has nagra installed."
+    ),
+)
+def test_create_app_postgres_backend_importless_extra() -> None:
+    """AC #7: module import succeeds without the ``[postgres]`` extra installed.
+
+    This test is intentionally inverted — it only runs when ``nagra`` is NOT
+    importable. In CI with the extra installed it skips. The purpose is to
+    guard against regressions in environments that do NOT install the extra.
+    """
+    from akgentic.catalog.api.app import create_app as _create_app
+
+    assert _create_app is not None

--- a/tests/api/test_app_postgres_no_extra.py
+++ b/tests/api/test_app_postgres_no_extra.py
@@ -1,0 +1,30 @@
+"""No-extra regression guard: ``api.app`` imports without the ``[postgres]`` extra.
+
+This module deliberately does NOT gate itself with ``pytest.importorskip("nagra")``.
+The single test inside is inverted: it runs only when ``nagra`` is NOT available
+so it can verify that importing ``akgentic.catalog.api.app`` still succeeds
+without the Postgres extra installed. Per AC #7 / AC #14 of Story 15.6.
+
+In CI environments where the ``[postgres]`` extra is installed the test is
+skipped cleanly. The separate file exists because the sibling
+``test_app_postgres.py`` cannot host it — that module top-levels
+``importorskip("nagra")`` which would itself skip the entire file in no-extra
+environments, making the regression guard unreachable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("nagra") is not None,
+    reason="Regression guard for no-extra environments; nagra is installed here.",
+)
+def test_create_app_postgres_backend_importless_extra() -> None:
+    """Top-level ``create_app`` import succeeds without the ``[postgres]`` extra."""
+    from akgentic.catalog.api.app import create_app
+
+    assert create_app is not None

--- a/tests/cli/test_backend_selection.py
+++ b/tests/cli/test_backend_selection.py
@@ -226,11 +226,11 @@ class TestMongoMissingOptions:
     def test_invalid_backend_value_rejected(self) -> None:
         result = runner.invoke(
             app,
-            ["--backend", "postgres", "template", "list"],
+            ["--backend", "redis", "template", "list"],
         )
         assert result.exit_code == 1
         assert "Invalid backend" in result.output
-        assert "postgres" in result.output
+        assert "redis" in result.output
 
     def test_no_python_traceback_on_error(self) -> None:
         result = runner.invoke(

--- a/tests/cli/test_cli_postgres.py
+++ b/tests/cli/test_cli_postgres.py
@@ -1,0 +1,110 @@
+"""Integration tests for the CLI ``--backend postgres`` dispatch.
+
+Skips cleanly when the ``[postgres]`` extra is absent. Uses the session-scoped
+Postgres testcontainer fixtures defined in the package-root
+``tests/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nagra")
+pytest.importorskip("testcontainers.postgres")
+
+from typer.testing import CliRunner  # noqa: E402
+
+from akgentic.catalog.cli.main import app  # noqa: E402
+from akgentic.catalog.repositories.postgres import (  # noqa: E402
+    NagraTemplateCatalogRepository,
+    init_db,
+)
+from tests.conftest import make_template  # noqa: E402
+
+runner = CliRunner()
+
+
+def _truncate(conn_string: str) -> None:
+    """Truncate the four catalog tables on the shared session container."""
+    from nagra import Transaction
+
+    with Transaction(conn_string) as trn:
+        trn.execute(
+            "TRUNCATE template_entries, tool_entries, agent_entries, team_entries"
+        )
+
+
+def test_cli_backend_postgres_template_list_end_to_end(
+    postgres_conn_string: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #13 / AC #15: CLI dispatches to Nagra repos and returns seeded rows."""
+    # Prevent the env-var fallback from leaking into this test.
+    monkeypatch.delenv("DB_CONN_STRING_PERSISTENCE", raising=False)
+
+    init_db(postgres_conn_string)
+    _truncate(postgres_conn_string)
+
+    NagraTemplateCatalogRepository(postgres_conn_string).create(
+        make_template(id="cli-pg-e2e", template="Hi {name}")
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "--backend",
+            "postgres",
+            "--postgres-conn-string",
+            postgres_conn_string,
+            "--format",
+            "json",
+            "template",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "cli-pg-e2e" in result.stdout
+
+
+def test_cli_backend_postgres_missing_conn_string_exits_non_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #9 / AC #15: missing conn string -> exit 1 with operator-facing message."""
+    monkeypatch.delenv("DB_CONN_STRING_PERSISTENCE", raising=False)
+
+    result = runner.invoke(
+        app,
+        ["--backend", "postgres", "template", "list"],
+    )
+    assert result.exit_code == 1
+    combined = result.stdout + result.output
+    assert "--postgres-conn-string" in combined
+    assert "DB_CONN_STRING_PERSISTENCE" in combined
+
+
+def test_cli_backend_postgres_env_var_fallback(
+    postgres_conn_string: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC #9 / AC #15: ``DB_CONN_STRING_PERSISTENCE`` env var binds to Typer."""
+    init_db(postgres_conn_string)
+    _truncate(postgres_conn_string)
+
+    NagraTemplateCatalogRepository(postgres_conn_string).create(
+        make_template(id="cli-pg-env", template="Env {name}")
+    )
+
+    monkeypatch.setenv("DB_CONN_STRING_PERSISTENCE", postgres_conn_string)
+    result = runner.invoke(
+        app,
+        [
+            "--backend",
+            "postgres",
+            "--format",
+            "json",
+            "template",
+            "list",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "cli-pg-env" in result.stdout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,23 @@
 Factory functions are plain functions (not fixtures) — they are pure constructors
 with no state. Fixtures are only for stateful objects that benefit from pytest
 lifecycle management.
+
+Session-scoped Postgres testcontainer fixtures (``postgres_container``,
+``postgres_conn_string``) live here so they can be reused across subdirectories
+(``tests/api/``, ``tests/cli/``, ``tests/repositories/postgres/``) with one
+container per pytest session. The fixtures are only registered when both
+``nagra`` and ``testcontainers.postgres`` are importable; tests that depend on
+them gate themselves with ``pytest.importorskip`` at module level.
 """
 
 from __future__ import annotations
 
 import builtins
+import importlib.util
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
+
+import pytest
 
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
@@ -20,6 +31,54 @@ if TYPE_CHECKING:
     from akgentic.catalog.models.queries import ToolQuery
 
 _list = builtins.list  # Avoids shadowing by Pydantic 'list' fields
+
+
+# --- Postgres testcontainer fixtures (conditional registration) ---
+
+_POSTGRES_AVAILABLE = (
+    importlib.util.find_spec("nagra") is not None
+    and importlib.util.find_spec("testcontainers.postgres") is not None
+)
+
+
+def _to_nagra_conn_string(sqlalchemy_url: str) -> str:
+    """Strip the SQLAlchemy driver suffix from a testcontainers URL.
+
+    ``testcontainers`` emits URLs like
+    ``postgresql+psycopg2://user:pw@host:port/db``. Nagra's ``Transaction``
+    wraps a psycopg / libpq connection, which accepts the standard
+    ``postgresql://`` scheme without the driver suffix. Strip the driver so
+    the URL is portable regardless of Nagra's current psycopg binding.
+    """
+    if "+" in sqlalchemy_url.split("://", 1)[0]:
+        scheme, rest = sqlalchemy_url.split("://", 1)
+        scheme = scheme.split("+", 1)[0]
+        return f"{scheme}://{rest}"
+    return sqlalchemy_url
+
+
+if _POSTGRES_AVAILABLE:
+    from testcontainers.postgres import PostgresContainer  # noqa: E402
+
+    @pytest.fixture(scope="session")
+    def postgres_container() -> Iterator[PostgresContainer]:
+        """Start a single postgres:16-alpine container for the test session."""
+        with PostgresContainer("postgres:16-alpine") as container:
+            yield container
+
+    @pytest.fixture(scope="session")
+    def postgres_conn_string(postgres_container: PostgresContainer) -> str:
+        """Nagra-compatible connection string derived from the session container."""
+        raw_url = postgres_container.get_connection_url()
+        return _to_nagra_conn_string(raw_url)
+
+    @pytest.fixture(scope="session")
+    def postgres_initialized(postgres_conn_string: str) -> str:
+        """Run ``init_db`` exactly once against the session container."""
+        from akgentic.catalog.repositories.postgres import init_db
+
+        init_db(postgres_conn_string)
+        return postgres_conn_string
 
 
 # --- Factory Functions ---

--- a/tests/repositories/postgres/conftest.py
+++ b/tests/repositories/postgres/conftest.py
@@ -1,64 +1,26 @@
 """Fixtures for Postgres (Nagra) repository tests.
 
-Uses ``testcontainers[postgres]`` to spin up a single session-scoped
-``postgres:16-alpine`` container. If ``nagra`` or ``testcontainers.postgres``
-is not importable, the whole module (and therefore every Postgres test) is
-skipped via ``pytest.importorskip`` — mirrors the Mongo test layout.
+The session-scoped ``postgres_container`` / ``postgres_conn_string`` /
+``postgres_initialized`` fixtures live in the package-root
+``tests/conftest.py`` so that ``tests/api/`` and ``tests/cli/`` can share
+the same container with this directory — one container per pytest session,
+regardless of which subdirectory triggered it. See issue #104 for the lift
+rationale.
+
+This module only adds the per-test ``postgres_clean_tables`` fixture that
+truncates the four catalog tables between tests, and skips the whole
+directory cleanly via ``pytest.importorskip`` when the ``[postgres]`` extra
+is absent.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
 
 import pytest
 
 pytest.importorskip("nagra")
 pytest.importorskip("testcontainers.postgres")
-
-from testcontainers.postgres import PostgresContainer  # noqa: E402
-
-from akgentic.catalog.repositories.postgres import init_db  # noqa: E402
-
-if TYPE_CHECKING:
-    pass
-
-
-def _to_nagra_conn_string(sqlalchemy_url: str) -> str:
-    """Convert the testcontainers SQLAlchemy-style URL to a libpq URL.
-
-    ``testcontainers`` emits URLs like
-    ``postgresql+psycopg2://user:pw@host:port/db``. Nagra's ``Transaction``
-    wraps a psycopg / libpq connection, which accepts the standard
-    ``postgresql://`` scheme without the driver suffix. Strip the driver so
-    the URL is portable regardless of Nagra's current psycopg binding.
-    """
-    if "+" in sqlalchemy_url.split("://", 1)[0]:
-        scheme, rest = sqlalchemy_url.split("://", 1)
-        scheme = scheme.split("+", 1)[0]
-        return f"{scheme}://{rest}"
-    return sqlalchemy_url
-
-
-@pytest.fixture(scope="session")
-def postgres_container() -> Iterator[PostgresContainer]:
-    """Start a single postgres:16-alpine container for the test session."""
-    with PostgresContainer("postgres:16-alpine") as container:
-        yield container
-
-
-@pytest.fixture(scope="session")
-def postgres_conn_string(postgres_container: PostgresContainer) -> str:
-    """Nagra-compatible connection string derived from the session container."""
-    raw_url = postgres_container.get_connection_url()
-    return _to_nagra_conn_string(raw_url)
-
-
-@pytest.fixture(scope="session")
-def postgres_initialized(postgres_conn_string: str) -> str:
-    """Run ``init_db`` exactly once against the session container."""
-    init_db(postgres_conn_string)
-    return postgres_conn_string
 
 
 @pytest.fixture

--- a/tests/repositories/postgres/test_init_db.py
+++ b/tests/repositories/postgres/test_init_db.py
@@ -38,8 +38,9 @@ class TestEnsureSchemaLoadedIdempotent:
         ``_SCHEMA_LOADED`` back to its pre-test value afterwards, the real
         schema loader in the session fixture still runs exactly once.
         """
-        import akgentic.catalog.repositories.postgres as pg_pkg
         from nagra import Schema
+
+        import akgentic.catalog.repositories.postgres as pg_pkg
 
         # Save the pre-test guard value so we can restore it exactly — monkeypatch
         # would also restore it, but we want both directions to be explicit.
@@ -101,8 +102,9 @@ class TestInitDbIntegration:
         assert expected.issubset(found)
 
     def test_init_db_is_idempotent(self, postgres_initialized: str) -> None:
-        from akgentic.catalog.repositories.postgres import init_db
         from nagra import Transaction
+
+        from akgentic.catalog.repositories.postgres import init_db
 
         with Transaction(postgres_initialized) as trn:
             cursor = trn.execute(

--- a/tests/scripts/test_init_db_script.py
+++ b/tests/scripts/test_init_db_script.py
@@ -1,0 +1,48 @@
+"""Tests for the ``akgentic.catalog.scripts.init_db`` init-container entrypoint.
+
+Cover the three exit paths without requiring a real Postgres instance:
+
+* Exit 2 when ``DB_CONN_STRING_PERSISTENCE`` is unset.
+* Exit 0 when :func:`init_db` succeeds (patched).
+* Exit 1 when :func:`init_db` raises (patched).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import akgentic.catalog.scripts.init_db as script
+
+
+class TestInitDbScriptExitCodes:
+    """Unit tests for :func:`akgentic.catalog.scripts.init_db.main`."""
+
+    def test_missing_env_returns_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Missing env var exits with code 2 (distinct from other errors)."""
+        monkeypatch.delenv("DB_CONN_STRING_PERSISTENCE", raising=False)
+
+        assert script.main() == 2
+
+    def test_init_db_success_returns_0(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Happy path: init_db succeeds, process exits 0."""
+        monkeypatch.setenv("DB_CONN_STRING_PERSISTENCE", "postgresql://fake")
+
+        with patch(
+            "akgentic.catalog.repositories.postgres.init_db",
+            return_value=None,
+        ) as mock_init_db:
+            assert script.main() == 0
+
+        mock_init_db.assert_called_once_with("postgresql://fake")
+
+    def test_init_db_failure_returns_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Any exception from init_db produces exit code 1."""
+        monkeypatch.setenv("DB_CONN_STRING_PERSISTENCE", "postgresql://fake")
+
+        with patch(
+            "akgentic.catalog.repositories.postgres.init_db",
+            side_effect=RuntimeError("connection refused"),
+        ):
+            assert script.main() == 1


### PR DESCRIPTION
## Summary

- Extend `create_app` with `backend="postgres"` and `postgres_conn_string=...` keyword, dispatching to a new `_wire_postgres_backend` helper that wires the four Nagra repositories into catalog services in dependency order.
- Add `--backend postgres --postgres-conn-string ...` support to the CLI (with `DB_CONN_STRING_PERSISTENCE` env-var fallback), a new `GlobalState.postgres_conn_string` field, `_validate_postgres_options` validator, and a new `build_postgres_catalogs` wiring helper in `cli/_catalog.py`.
- Lift session-scoped Postgres testcontainer fixtures to package-root `tests/conftest.py` so they are reusable across `tests/api/`, `tests/cli/`, and `tests/repositories/postgres/` with a single container per pytest session.
- Add end-to-end integration tests (`tests/api/test_app_postgres.py`, `tests/cli/test_cli_postgres.py`) that exercise HTTP and CLI round-trips against the Nagra repos, plus a no-extra regression guard (`tests/api/test_app_postgres_no_extra.py`) that verifies the module still imports without the `[postgres]` extra.
- Document the new backend in `README.md` and the architecture sharded docs.

Closes #104

Stacked on top of PR #103 (`feat/102-15-5-ilike-escape-reexport-symmetry`).
