### PR TITLE
feat(catalog): epic 15 — Catalog v2 Unified Entry (15-1 → 15-5)

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -37,6 +37,7 @@ from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogReposi
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
 from akgentic.catalog.resolver import (
     REF_KEY,
     TYPE_KEY,
@@ -80,6 +81,7 @@ __all__ = [
     "ToolEntry",
     "ToolQuery",
     "YamlAgentCatalogRepository",
+    "YamlEntryRepository",
     "YamlTeamCatalogRepository",
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -37,7 +37,16 @@ from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogReposi
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
-from akgentic.catalog.resolver import REF_KEY, TYPE_KEY, load_model_type
+from akgentic.catalog.resolver import (
+    REF_KEY,
+    TYPE_KEY,
+    load_model_type,
+    populate_refs,
+    prepare_for_write,
+    reconcile_refs,
+    resolve,
+    validate_delete,
+)
 from akgentic.catalog.services.agent_catalog import AgentCatalog
 from akgentic.catalog.services.team_catalog import TeamCatalog
 from akgentic.catalog.services.template_catalog import TemplateCatalog
@@ -75,7 +84,12 @@ __all__ = [
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
     "load_model_type",
+    "populate_refs",
+    "prepare_for_write",
+    "reconcile_refs",
+    "resolve",
     "resolve_env_vars",
+    "validate_delete",
 ]
 
 try:

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -104,10 +104,12 @@ try:
         from_document,
         to_document,
     )
+    from akgentic.catalog.repositories.mongo_entry_repo import MongoEntryRepository
 
     __all__ += [
         "MongoAgentCatalogRepository",
         "MongoCatalogConfig",
+        "MongoEntryRepository",
         "MongoTeamCatalogRepository",
         "MongoTemplateCatalogRepository",
         "MongoToolCatalogRepository",

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -11,6 +11,7 @@ installed.
 
 from __future__ import annotations
 
+from akgentic.catalog.catalog import UNSET_NAMESPACE, Catalog
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
 from akgentic.catalog.models.entry import Entry, EntryKind
@@ -60,6 +61,7 @@ __all__ = [
     "AgentCatalogRepository",
     "AgentEntry",
     "AgentQuery",
+    "Catalog",
     "CatalogValidationError",
     "CloneRequest",
     "Entry",
@@ -80,6 +82,7 @@ __all__ = [
     "ToolCatalogRepository",
     "ToolEntry",
     "ToolQuery",
+    "UNSET_NAMESPACE",
     "YamlAgentCatalogRepository",
     "YamlEntryRepository",
     "YamlTeamCatalogRepository",

--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -1,22 +1,34 @@
 """Public API surface for akgentic-catalog.
 
-Re-exports entry models (TemplateEntry, ToolEntry, AgentEntry, TeamEntry),
-query models, error types, abstract and YAML repository interfaces,
-catalog services, and the resolve_env_vars utility. MongoDB backend exports
-are conditionally available when pymongo is installed.
+Re-exports v1 entry models (TemplateEntry, ToolEntry, AgentEntry, TeamEntry),
+query models, error types, abstract and YAML repository interfaces, catalog
+services, and the resolve_env_vars utility. v2 additions (Entry, EntryKind,
+EntryQuery, CloneRequest, EntryRepository, REF_KEY, TYPE_KEY, load_model_type)
+are layered on top without removing any v1 names — v1 removal is deferred to
+Epic 19. MongoDB backend exports are conditionally available when pymongo is
+installed.
 """
 
 from __future__ import annotations
 
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.agent import AgentEntry
+from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
+from akgentic.catalog.models.queries import (
+    AgentQuery,
+    CloneRequest,
+    EntryQuery,
+    TeamQuery,
+    TemplateQuery,
+    ToolQuery,
+)
 from akgentic.catalog.models.team import TeamEntry, TeamMemberSpec
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 from akgentic.catalog.repositories.base import (
     AgentCatalogRepository,
+    EntryRepository,
     TeamCatalogRepository,
     TemplateCatalogRepository,
     ToolCatalogRepository,
@@ -25,23 +37,31 @@ from akgentic.catalog.repositories.yaml.agent_repo import YamlAgentCatalogReposi
 from akgentic.catalog.repositories.yaml.team_repo import YamlTeamCatalogRepository
 from akgentic.catalog.repositories.yaml.template_repo import YamlTemplateCatalogRepository
 from akgentic.catalog.repositories.yaml.tool_repo import YamlToolCatalogRepository
+from akgentic.catalog.resolver import REF_KEY, TYPE_KEY, load_model_type
 from akgentic.catalog.services.agent_catalog import AgentCatalog
 from akgentic.catalog.services.team_catalog import TeamCatalog
 from akgentic.catalog.services.template_catalog import TemplateCatalog
 from akgentic.catalog.services.tool_catalog import ToolCatalog
 
 __all__ = [
+    "REF_KEY",
+    "TYPE_KEY",
     "AgentCatalog",
     "AgentCatalogRepository",
     "AgentEntry",
     "AgentQuery",
     "CatalogValidationError",
+    "CloneRequest",
+    "Entry",
+    "EntryKind",
     "EntryNotFoundError",
+    "EntryQuery",
+    "EntryRepository",
     "TeamCatalog",
     "TeamCatalogRepository",
+    "TeamEntry",
     "TeamMemberSpec",
     "TeamQuery",
-    "TeamEntry",
     "TemplateCatalog",
     "TemplateCatalogRepository",
     "TemplateEntry",
@@ -54,6 +74,7 @@ __all__ = [
     "YamlTeamCatalogRepository",
     "YamlTemplateCatalogRepository",
     "YamlToolCatalogRepository",
+    "load_model_type",
     "resolve_env_vars",
 ]
 

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -1,0 +1,547 @@
+"""Unified v2 ``Catalog`` service — CRUD, clone, resolve, and load_team.
+
+This module owns the single public service that composes an ``EntryRepository``
+with the resolver pipeline (:mod:`akgentic.catalog.resolver`) to gate CRUD
+semantics, own the ``clone`` deep-copy primitive, and expose ``resolve`` /
+``resolve_by_id`` / ``load_team``.
+
+Placement is deliberate — ``catalog.py`` sits at the top level of the package
+(next to :mod:`resolver`, :mod:`env`) per the shard 10 package-structure plan.
+The v1 ``services/`` directory (home of ``TemplateCatalog``, ``ToolCatalog``,
+``AgentCatalog``, ``TeamCatalog``) is retired by Epic 19.
+
+Invariants enforced by the service (not the repository):
+
+* **Namespace bootstrap** — non-team entries in a namespace require a pre-existing
+  team entry in the same namespace (``_check_bootstrap``).
+* **Ownership** — sub-entries' ``user_id`` MUST equal the team entry's
+  ``user_id`` (``_check_ownership``).
+* **Namespace minting** — a team entry whose ``namespace`` equals the sentinel
+  :data:`UNSET_NAMESPACE` has its namespace replaced by a fresh ``uuid.uuid4()``
+  string before any other pipeline step runs.
+* **Clone atomicity** — ``clone`` collects every intended write in memory, then
+  emits them in a single pass; partial failures leave the destination namespace
+  untouched.
+* **Clone root-only lineage** — ``parent_namespace`` and ``parent_id`` are set
+  only on the top-level cloned entry; sub-entries have ``parent_*=None``.
+* **``load_team`` single-query** — exactly one ``list_by_namespace`` call reaches
+  the repository; ref resolution is served by an in-memory wrapper.
+
+The service never catches and re-wraps :class:`CatalogValidationError` from
+``prepare_for_write`` — those propagate unchanged.
+"""
+
+from __future__ import annotations
+
+import builtins
+import uuid
+from typing import Any, Final
+
+from pydantic import BaseModel
+
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.base import EntryRepository
+from akgentic.catalog.resolver import REF_KEY, prepare_for_write, validate_delete
+from akgentic.catalog.resolver import resolve as _resolve
+from akgentic.team.models import TeamCard
+
+__all__ = ["UNSET_NAMESPACE", "Catalog"]
+
+_list = builtins.list  # Alias: Catalog.list shadows the built-in inside the class.
+
+
+UNSET_NAMESPACE: Final[str] = "__MINT__"
+"""Sentinel ``namespace`` value signalling "mint a fresh UUID on create".
+
+The shard-06 "empty string" convention is rejected at the Pydantic layer
+(``Entry.namespace`` is ``NonEmptyStr``), so the service owns the magic value.
+Callers that want a newly-minted namespace construct
+``Entry(namespace=UNSET_NAMESPACE, kind="team", ...)``; :meth:`Catalog.create`
+substitutes a fresh ``uuid.uuid4()`` string before running the rest of the
+write pipeline.
+"""
+
+
+class Catalog:
+    """Unified catalog service — CRUD + clone + resolve + load_team.
+
+    Constructed with a single ``EntryRepository`` dependency; holds no other
+    state; performs no I/O in ``__init__``. All semantic concerns — namespace
+    bootstrap, ownership propagation, clone dedup, ref reconciliation, delete
+    guards — live here; the repository stays a narrow data plane.
+
+    Example:
+        >>> repo = YamlEntryRepository(tmp_path)
+        >>> catalog = Catalog(repo)
+        >>> team = Entry(id="team", kind="team", namespace=UNSET_NAMESPACE,
+        ...              model_type="akgentic.team.models.TeamCard",
+        ...              payload={...})
+        >>> stored = catalog.create(team)  # namespace now a fresh UUID
+        >>> stored.namespace
+        '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+    """
+
+    def __init__(self, repository: EntryRepository) -> None:
+        """Store ``repository`` on ``self._repository``; no I/O.
+
+        Args:
+            repository: Any concrete ``EntryRepository`` implementation.
+        """
+        self._repository: EntryRepository = repository
+
+    # --- Read -----------------------------------------------------------------
+
+    def get(self, namespace: str, id: str) -> Entry:
+        """Return the entry at ``(namespace, id)`` or raise ``EntryNotFoundError``.
+
+        Args:
+            namespace: The namespace of the entry.
+            id: The id within ``namespace``.
+
+        Returns:
+            The stored ``Entry``.
+
+        Raises:
+            EntryNotFoundError: If the repository returns ``None`` for the
+                ``(namespace, id)`` pair.
+        """
+        entry = self._repository.get(namespace, id)
+        if entry is None:
+            raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
+        return entry
+
+    def list(self, query: EntryQuery) -> _list[Entry]:
+        """Return entries matching ``query`` — repository pass-through."""
+        return self._repository.list(query)
+
+    def list_by_namespace(self, namespace: str) -> _list[Entry]:
+        """Return every entry in ``namespace`` — repository pass-through."""
+        return self._repository.list_by_namespace(namespace)
+
+    def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries in ``namespace`` referencing ``target_id`` — pass-through."""
+        return self._repository.find_references(namespace, target_id)
+
+    # --- Write ----------------------------------------------------------------
+
+    def create(self, entry: Entry) -> Entry:
+        """Persist a new entry with gating, minting, and ref reconciliation.
+
+        Pipeline:
+
+        1. If ``entry.kind == "team"`` and ``entry.namespace == UNSET_NAMESPACE``:
+           mint a fresh ``uuid.uuid4()`` and substitute it.
+        2. Reject duplicates via ``_check_duplicate`` — raises
+           ``CatalogValidationError`` if ``(namespace, id)`` already exists.
+        3. Non-team entries: run ``_check_bootstrap`` then ``_check_ownership``.
+           Team entries skip both (a team entry IS the bootstrap; it is the
+           ``user_id`` authority for its own namespace).
+        4. Run ``prepare_for_write`` — ref resolution, class load, Pydantic
+           validation, dump, reconcile. ``CatalogValidationError`` propagates
+           unchanged.
+        5. Call ``repository.put`` with the prepared entry; return it.
+
+        Args:
+            entry: Candidate entry to create. For team entries with a sentinel
+                namespace, :attr:`entry.namespace` MUST equal
+                :data:`UNSET_NAMESPACE`.
+
+        Returns:
+            The persisted ``Entry``, carrying the minted namespace if applicable
+            and the reconciled payload from ``prepare_for_write``.
+
+        Raises:
+            CatalogValidationError: On duplicate, bootstrap, ownership, or
+                ``prepare_for_write`` failure.
+        """
+        if entry.kind == "team" and entry.namespace == UNSET_NAMESPACE:
+            entry = self._mint_team_namespace(entry)
+
+        self._check_duplicate(entry.namespace, entry.id)
+
+        if entry.kind != "team":
+            self._check_bootstrap(entry.namespace)
+            self._check_ownership(entry)
+
+        prepared = prepare_for_write(entry, self._repository)
+        self._repository.put(prepared)
+        return prepared
+
+    def update(self, entry: Entry) -> Entry:
+        """Update an existing entry; re-run ref-reconciliation and ownership.
+
+        Pipeline:
+
+        1. Existence check: ``repository.get`` MUST return non-``None``.
+        2. Run ``prepare_for_write`` (may raise ``CatalogValidationError``).
+        3. For non-team entries, re-run ``_check_ownership`` on the prepared
+           shape so validator normalisations are honoured. Team entries are
+           authoritative for their own ``user_id`` and skip this check —
+           changing a team's ``user_id`` is a deliberate ownership transfer
+           that leaves sub-entries inconsistent until a caller-side migration
+           follows up (not this service's concern).
+        4. ``repository.put`` + return.
+
+        ``update`` NEVER mints a namespace; the empty-string / sentinel path
+        is exclusive to :meth:`create`.
+
+        Args:
+            entry: The candidate entry; its ``(namespace, id)`` MUST already
+                exist.
+
+        Returns:
+            The prepared, persisted ``Entry``.
+
+        Raises:
+            EntryNotFoundError: If no entry exists at ``(entry.namespace, entry.id)``.
+            CatalogValidationError: From ``prepare_for_write`` or
+                ``_check_ownership``.
+        """
+        if self._repository.get(entry.namespace, entry.id) is None:
+            raise EntryNotFoundError(f"Entry ({entry.namespace}, {entry.id}) not found")
+        prepared = prepare_for_write(entry, self._repository)
+        if prepared.kind != "team":
+            self._check_ownership(prepared)
+        self._repository.put(prepared)
+        return prepared
+
+    def delete(self, namespace: str, id: str) -> None:
+        """Delete ``(namespace, id)``, guarded by ``validate_delete``.
+
+        ``EntryNotFoundError`` fires for missing targets (distinguished from
+        inbound-ref blockers). ``CatalogValidationError`` fires when inbound
+        refs exist and carries each referring entry's id in the error message.
+
+        Args:
+            namespace: The namespace of the entry to delete.
+            id: The id within ``namespace``.
+
+        Raises:
+            EntryNotFoundError: If the target does not exist.
+            CatalogValidationError: If any inbound refs would be broken.
+        """
+        if self._repository.get(namespace, id) is None:
+            raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
+        errors = validate_delete(namespace, id, self._repository)
+        if errors:
+            raise CatalogValidationError(errors)
+        self._repository.delete(namespace, id)
+
+    # --- Clone ----------------------------------------------------------------
+
+    def clone(
+        self,
+        src_namespace: str,
+        src_id: str,
+        dst_namespace: str,
+        dst_user_id: str | None,
+    ) -> Entry:
+        """Deep-copy an entry tree into ``dst_namespace`` with ref rewrite and dedup.
+
+        Semantics (pinned by ADR-07 clone):
+
+        * Id preservation — when ``dst_namespace != src_namespace`` the source
+          id is reused; when equal, a numeric suffix (``-2``, ``-3``, …) is
+          appended until no collision exists in the repository or in the
+          intra-call dedup map.
+        * Root-only lineage — the top-level cloned entry carries
+          ``parent_namespace=src_namespace`` and ``parent_id=src_id``;
+          sub-entries have ``parent_*=None``.
+        * Deduplication — an intra-call ``cloned`` map keyed by the source
+          ``(namespace, id)`` pair guarantees every source sub-entry is cloned
+          exactly once per ``clone`` call.
+        * Atomicity — every ``put`` is deferred until the entire recursive
+          resolution completes. A mid-resolution failure leaves
+          ``dst_namespace`` untouched.
+        * No ``prepare_for_write`` — source entries were validated when they
+          were created; cloning is a structural copy + ref rewrite.
+        * Ownership — satisfied by construction (every cloned entry's
+          ``user_id`` is stamped to ``dst_user_id``), so ``_check_ownership``
+          is not re-run per-write.
+
+        Args:
+            src_namespace: Source namespace containing the entry to clone.
+            src_id: Id of the source entry within ``src_namespace``.
+            dst_namespace: Destination namespace receiving the cloned entries.
+            dst_user_id: ``user_id`` to stamp on every cloned entry; ``None``
+                for enterprise-scoped clones.
+
+        Returns:
+            The top-level cloned entry, as freshly re-read from the repository.
+
+        Raises:
+            EntryNotFoundError: If the source entry does not exist.
+            CatalogValidationError: If the source graph references a missing
+                entry (atomicity guarantees zero destination writes on this
+                path).
+        """
+        if self._repository.get(src_namespace, src_id) is None:
+            raise EntryNotFoundError(f"Source entry ({src_namespace}, {src_id}) not found")
+        cloned: dict[tuple[str, str], str] = {}
+        pending_writes: _list[Entry] = []
+        top_new_id = self._clone_one(
+            src_namespace=src_namespace,
+            src_id=src_id,
+            is_top_level=True,
+            cloned=cloned,
+            pending_writes=pending_writes,
+            dst_namespace=dst_namespace,
+            dst_user_id=dst_user_id,
+        )
+        for entry in pending_writes:
+            self._repository.put(entry)
+        top = self._repository.get(dst_namespace, top_new_id)
+        if top is None:  # pragma: no cover — defensive; put just stored it
+            raise CatalogValidationError(
+                [f"Clone post-write lookup failed for ({dst_namespace}, {top_new_id})"]
+            )
+        return top
+
+    # --- Resolve --------------------------------------------------------------
+
+    def resolve(self, entry: Entry) -> BaseModel:
+        """Hydrate ``entry`` into a runtime Pydantic instance — delegates to resolver."""
+        return _resolve(entry, self._repository)
+
+    def resolve_by_id(self, namespace: str, id: str) -> BaseModel:
+        """Convenience: ``self.resolve(self.get(namespace, id))``."""
+        return self.resolve(self.get(namespace, id))
+
+    def load_team(self, namespace: str) -> TeamCard:
+        """Load and resolve the ``kind="team"`` entry in ``namespace`` into a ``TeamCard``.
+
+        Issues exactly ONE ``list_by_namespace`` call against the real
+        repository, then builds a pre-loaded in-memory wrapper to short-circuit
+        every per-ref ``get`` call ``populate_refs`` would otherwise make. A
+        defensive runtime ``isinstance(result, TeamCard)`` check catches
+        misconfigured team entries (those whose ``model_type`` points at a
+        non-``TeamCard`` class) before they leak out.
+
+        Args:
+            namespace: The namespace to load.
+
+        Returns:
+            The resolved :class:`TeamCard` for ``namespace``.
+
+        Raises:
+            CatalogValidationError: If no team entry exists in ``namespace``
+                or if the team entry's ``model_type`` resolves to a class
+                other than :class:`TeamCard`.
+        """
+        entries = self._repository.list_by_namespace(namespace)
+        team_entries = [e for e in entries if e.kind == "team"]
+        if not team_entries:
+            raise CatalogValidationError([f"Namespace '{namespace}' has no team entry"])
+        team_entry = team_entries[0]
+        in_memory = _InMemoryEntryRepository(entries)
+        result = _resolve(team_entry, in_memory)
+        if not isinstance(result, TeamCard):
+            raise CatalogValidationError(
+                [f"Team entry's model_type resolved to {type(result).__name__}, expected TeamCard"]
+            )
+        return result
+
+    # --- Private helpers ------------------------------------------------------
+
+    def _mint_team_namespace(self, entry: Entry) -> Entry:
+        """Return a copy of ``entry`` with ``namespace`` set to a fresh UUID string."""
+        return entry.model_copy(update={"namespace": str(uuid.uuid4())})
+
+    def _check_duplicate(self, namespace: str, id: str) -> None:
+        """Raise ``CatalogValidationError`` if ``(namespace, id)`` already exists."""
+        if self._repository.get(namespace, id) is not None:
+            raise CatalogValidationError([f"Entry ({namespace}, {id}) already exists"])
+
+    def _check_bootstrap(self, namespace: str) -> None:
+        """Ensure a team entry exists in ``namespace``; raise otherwise."""
+        if self._repository.get_by_kind(namespace, "team") is None:
+            raise CatalogValidationError(
+                [
+                    f"Namespace '{namespace}' has no team entry — create the team "
+                    f"entry first (bootstrap invariant)"
+                ]
+            )
+
+    def _check_ownership(self, entry: Entry) -> None:
+        """Ensure ``entry.user_id == team_entry.user_id`` within ``entry.namespace``."""
+        team = self._repository.get_by_kind(entry.namespace, "team")
+        if team is None:
+            # Bootstrap already guards this for create(); update() uses the same
+            # helper, and an update to a non-team entry that left the team
+            # behind is a corrupted state — reject defensively.
+            raise CatalogValidationError(
+                [
+                    f"Namespace '{entry.namespace}' has no team entry — cannot "
+                    f"verify ownership for '{entry.id}'"
+                ]
+            )
+        if entry.user_id != team.user_id:
+            raise CatalogValidationError(
+                [
+                    f"Ownership mismatch in namespace '{entry.namespace}': "
+                    f"entry '{entry.id}' has user_id={entry.user_id!r} but "
+                    f"team has user_id={team.user_id!r}"
+                ]
+            )
+
+    def _clone_one(
+        self,
+        src_namespace: str,
+        src_id: str,
+        is_top_level: bool,
+        cloned: dict[tuple[str, str], str],
+        pending_writes: _list[Entry],
+        dst_namespace: str,
+        dst_user_id: str | None,
+    ) -> str:
+        """Clone a single source entry, recursing into its payload refs."""
+        key = (src_namespace, src_id)
+        if key in cloned:
+            return cloned[key]
+
+        src = self._repository.get(src_namespace, src_id)
+        if src is None:
+            raise CatalogValidationError(
+                [f"Clone source ({src_namespace}, {src_id}) not found during resolution"]
+            )
+
+        new_id = self._mint_dst_id(dst_namespace, src_namespace, src_id, cloned)
+        # Record BEFORE recursing so a back-ref to the same source returns
+        # the same dst id (prevents infinite recursion on cycles-by-construction).
+        cloned[key] = new_id
+
+        def _callback(target_id: str) -> str:
+            return self._clone_one(
+                src_namespace=src_namespace,
+                src_id=target_id,
+                is_top_level=False,
+                cloned=cloned,
+                pending_writes=pending_writes,
+                dst_namespace=dst_namespace,
+                dst_user_id=dst_user_id,
+            )
+
+        new_payload = _rewrite_refs(src.payload, _callback)
+        new_entry = src.model_copy(
+            update={
+                "id": new_id,
+                "namespace": dst_namespace,
+                "user_id": dst_user_id,
+                "parent_namespace": src_namespace if is_top_level else None,
+                "parent_id": src_id if is_top_level else None,
+                "payload": new_payload,
+            }
+        )
+        pending_writes.append(new_entry)
+        return new_id
+
+    def _mint_dst_id(
+        self,
+        dst_namespace: str,
+        src_namespace: str,
+        src_id: str,
+        cloned: dict[tuple[str, str], str],
+    ) -> str:
+        """Return the destination id for a clone.
+
+        Cross-namespace: reuse ``src_id``. Same-namespace: append a numeric
+        suffix starting at ``-2`` and increment until the candidate does not
+        collide with either a stored entry or an id already planned by the
+        current clone operation.
+        """
+        if dst_namespace != src_namespace:
+            return src_id
+        planned: set[str] = set(cloned.values())
+        suffix = 2
+        while True:
+            candidate = f"{src_id}-{suffix}"
+            if self._repository.get(dst_namespace, candidate) is None and candidate not in planned:
+                return candidate
+            suffix += 1
+
+
+def _rewrite_refs(node: Any, clone_target: Any) -> Any:
+    """Recursively copy ``node``, replacing ref targets via ``clone_target``.
+
+    Dicts carrying a ``REF_KEY`` entry have their target id replaced by
+    ``clone_target(target_id)`` — the callback is typically a recursive clone
+    invocation that also clones the target entry. ``TYPE_KEY`` (if present) is
+    preserved verbatim. Non-ref dicts and lists recurse structurally; leaves
+    pass through unchanged.
+
+    Args:
+        node: Arbitrary payload subtree.
+        clone_target: Callback mapping a source target id to the corresponding
+            destination target id (with side effect of cloning the target).
+
+    Returns:
+        A new payload subtree with every ref marker pointing at the newly
+        minted destination ids.
+    """
+    if isinstance(node, dict):
+        if REF_KEY in node:
+            new: dict[str, Any] = dict(node)
+            new[REF_KEY] = clone_target(node[REF_KEY])
+            return new
+        return {k: _rewrite_refs(v, clone_target) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_rewrite_refs(v, clone_target) for v in node]
+    return node
+
+
+class _InMemoryEntryRepository:
+    """Pre-loaded ``EntryRepository`` wrapper serving ``get`` from a list.
+
+    Used exclusively by :meth:`Catalog.load_team` to short-circuit the per-ref
+    ``get`` calls :func:`~akgentic.catalog.resolver.populate_refs` would
+    otherwise issue against the namespace that was just loaded wholesale.
+    Every non-``get`` method raises :class:`NotImplementedError` — this wrapper
+    is intentionally a degraded shape, not a drop-in replacement for a real
+    repository.
+    """
+
+    def __init__(self, entries: list[Entry]) -> None:
+        """Index ``entries`` by ``(namespace, id)`` for O(1) ``get`` lookups."""
+        self._by_key: dict[tuple[str, str], Entry] = {(e.namespace, e.id): e for e in entries}
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        """Return the pre-loaded entry or ``None`` if absent."""
+        return self._by_key.get((namespace, id))
+
+    def put(self, entry: Entry) -> Entry:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def delete(self, namespace: str, id: str) -> None:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def list(self, query: EntryQuery) -> _list[Entry]:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def list_by_namespace(self, namespace: str) -> _list[Entry]:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def get_by_kind(self, namespace: str, kind: Any) -> Entry | None:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def find_references(self, namespace: str, target_id: str) -> _list[Entry]:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )

--- a/src/akgentic/catalog/models/entry.py
+++ b/src/akgentic/catalog/models/entry.py
@@ -1,0 +1,154 @@
+"""Unified v2 ``Entry`` model, ``EntryKind`` literal, and allowlisted-path type.
+
+This module is the documented import site for the catalog v2 entry type system.
+It lands alongside the v1 per-kind entry models (``TemplateEntry`` etc.) without
+replacing them — v1 removal is deferred to Epic 19.
+
+Key exports:
+
+* ``Entry`` — the single unified catalog entry model used by v2 code.
+* ``EntryKind`` — ``Literal`` alias of the five supported entry kinds.
+* ``AllowlistedPath`` — ``Annotated[str, AfterValidator(...)]`` enforcing the
+  ``akgentic.`` prefix on class-path fields at Pydantic validation time.
+* ``NonEmptyStr`` — re-exported from ``._types`` so consumers have a single
+  import site for v2.
+
+The allowlist check implemented here is the storage-side defence (catches bad
+``Entry.model_type`` at construction time, before any import). The runtime
+counterpart in ``akgentic.catalog.resolver.load_model_type`` repeats the prefix
+check and adds the ``BaseModel`` / reserved-key checks that require the class
+object in hand. The duplication is intentional (see Story 15.1 Dev Notes).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import AfterValidator, BaseModel, Field, model_validator
+
+from ._types import NonEmptyStr
+
+__all__ = ["AllowlistedPath", "Entry", "EntryKind", "NonEmptyStr"]
+
+
+EntryKind = Literal["team", "agent", "tool", "model", "prompt"]
+"""The five entry kinds a v2 catalog stores.
+
+``team``/``agent``/``tool`` mirror v1 semantics. ``model`` and ``prompt`` are
+new v2 kinds — model-type configs and reusable prompt templates promoted to
+first-class entries so they can be referenced via the ref-sentinel mechanism
+(see ``akgentic.catalog.resolver``).
+"""
+
+
+# Storage-side allowlist for class paths stored in ``Entry.model_type``.
+# Duplicated intentionally in ``resolver.py`` — two layers, two policies that
+# only happen to agree today. See Story 15.1 Dev Notes.
+_ALLOWED_PREFIXES: tuple[str, ...] = ("akgentic.",)
+
+
+def _check_allowlist(v: str) -> str:
+    """Reject class paths that do not start with an allowlisted prefix.
+
+    Args:
+        v: Candidate dotted class path (e.g. ``"akgentic.llm.ModelConfig"``).
+
+    Returns:
+        The input string unchanged when it passes the prefix check.
+
+    Raises:
+        ValueError: When ``v`` does not start with any allowlisted prefix.
+            The error message is ``"... outside allowlist ..."`` to satisfy
+            the substring assertions pinned by Story 15.1 acceptance criteria.
+    """
+    if not any(v.startswith(prefix) for prefix in _ALLOWED_PREFIXES):
+        raise ValueError(f"model_type '{v}' outside allowlist {_ALLOWED_PREFIXES}")
+    return v
+
+
+AllowlistedPath = Annotated[str, AfterValidator(_check_allowlist)]
+"""Dotted class path constrained to the ``akgentic.`` namespace.
+
+Used by ``Entry.model_type``. The check fires at Pydantic validation time —
+construction of an ``Entry`` with a non-allowlisted path raises
+``pydantic.ValidationError`` before any import side effect runs.
+"""
+
+
+class Entry(BaseModel):
+    """Unified catalog entry (v2).
+
+    Replaces the four v1 per-kind entry models (``TemplateEntry``,
+    ``ToolEntry``, ``AgentEntry``, ``TeamEntry``) with a single shape whose
+    ``kind`` discriminator selects the semantics and whose ``payload`` carries
+    the kind-specific configuration (validated against the Pydantic class named
+    by ``model_type`` at resolve time — see ``akgentic.catalog.resolver``).
+
+    Lineage fields (``parent_namespace`` / ``parent_id``) support the three
+    lineage cases called out in ADR-07:
+
+    * both ``None`` — fresh entry minted in this namespace.
+    * ``parent_namespace=None`` + ``parent_id=<str>`` — same-namespace
+      duplicate (same catalog, new id, e.g. a user-owned edit of a global
+      entry that was cloned without changing namespace).
+    * both set — cross-namespace clone.
+
+    The validator ``_check_parent_pair`` rejects the fourth combination
+    (``parent_namespace`` set, ``parent_id is None``) because a namespace
+    without an id does not identify a parent entry.
+    """
+
+    id: NonEmptyStr = Field(description="Entry id, unique within (namespace, kind).")
+    kind: EntryKind = Field(description="Discriminator selecting entry semantics.")
+    namespace: NonEmptyStr = Field(
+        description="Namespace this entry belongs to; scopes id uniqueness."
+    )
+    user_id: NonEmptyStr | None = Field(
+        default=None,
+        description=("Owner user id for user-scoped entries; None for global/enterprise entries."),
+    )
+    parent_namespace: NonEmptyStr | None = Field(
+        default=None,
+        description=(
+            "Lineage pointer: namespace of the parent entry. Set together with "
+            "parent_id for cross-namespace clones; leave None for same-namespace "
+            "duplicates or fresh entries."
+        ),
+    )
+    parent_id: NonEmptyStr | None = Field(
+        default=None,
+        description=(
+            "Lineage pointer: id of the parent entry. Set for clones and "
+            "same-namespace duplicates; None for fresh entries."
+        ),
+    )
+    model_type: AllowlistedPath = Field(
+        description=(
+            "Dotted path to the Pydantic BaseModel class that validates payload. "
+            "Restricted to the akgentic.* namespace at the annotation layer; "
+            "resolver adds BaseModel and reserved-key checks at resolve time."
+        ),
+    )
+    description: str = Field(
+        default="",
+        description="Human-readable description; may be empty.",
+    )
+    payload: dict[str, Any] = Field(
+        description=(
+            "Kind-specific configuration; validated against the class named by "
+            "model_type during resolve. May contain ref sentinels populated by "
+            "the resolver."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_parent_pair(self) -> Entry:
+        """Reject lineage pairs with ``parent_namespace`` set and ``parent_id`` missing.
+
+        Three lineage combinations are valid (see class docstring). The rejected
+        case — ``parent_namespace`` set without ``parent_id`` — is rejected
+        because a namespace alone cannot identify a parent entry.
+        """
+        if self.parent_namespace is not None and self.parent_id is None:
+            raise ValueError("parent_namespace set but parent_id is None")
+        return self

--- a/src/akgentic/catalog/models/queries.py
+++ b/src/akgentic/catalog/models/queries.py
@@ -1,11 +1,21 @@
-"""Query models for catalog repository search operations."""
+"""Query models for catalog repository search operations.
+
+Holds both the v1 per-kind query models (``TemplateQuery``, ``ToolQuery``,
+``AgentQuery``, ``TeamQuery``) and the v2 ``EntryQuery`` + ``CloneRequest``
+models. v1 models are preserved unchanged; v2 additions are additive only.
+v1 removal is deferred to Epic 19.
+"""
 
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .entry import EntryKind, NonEmptyStr
+
 __all__ = [
     "AgentQuery",
+    "CloneRequest",
+    "EntryQuery",
     "TeamQuery",
     "TemplateQuery",
     "ToolQuery",
@@ -63,4 +73,71 @@ class TeamQuery(BaseModel):
     )
     agent_id: str | None = Field(
         default=None, description="Filter by agent id present in team members"
+    )
+
+
+class EntryQuery(BaseModel):
+    """Query model for filtering v2 unified ``Entry`` rows.
+
+    All fields are optional and default to ``None``. Fields combine with AND
+    semantics — a ``None`` field means "don't filter by this attribute".
+
+    ``user_id_set`` is a tri-state filter layered on top of ``user_id``:
+
+    * ``None`` — ignore user_id scoping entirely.
+    * ``True`` — include only entries with any non-``None`` ``user_id``
+      (i.e. user-scoped entries).
+    * ``False`` — include only entries with ``user_id is None``
+      (i.e. global/enterprise entries).
+
+    This is orthogonal to ``user_id``: passing ``user_id="alice"`` narrows to
+    exactly that user, whereas ``user_id_set=True`` narrows to "any user".
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    namespace: NonEmptyStr | None = Field(default=None, description="Filter by exact namespace.")
+    kind: EntryKind | None = Field(
+        default=None, description="Filter by entry kind (team/agent/tool/model/prompt)."
+    )
+    id: NonEmptyStr | None = Field(default=None, description="Filter by exact entry id.")
+    user_id: NonEmptyStr | None = Field(
+        default=None,
+        description="Filter by exact user_id; use user_id_set for presence-only filtering.",
+    )
+    user_id_set: bool | None = Field(
+        default=None,
+        description=(
+            "Tri-state user_id scope filter: None=any, True=user_id set, False=user_id is None."
+        ),
+    )
+    parent_namespace: NonEmptyStr | None = Field(
+        default=None, description="Filter by parent_namespace lineage pointer."
+    )
+    parent_id: NonEmptyStr | None = Field(
+        default=None, description="Filter by parent_id lineage pointer."
+    )
+    description_contains: str | None = Field(
+        default=None, description="Filter by substring match in entry description."
+    )
+
+
+class CloneRequest(BaseModel):
+    """Request model for cloning an entry from one namespace to another.
+
+    ``dst_namespace`` is required — cloning into an unnamed target is not
+    meaningful. Creating a namespace from scratch is a ``Catalog.create``
+    concern, not a clone concern.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    src_namespace: NonEmptyStr = Field(
+        description="Source namespace containing the entry to clone."
+    )
+    src_id: NonEmptyStr = Field(description="Id of the source entry to clone.")
+    dst_namespace: NonEmptyStr = Field(description="Destination namespace for the clone.")
+    dst_user_id: NonEmptyStr | None = Field(
+        default=None,
+        description=("Destination user_id; None targets a global/enterprise clone."),
     )

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -3,21 +3,34 @@
 Each entity type (template, tool, agent, team) gets its own ABC with ``create``,
 ``get``, ``list``, ``search``, ``update``, and ``delete``. Concrete backends
 (e.g. ``YamlRepositoryBase``) implement these interfaces.
+
+The v2 ``EntryRepository`` ``typing.Protocol`` lives in this same file — it is
+a sibling contract, not a replacement for the v1 ABCs. Both coexist for the
+duration of Epic 15; v1 ABCs are removed in Epic 19.
 """
 
 from __future__ import annotations
 
 import builtins
 from abc import ABC, abstractmethod
+from typing import Protocol
 
 from akgentic.catalog.models.agent import AgentEntry
-from akgentic.catalog.models.queries import AgentQuery, TeamQuery, TemplateQuery, ToolQuery
+from akgentic.catalog.models.entry import Entry, EntryKind
+from akgentic.catalog.models.queries import (
+    AgentQuery,
+    EntryQuery,
+    TeamQuery,
+    TemplateQuery,
+    ToolQuery,
+)
 from akgentic.catalog.models.team import TeamEntry
 from akgentic.catalog.models.template import TemplateEntry
 from akgentic.catalog.models.tool import ToolEntry
 
 __all__ = [
     "AgentCatalogRepository",
+    "EntryRepository",
     "TeamCatalogRepository",
     "TemplateCatalogRepository",
     "ToolCatalogRepository",
@@ -292,3 +305,34 @@ class TeamCatalogRepository(ABC):
         Raises:
             EntryNotFoundError: If no entry with the given id exists.
         """
+
+
+class EntryRepository(Protocol):
+    """Type contract for concrete v2 backends storing unified ``Entry`` rows.
+
+    Structural protocol (no runtime-checkable decorator) — concrete
+    implementations in Stories 15.3 (YAML) and 15.4 (Mongo) satisfy it by
+    shape, not by inheritance. v1 per-kind ABCs are preserved alongside this
+    protocol until Epic 19.
+    """
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        """Fetch a single entry identified by (namespace, id); return None if absent."""
+
+    def put(self, entry: Entry) -> Entry:
+        """Insert or replace ``entry`` keyed by (namespace, id); return the stored entry."""
+
+    def delete(self, namespace: str, id: str) -> None:
+        """Remove the entry identified by (namespace, id)."""
+
+    def list(self, query: EntryQuery) -> _list[Entry]:
+        """Return entries matching ``query`` (AND semantics over set fields)."""
+
+    def list_by_namespace(self, namespace: str) -> _list[Entry]:
+        """Return every entry in ``namespace`` regardless of kind."""
+
+    def get_by_kind(self, namespace: str, kind: EntryKind) -> Entry | None:
+        """Return a single entry of ``kind`` in ``namespace`` if one exists."""
+
+    def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries in ``namespace`` whose payload references ``target_id``."""

--- a/src/akgentic/catalog/repositories/mongo_entry_repo.py
+++ b/src/akgentic/catalog/repositories/mongo_entry_repo.py
@@ -1,0 +1,348 @@
+"""MongoDB-backed v2 ``EntryRepository`` storing every entry in one collection.
+
+Layout: one ``catalog_entries`` collection keyed by a compound ``_id`` of the
+form ``{"namespace": <ns>, "id": <id>}``. ``(namespace, id)`` is the v2
+uniqueness key; ``kind`` is metadata. Mongo's primary-key uniqueness on the
+compound ``_id`` structurally prevents duplicate ids within a single namespace,
+so the duplicate-id reconciliation the YAML backend performs is unnecessary
+here.
+
+The repository is intent-preserving: ``put`` writes
+``entry.model_dump(mode="json")`` verbatim, so author-written ref markers
+(``{"__ref__": ...}``, ``{"__type__": ...}``) round-trip byte-for-byte without
+any resolver-layer expansion. The ``Catalog`` service (Story 15.5) runs
+``prepare_for_write`` before reaching this repository; the repository itself
+never calls ``populate_refs`` / ``reconcile_refs`` / ``prepare_for_write``.
+
+The module name ``mongo_entry_repo`` is temporary: the v1 package
+``repositories/mongo/`` still lives at the same directory level and a Python
+``repositories/mongo.py`` module would collide with it. Epic 19 Story 19.2
+renames this module to ``mongo.py`` after v1 deletion. The module intentionally
+lives at ``repositories/`` level (not inside ``repositories/mongo/``) to match
+the placement of ``yaml_entry_repo.py`` so the rename is symmetric across
+backends.
+
+``pymongo`` is NOT imported at module top level — the only typing surface that
+references ``pymongo`` lives under ``if TYPE_CHECKING:``. Runtime code imports
+``pymongo.ASCENDING`` inside the method bodies that need it, so importing this
+module without ``pymongo`` installed succeeds. The caller only pays the
+``pymongo`` tax when they actually hand a live ``Collection`` to the
+constructor. The ``repositories/mongo/`` package's own import guard (``try:
+import pymongo; except ImportError: raise ImportError("pip install
+akgentic-catalog[mongo]")``) is orthogonal — ``mongo_entry_repo.py`` is one
+directory level up.
+
+Secondary indexes (``(namespace, kind)`` and ``(namespace, parent_id)``) are
+created lazily on the first ``put``. Read-only repositories never touch the
+index surface. Under ``mongomock``, ``create_index`` is a no-op that still
+records the call so tests can verify the production code path.
+
+Implements the storage layer described in architecture shard 04
+(``_bmad-output/akgentic-catalog/architecture/04-repositories.md``) under the
+unified-entry contract of ADR-007.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from akgentic.catalog.models.entry import Entry, EntryKind
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.yaml_entry_repo import _payload_has_ref
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+__all__ = ["MongoEntryRepository"]
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+class MongoEntryRepository:
+    """Single-collection, compound-``_id`` v2 ``EntryRepository`` on MongoDB.
+
+    Satisfies the ``akgentic.catalog.repositories.base.EntryRepository``
+    structural protocol. Construction stores the passed ``Collection`` and does
+    not perform any I/O — indexes are created lazily on the first ``put``.
+
+    The document shape is:
+
+    ``{
+        "_id": {"namespace": <ns>, "id": <id>},
+        "namespace": <ns>,
+        "id": <id>,
+        "kind": <kind>,
+        "user_id": <str|None>,
+        "parent_namespace": <str|None>,
+        "parent_id": <str|None>,
+        "model_type": <akgentic.* dotted path>,
+        "description": <str>,
+        "payload": {...},
+    }``
+
+    ``namespace`` and ``id`` are duplicated at the top level so secondary index
+    queries do not need to destructure ``_id`` and so
+    ``Entry.model_validate(doc_minus_underscore_id)`` reconstructs the entry
+    without having to re-inject ``id`` from ``_id``. This diverges from the v1
+    ``repositories/mongo/_helpers.py::to_document`` /``from_document`` helpers
+    (which store a plain-string ``_id`` equal to ``entry.id``); v2 uses its own
+    shape conversion and does NOT reuse those helpers.
+
+    The repository is intent-preserving — see module docstring. Callers that
+    want ref markers expanded must call the resolver pipeline in
+    ``akgentic.catalog.resolver`` before / after the repository round-trip;
+    this class does not mutate payload content.
+    """
+
+    def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
+        """Store the collection; do not touch the server.
+
+        Args:
+            collection: A ``pymongo.collection.Collection`` (or mongomock
+                equivalent) holding v2 ``Entry`` documents. The repository
+                does NOT own the client, the database, or the collection
+                lifecycle — the caller wires the ``client → db → collection``
+                chain and hands the collection to the constructor.
+        """
+        self._collection = collection
+        self._indexes_created: bool = False
+        logger.info("MongoEntryRepository initialized")
+
+    # --- Compound-id and document-shape helpers ---
+
+    def _compound_id(self, namespace: str, id: str) -> dict[str, str]:
+        """Return the compound-``_id`` dict ``{"namespace": ns, "id": id}``.
+
+        This is the only form of ``_id`` the v2 collection recognises. The
+        dict is constructed fresh on every call — Mongo compares ``_id``
+        values by deep equality, so a dict literal is safe to pass to
+        ``find_one`` / ``delete_one`` / ``replace_one``.
+        """
+        return {"namespace": namespace, "id": id}
+
+    def _to_document(self, entry: Entry) -> dict[str, Any]:
+        """Serialise ``entry`` to the v2 compound-``_id`` document shape.
+
+        Starts from ``entry.model_dump(mode="json")`` (which includes every
+        field of ``Entry`` — ``id``, ``namespace``, ``kind``, … and ``payload``
+        verbatim) and adds a compound ``_id`` composed of ``namespace`` + ``id``.
+        The top-level ``id`` / ``namespace`` fields are kept so a full read can
+        call ``Entry.model_validate`` after popping ``_id`` without having to
+        destructure the compound key.
+
+        Diverges from v1 ``_helpers.py::to_document`` — that helper pops ``id``
+        to a plain-string ``_id``; v2 keeps ``id`` at the top level AND nests
+        it inside the compound ``_id``. The two shapes are incompatible and
+        share no code.
+        """
+        doc = entry.model_dump(mode="json")
+        doc["_id"] = self._compound_id(entry.namespace, entry.id)
+        return doc
+
+    def _from_document(self, doc: dict[str, Any]) -> Entry:
+        """Reconstruct an ``Entry`` from a v2 compound-``_id`` document.
+
+        Takes a shallow copy so the caller's dict is not mutated (some driver
+        versions reuse the document object passed to ``replace_one`` or mutate
+        cursor results). Pops ``_id`` — the top-level ``namespace`` + ``id``
+        fields already carry the same values — and delegates the remaining
+        fields to ``Entry.model_validate``.
+
+        Diverges from v1 ``_helpers.py::from_document`` — that helper pops
+        ``_id`` into the ``id`` field; v2 discards ``_id`` outright since the
+        top-level ``id`` field is authoritative.
+        """
+        data = dict(doc)
+        data.pop("_id", None)
+        return Entry.model_validate(data)
+
+    # --- Lazy index creation ---
+
+    def _ensure_indexes(self) -> None:
+        """Create the two v2 secondary indexes on the first call; no-op after.
+
+        Declared indexes:
+
+        * ``(namespace, kind)`` — the standard listing path
+          (``list_by_namespace`` + ``get_by_kind``).
+        * ``(namespace, parent_id)`` — lineage traversal (reserved for future
+          "find all clones of X" queries; not directly used in this story).
+
+        No index is created on ``_id`` — Mongo enforces primary-key uniqueness
+        on ``_id`` by default. No index is created for the payload walk
+        ``find_references`` uses (v2 acceptance — no wildcard payload index).
+
+        The one-shot ``self._indexes_created`` flag keeps subsequent ``put``
+        calls cheap. The ``ASCENDING`` constant is imported inside this method
+        so the module's top-level imports stay free of ``pymongo``.
+        """
+        if self._indexes_created:
+            return
+        from pymongo import ASCENDING
+
+        self._collection.create_index([("namespace", ASCENDING), ("kind", ASCENDING)])
+        self._collection.create_index([("namespace", ASCENDING), ("parent_id", ASCENDING)])
+        self._indexes_created = True
+
+    # --- Write operations ---
+
+    def put(self, entry: Entry) -> Entry:
+        """Upsert ``entry`` keyed by ``(namespace, id)``; return the stored entry.
+
+        Creates the two secondary indexes on the first call (see
+        ``_ensure_indexes``) and issues ``replace_one(filter, doc,
+        upsert=True)`` with ``filter = {"_id": {"namespace": ..., "id": ...}}``.
+        The "second write wins" contract (the v2 upsert semantics pinned by
+        the acceptance criteria) means the collection count does not grow on
+        re-writes of the same ``(namespace, id)`` pair — including when
+        ``kind`` changes between writes, since ``kind`` is metadata and not
+        part of the uniqueness key.
+
+        Does NOT use ``insert_one`` + ``DuplicateKeyError`` recovery — the
+        contract is unambiguous upsert and ``replace_one`` + ``upsert=True``
+        is the direct path. Does NOT call ``populate_refs`` / ``reconcile_refs``
+        / ``prepare_for_write`` / ``entry.model_dump(exclude_unset=True)`` —
+        the repository is intent-preserving (writes what it was handed).
+
+        Args:
+            entry: The entry to persist. The ``(namespace, id)`` pair is the
+                uniqueness key.
+
+        Returns:
+            The ``entry`` argument unchanged — callers treat it as the stored
+            form for chaining or assertion.
+        """
+        self._ensure_indexes()
+        doc = self._to_document(entry)
+        self._collection.replace_one({"_id": doc["_id"]}, doc, upsert=True)
+        logger.debug("Upserted entry ns=%s id=%s kind=%s", entry.namespace, entry.id, entry.kind)
+        return entry
+
+    def delete(self, namespace: str, id: str) -> None:
+        """Remove the entry at ``(namespace, id)``; no-op when absent.
+
+        Issues ``delete_one({"_id": {"namespace": ..., "id": ...}})`` and
+        ignores ``DeleteResult.deleted_count`` — the repository accepts
+        idempotency. The service layer's ``validate_delete`` is the
+        authoritative guard against deleting missing entries.
+        """
+        self._collection.delete_one({"_id": self._compound_id(namespace, id)})
+        logger.debug("Deleted entry ns=%s id=%s (idempotent on miss)", namespace, id)
+
+    # --- Read operations ---
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        """Return the entry at ``(namespace, id)`` or ``None`` if absent.
+
+        Issues ``find_one({"_id": {"namespace": ..., "id": ...}})``. Because
+        the filter uses the compound primary key, namespace isolation is
+        enforced by construction — a matching id in a different namespace
+        cannot bleed across.
+        """
+        doc = self._collection.find_one({"_id": self._compound_id(namespace, id)})
+        if doc is None:
+            return None
+        return self._from_document(doc)
+
+    def list(self, query: EntryQuery) -> _list[Entry]:
+        """Return entries matching ``query`` with AND semantics over set fields.
+
+        Builds a single server-side filter dict via ``_build_filter`` and
+        issues one ``find``. Every filter supported by ``EntryQuery`` is
+        translated to an exact-match Mongo clause, except
+        ``description_contains`` which becomes a case-sensitive
+        ``{"$regex": re.escape(value)}`` clause (no ``$options: "i"`` —
+        parity with the YAML backend's case-sensitive substring check).
+
+        When ``query.namespace`` is ``None``, the filter omits the
+        ``namespace`` clause and the scan spans every document subject to
+        the remaining filters.
+        """
+        mongo_filter = self._build_filter(query)
+        cursor = self._collection.find(mongo_filter)
+        return [self._from_document(doc) for doc in cursor]
+
+    def _build_filter(self, query: EntryQuery) -> dict[str, Any]:
+        """Translate an ``EntryQuery`` into a server-side Mongo filter dict.
+
+        Each non-``None`` field contributes exactly one clause. ``user_id_set``
+        is tri-state (``None`` = ignore, ``True`` = ``user_id != null``,
+        ``False`` = ``user_id is null``). ``description_contains`` uses
+        ``re.escape`` to defuse regex metacharacters in user input.
+        """
+        mongo_filter: dict[str, Any] = {}
+        if query.namespace is not None:
+            mongo_filter["namespace"] = query.namespace
+        if query.kind is not None:
+            mongo_filter["kind"] = query.kind
+        if query.id is not None:
+            mongo_filter["id"] = query.id
+        if query.user_id is not None:
+            mongo_filter["user_id"] = query.user_id
+        if query.user_id_set is True:
+            mongo_filter["user_id"] = {"$ne": None}
+        elif query.user_id_set is False:
+            mongo_filter["user_id"] = None
+        if query.parent_namespace is not None:
+            mongo_filter["parent_namespace"] = query.parent_namespace
+        if query.parent_id is not None:
+            mongo_filter["parent_id"] = query.parent_id
+        if query.description_contains is not None:
+            mongo_filter["description"] = {"$regex": re.escape(query.description_contains)}
+        return mongo_filter
+
+    def list_by_namespace(self, namespace: str) -> _list[Entry]:
+        """Return every entry in ``namespace`` in a single ``find``.
+
+        Issues ``find({"namespace": namespace})`` — exactly one round-trip, no
+        per-kind fan-out. Missing namespace (no documents with that
+        ``namespace`` value) returns ``[]`` without raising.
+        """
+        cursor = self._collection.find({"namespace": namespace})
+        return [self._from_document(doc) for doc in cursor]
+
+    def get_by_kind(self, namespace: str, kind: EntryKind) -> Entry | None:
+        """Return a single entry of ``kind`` in ``namespace`` or ``None``.
+
+        Issues ``find_one({"namespace": namespace, "kind": kind},
+        sort=[("_id.id", ASCENDING)])`` so that, in the corruption case where
+        two documents share ``(namespace, kind)`` (which the service-layer
+        singleton invariant forbids but the repository tolerates), the
+        deterministic alphabetically-first result by ``_id.id`` is returned.
+        The repository does NOT raise on duplicates — the singleton invariant
+        is owned by ``Catalog.create`` (Story 15.5).
+        """
+        from pymongo import ASCENDING
+
+        doc = self._collection.find_one(
+            {"namespace": namespace, "kind": kind},
+            sort=[("_id.id", ASCENDING)],
+        )
+        if doc is None:
+            return None
+        return self._from_document(doc)
+
+    def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries in ``namespace`` whose payload references ``target_id``.
+
+        Loads every entry in ``namespace`` via ``list_by_namespace`` (one
+        server-side query), then walks each payload in memory using the
+        ``_payload_has_ref`` helper shared with the YAML backend. No
+        server-side wildcard payload index is used — v2 acceptance
+        (``no wildcard payload index``) — the in-memory walk is cheap at
+        namespace scale and keeps the two backends in lockstep with a single
+        shared walker.
+
+        Namespace isolation is strict: refs in other namespaces are not
+        inspected.
+        """
+        return [
+            entry
+            for entry in self.list_by_namespace(namespace)
+            if _payload_has_ref(entry.payload, target_id)
+        ]

--- a/src/akgentic/catalog/repositories/mongo_entry_repo.py
+++ b/src/akgentic/catalog/repositories/mongo_entry_repo.py
@@ -272,8 +272,12 @@ class MongoEntryRepository:
 
         Each non-``None`` field contributes exactly one clause. ``user_id_set``
         is tri-state (``None`` = ignore, ``True`` = ``user_id != null``,
-        ``False`` = ``user_id is null``). ``description_contains`` uses
-        ``re.escape`` to defuse regex metacharacters in user input.
+        ``False`` = ``user_id is null``). ``user_id`` and ``user_id_set``
+        combine with AND semantics — if both are set, the emitted ``user_id``
+        clause honours both constraints jointly so the Mongo filter matches
+        the YAML backend's ``_matches`` evaluation (conjunctive over both
+        fields). ``description_contains`` uses ``re.escape`` to defuse regex
+        metacharacters in user input.
         """
         mongo_filter: dict[str, Any] = {}
         if query.namespace is not None:
@@ -282,12 +286,7 @@ class MongoEntryRepository:
             mongo_filter["kind"] = query.kind
         if query.id is not None:
             mongo_filter["id"] = query.id
-        if query.user_id is not None:
-            mongo_filter["user_id"] = query.user_id
-        if query.user_id_set is True:
-            mongo_filter["user_id"] = {"$ne": None}
-        elif query.user_id_set is False:
-            mongo_filter["user_id"] = None
+        self._apply_user_id_clauses(query, mongo_filter)
         if query.parent_namespace is not None:
             mongo_filter["parent_namespace"] = query.parent_namespace
         if query.parent_id is not None:
@@ -295,6 +294,44 @@ class MongoEntryRepository:
         if query.description_contains is not None:
             mongo_filter["description"] = {"$regex": re.escape(query.description_contains)}
         return mongo_filter
+
+    def _apply_user_id_clauses(
+        self,
+        query: EntryQuery,
+        mongo_filter: dict[str, Any],
+    ) -> None:
+        """Write a conjunctive ``user_id`` clause into ``mongo_filter``.
+
+        ``user_id`` and ``user_id_set`` are orthogonal knobs that combine
+        with AND semantics (parity with YAML's ``_matches``). Table of
+        behaviours for the four relevant combinations:
+
+        * both unset → no ``user_id`` key is added.
+        * ``user_id`` only → exact match (``{"user_id": value}``).
+        * ``user_id_set`` only → presence filter
+          (``{"$ne": None}`` / ``None``).
+        * both set → the joint constraint: if ``user_id_set=True`` the exact
+          value already guarantees non-``None``, so the exact match is
+          emitted; if ``user_id_set=False`` the combination is logically
+          impossible (a non-``None`` value cannot also be ``None``), so an
+          unsatisfiable clause (``{"$in": []}``) is emitted so the query
+          returns zero documents — which is exactly what the YAML backend
+          returns for the same contradictory pair.
+        """
+        if query.user_id is None and query.user_id_set is None:
+            return
+        if query.user_id_set is None:
+            mongo_filter["user_id"] = query.user_id
+            return
+        if query.user_id is None:
+            mongo_filter["user_id"] = {"$ne": None} if query.user_id_set else None
+            return
+        if query.user_id_set:
+            # Exact value is already non-None; the exact match satisfies both.
+            mongo_filter["user_id"] = query.user_id
+            return
+        # user_id set but user_id_set is False → contradiction; match nothing.
+        mongo_filter["user_id"] = {"$in": []}
 
     def list_by_namespace(self, namespace: str) -> _list[Entry]:
         """Return every entry in ``namespace`` in a single ``find``.

--- a/src/akgentic/catalog/repositories/yaml_entry_repo.py
+++ b/src/akgentic/catalog/repositories/yaml_entry_repo.py
@@ -1,0 +1,409 @@
+"""Filesystem-backed v2 ``EntryRepository`` storing one YAML file per entry.
+
+Layout: ``root/{namespace}/{kind}/{id}.yaml`` — the namespace is the top-level
+directory, the kind is the second segment, and the filename stem is the entry
+id. Each file holds a single YAML document equal to
+``entry.model_dump(mode="json")``. Empty directories are pruned on delete so a
+round-trip ``put``/``delete`` leaves the root clean.
+
+``(namespace, id)`` is the uniqueness key under v2; ``kind`` is metadata. Two
+files with the same stem inside a single namespace — even across different kind
+subdirectories — is a corruption signal the repository surfaces with
+``CatalogValidationError`` on the first read that touches the namespace.
+
+The module name ``yaml_entry_repo`` is temporary: the v1 package
+``repositories/yaml/`` still lives next to this file and a Python
+``repositories/yaml.py`` module would shadow it. Epic 19 Story 19.2 renames
+this module to ``yaml.py`` after v1 deletion.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from pathlib import Path
+
+import yaml
+
+from akgentic.catalog.models.entry import Entry, EntryKind
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.models.queries import EntryQuery
+
+__all__ = ["YamlEntryRepository"]
+
+logger = logging.getLogger(__name__)
+
+_list = builtins.list  # Alias: the repository's list() method shadows the built-in
+
+
+def _payload_has_ref(node: object, target_id: str) -> bool:
+    """Depth-first scan for any ``{"__ref__": target_id}`` marker in ``node``.
+
+    Walks dicts and lists recursively. Only dict keys named ``"__ref__"`` whose
+    value equals ``target_id`` are treated as matches — raw string occurrences
+    of ``"__ref__"`` or ``target_id`` as plain values are not matches. The
+    sentinel key is hard-coded here to avoid importing ``REF_KEY`` from the
+    resolver module (which would otherwise grow into a wider import surface in
+    production code — ``REF_KEY`` is a runtime constant pinned by the resolver
+    contract, not a dependency).
+
+    Args:
+        node: Arbitrary payload subtree (dict, list, or leaf value).
+        target_id: The id to look for.
+
+    Returns:
+        ``True`` if any dict in the tree has ``"__ref__" == target_id``.
+    """
+    if isinstance(node, dict):
+        if node.get("__ref__") == target_id:
+            return True
+        return any(_payload_has_ref(v, target_id) for v in node.values())
+    if isinstance(node, list):
+        return any(_payload_has_ref(v, target_id) for v in node)
+    return False
+
+
+class YamlEntryRepository:
+    """Per-namespace, per-kind, per-file v2 ``EntryRepository`` on the filesystem.
+
+    Satisfies the ``akgentic.catalog.repositories.base.EntryRepository``
+    structural protocol. ``root`` is stored verbatim as a ``Path`` — no
+    directory is created in ``__init__``; the first ``put`` materialises the
+    tree lazily. Reads across a namespace go through ``_scan_namespace`` which
+    validates every file and surfaces duplicate-id corruption.
+
+    The repository is intent-preserving: ``put`` writes
+    ``entry.model_dump(mode="json")`` verbatim, so author-written ref markers
+    (``{"__ref__": ...}``, ``{"__type__": ...}``) round-trip byte-for-byte.
+    The ``Catalog`` service (Story 15.5) runs ``prepare_for_write`` before
+    reaching the repository; this class never re-dumps payload content.
+
+    Caching is namespace-scoped and lazy: the first read for a namespace walks
+    the directory once; subsequent reads return the cached list until a write
+    or ``reload`` invalidates it. ``reload(namespace=None)`` clears the entire
+    cache when no argument is given.
+    """
+
+    def __init__(self, root: Path) -> None:
+        """Store the repository root; do not create it on disk.
+
+        Args:
+            root: Root directory under which per-namespace subtrees live.
+                The directory does NOT have to exist — it is created lazily on
+                the first ``put``.
+        """
+        self._root = root
+        self._cache: dict[str, _list[Entry]] = {}
+
+    # --- Path helpers ---
+
+    def _namespace_dir(self, namespace: str) -> Path:
+        """Return ``root/{namespace}``."""
+        return self._root / namespace
+
+    def _kind_dir(self, namespace: str, kind: EntryKind) -> Path:
+        """Return ``root/{namespace}/{kind}``."""
+        return self._namespace_dir(namespace) / kind
+
+    def _entry_path(self, namespace: str, kind: EntryKind, id: str) -> Path:
+        """Return ``root/{namespace}/{kind}/{id}.yaml``."""
+        return self._kind_dir(namespace, kind) / f"{id}.yaml"
+
+    # --- Write operations ---
+
+    def put(self, entry: Entry) -> Entry:
+        """Insert or replace ``entry`` keyed by ``(namespace, id)``.
+
+        If an existing file for the same ``(namespace, id)`` lives under a
+        different kind directory, it is removed first (and any now-empty kind
+        directory is pruned). The new file is written atomically via
+        ``write_text``. The affected namespace cache entry is invalidated so
+        the next read reflects the write.
+
+        Args:
+            entry: The entry to persist.
+
+        Returns:
+            The stored ``entry`` (unchanged — caller may chain or assert).
+        """
+        self._remove_existing_with_different_kind(entry)
+        path = self._entry_path(entry.namespace, entry.kind, entry.id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = yaml.dump(
+            entry.model_dump(mode="json"),
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        path.write_text(payload, encoding="utf-8")
+        self._invalidate(entry.namespace)
+        return entry
+
+    def _remove_existing_with_different_kind(self, entry: Entry) -> None:
+        """Delete any prior file for ``(namespace, id)`` under another kind dir.
+
+        v2 uniqueness is ``(namespace, id)``; ``kind`` is metadata. When an
+        upsert changes the kind, the old file must be removed so the namespace
+        does not end up with two stems claiming the same id (which
+        ``_scan_namespace`` would surface as duplicate-id corruption).
+        """
+        namespace_dir = self._namespace_dir(entry.namespace)
+        if not namespace_dir.exists():
+            return
+        target_path = self._entry_path(entry.namespace, entry.kind, entry.id)
+        for existing in sorted(namespace_dir.glob(f"*/{entry.id}.yaml")):
+            if existing.resolve() == target_path.resolve():
+                continue
+            existing.unlink()
+            self._prune_empty_parents(existing.parent)
+
+    def delete(self, namespace: str, id: str) -> None:
+        """Remove the entry file and prune empty parent directories.
+
+        Locates the file by scanning every kind directory under
+        ``root/{namespace}/``. If no file is found, the call is a no-op (the
+        service layer's ``validate_delete`` is the authoritative guard against
+        deleting missing entries).
+
+        After unlink, the kind directory is removed if empty; if the namespace
+        directory is then empty, it is removed too. The root itself is never
+        removed.
+
+        Args:
+            namespace: Namespace containing the entry.
+            id: Entry id within ``namespace``.
+        """
+        namespace_dir = self._namespace_dir(namespace)
+        if not namespace_dir.exists():
+            return
+        for candidate in sorted(namespace_dir.glob(f"*/{id}.yaml")):
+            candidate.unlink()
+            self._prune_empty_parents(candidate.parent)
+            self._invalidate(namespace)
+            return
+        # AC12: no match — no-op (no cache invalidation needed either)
+
+    def _prune_empty_parents(self, leaf_dir: Path) -> None:
+        """Walk up from ``leaf_dir`` removing empty directories, stopping at root.
+
+        Uses ``any(path.iterdir())`` for a short-circuit emptiness check.
+        Never removes ``self._root`` itself — the repository may still be
+        written to after a full cleanup.
+        """
+        current = leaf_dir
+        while current != self._root and current.exists() and not any(current.iterdir()):
+            current.rmdir()
+            current = current.parent
+
+    # --- Read operations ---
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        """Return the entry for ``(namespace, id)`` or ``None`` if absent.
+
+        Delegates to ``_scan_namespace`` so the duplicate-id check runs on
+        the first read. If the namespace directory does not exist, returns
+        ``None`` without raising (empty namespace is not a corruption signal).
+        """
+        for entry in self._scan_namespace(namespace):
+            if entry.id == id:
+                return entry
+        return None
+
+    def list(self, query: EntryQuery) -> _list[Entry]:
+        """Return entries matching ``query`` with AND semantics over set fields.
+
+        The scan scope is narrowed from ``query.namespace`` (single namespace
+        subtree) or all namespaces under ``root``. Remaining filters are
+        applied in memory via ``_matches``.
+        """
+        scope = self._resolve_scan_scope(query.namespace)
+        return [entry for entry in scope if self._matches(entry, query)]
+
+    def _resolve_scan_scope(self, namespace: str | None) -> _list[Entry]:
+        """Return the entries the ``list`` filters should run over.
+
+        When ``namespace`` is set, scan only that namespace subtree. Otherwise
+        scan every namespace directory under ``root``.
+        """
+        if namespace is not None:
+            return self._scan_namespace(namespace)
+        if not self._root.exists():
+            return []
+        entries: _list[Entry] = []
+        for namespace_dir in sorted(self._root.iterdir()):
+            if namespace_dir.is_dir():
+                entries.extend(self._scan_namespace(namespace_dir.name))
+        return entries
+
+    def _matches(self, entry: Entry, query: EntryQuery) -> bool:
+        """Return ``True`` if ``entry`` satisfies every set filter in ``query``.
+
+        Each filter is a conjunct: a ``None`` filter is ignored, a set filter
+        must match. ``user_id_set`` is tri-state — ``None`` means "no filter",
+        ``True`` restricts to ``user_id is not None``, ``False`` restricts to
+        ``user_id is None``. ``description_contains`` is a case-sensitive
+        substring check matching v1 semantics.
+        """
+        if query.kind is not None and entry.kind != query.kind:
+            return False
+        if query.id is not None and entry.id != query.id:
+            return False
+        if query.user_id is not None and entry.user_id != query.user_id:
+            return False
+        if query.user_id_set is True and entry.user_id is None:
+            return False
+        if query.user_id_set is False and entry.user_id is not None:
+            return False
+        if query.parent_namespace is not None and entry.parent_namespace != query.parent_namespace:
+            return False
+        if query.parent_id is not None and entry.parent_id != query.parent_id:
+            return False
+        if (
+            query.description_contains is not None
+            and query.description_contains not in entry.description
+        ):
+            return False
+        return True
+
+    def list_by_namespace(self, namespace: str) -> _list[Entry]:
+        """Return every entry in ``namespace`` regardless of kind."""
+        return _list(self._scan_namespace(namespace))
+
+    def get_by_kind(self, namespace: str, kind: EntryKind) -> Entry | None:
+        """Return a single entry of ``kind`` in ``namespace`` or ``None``.
+
+        On multiple matches (the corruption state the service layer polices),
+        returns the alphabetically-first file. The repository does NOT raise —
+        the singleton invariant is a service-level concern (Story 15.5). The
+        cross-kind duplicate-id check still runs via ``_scan_namespace``.
+        """
+        # Trigger the per-namespace duplicate/mismatch checks before scanning
+        # the narrower kind directory — keeps semantics consistent with other
+        # read paths.
+        self._scan_namespace(namespace)
+        kind_dir = self._kind_dir(namespace, kind)
+        if not kind_dir.exists():
+            return None
+        yaml_files = sorted(kind_dir.glob("*.yaml"))
+        if not yaml_files:
+            return None
+        return self._load_entry(yaml_files[0], namespace, kind)
+
+    def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries in ``namespace`` whose payload references ``target_id``."""
+        return [
+            entry
+            for entry in self._scan_namespace(namespace)
+            if _payload_has_ref(entry.payload, target_id)
+        ]
+
+    def reload(self, namespace: str | None = None) -> None:
+        """Invalidate the internal cache.
+
+        Args:
+            namespace: If ``None``, clear the entire cache; otherwise clear
+                only the entry for ``namespace`` (missing key is fine).
+        """
+        if namespace is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(namespace, None)
+
+    def _invalidate(self, namespace: str) -> None:
+        """Drop the cached view for ``namespace`` so the next read re-scans."""
+        self._cache.pop(namespace, None)
+
+    # --- Namespace scan (single source of truth) ---
+
+    def _scan_namespace(self, namespace: str) -> _list[Entry]:
+        """Walk ``root/{namespace}/`` validating every file; cache and return.
+
+        Duplicate-id detection spans kind subdirectories: if two files under
+        different kind dirs share a filename stem, raise
+        ``CatalogValidationError`` (AC17). Per-file namespace/kind/id stem
+        must agree with the containing path segments (AC18). Empty files are
+        skipped with a warning (AC19).
+        """
+        cached = self._cache.get(namespace)
+        if cached is not None:
+            return cached
+
+        namespace_dir = self._namespace_dir(namespace)
+        if not namespace_dir.exists():
+            self._cache[namespace] = []
+            return []
+
+        entries: _list[Entry] = []
+        seen_ids: dict[str, Path] = {}
+        for kind_dir in sorted(namespace_dir.iterdir()):
+            if not kind_dir.is_dir():
+                continue
+            entries.extend(self._scan_kind_dir(kind_dir, namespace, seen_ids))
+
+        self._cache[namespace] = entries
+        return entries
+
+    def _scan_kind_dir(
+        self,
+        kind_dir: Path,
+        namespace: str,
+        seen_ids: dict[str, Path],
+    ) -> _list[Entry]:
+        """Load every YAML file in ``kind_dir``, checking duplicates vs ``seen_ids``.
+
+        The ``kind_dir.name`` is expected to be an ``EntryKind`` literal; if a
+        file's validated ``kind`` disagrees with the directory name, AC18
+        raises through ``_load_entry``.
+        """
+        kind = kind_dir.name
+        entries: _list[Entry] = []
+        for path in sorted(kind_dir.glob("*.yaml")):
+            entry = self._load_entry(path, namespace, kind)
+            if entry is None:
+                continue
+            if entry.id in seen_ids:
+                raise CatalogValidationError(
+                    [f"Duplicate id '{entry.id}' found in '{seen_ids[entry.id]}' and '{path}'"]
+                )
+            seen_ids[entry.id] = path
+            entries.append(entry)
+        return entries
+
+    def _load_entry(self, path: Path, namespace: str, kind: str) -> Entry | None:
+        """Parse ``path`` and validate it against the expected path segments.
+
+        Returns ``None`` for empty YAML (AC19). Raises
+        ``CatalogValidationError`` if the file body's ``namespace``, ``kind``,
+        or ``id`` disagrees with the directory segments or filename stem.
+        Pydantic ``ValidationError`` propagates unchanged — bad YAML is a
+        caller concern, matching v1 behaviour.
+        """
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if raw is None:
+            logger.warning("empty YAML file skipped: %s", path)
+            return None
+        entry = Entry.model_validate(raw)
+        self._check_path_agreement(entry, path, namespace, kind)
+        return entry
+
+    def _check_path_agreement(
+        self,
+        entry: Entry,
+        path: Path,
+        namespace: str,
+        kind: str,
+    ) -> None:
+        """Enforce AC18: file's ``namespace``/``kind``/``id`` must match path segments."""
+        if entry.namespace != namespace:
+            raise CatalogValidationError(
+                [f"File '{path}' has namespace '{entry.namespace}' but lives under '{namespace}'"]
+            )
+        if entry.kind != kind:
+            raise CatalogValidationError(
+                [f"File '{path}' has kind '{entry.kind}' but lives under '{kind}'"]
+            )
+        stem = path.stem
+        if entry.id != stem:
+            raise CatalogValidationError(
+                [f"File '{path}' has id '{entry.id}' but filename stem is '{stem}'"]
+            )

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -1,4 +1,4 @@
-"""Ref-sentinel constants and the allowlist-gated Pydantic-class loader.
+"""Ref-sentinel constants, allowlist loader, and the v2 resolver pipeline.
 
 This module owns the v2 ref-sentinel sentinel keys (``REF_KEY``, ``TYPE_KEY``)
 and the ``load_model_type(path)`` function that imports a Pydantic
@@ -12,22 +12,45 @@ and the ``load_model_type(path)`` function that imports a Pydantic
    ``__type__`` (the reserved keys used by the resolver's sentinel scheme —
    collisions would break round-tripping).
 
-``populate_refs``, ``reconcile_refs``, ``prepare_for_write``,
-``validate_delete``, and ``resolve`` are deliberately NOT defined here — they
-land in Story 15.2.
+It also exposes the v2 resolver pipeline built on top of those primitives:
+
+* :func:`populate_refs` — recursive ref replacement with cycle, missing-target,
+  and ``__type__`` mismatch detection; namespace-bounded.
+* :func:`reconcile_refs` — walks input + dumped trees in lockstep to preserve
+  author-written ref markers against a Pydantic-dumped payload.
+* :func:`resolve` — full hydration of an ``Entry`` into a runtime ``BaseModel``.
+* :func:`prepare_for_write` — five-step write pipeline producing the
+  intent-preserving, ref-preserving stored payload.
+* :func:`validate_delete` — inbound-ref guard that returns a list of
+  human-readable blocker messages (empty list = safe to delete).
+
+``check_ownership`` is deliberately NOT part of this module — Story 15.5 is the
+right place to decide whether ownership enforcement lives inside
+``prepare_for_write`` or inside the ``Catalog`` service itself.
 """
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Any, Final
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from akgentic.core.utils.deserializer import import_class
 
+from .models.entry import Entry
 from .models.errors import CatalogValidationError
+from .repositories.base import EntryRepository
 
-__all__ = ["REF_KEY", "TYPE_KEY", "load_model_type"]
+__all__ = [
+    "REF_KEY",
+    "TYPE_KEY",
+    "load_model_type",
+    "populate_refs",
+    "prepare_for_write",
+    "reconcile_refs",
+    "resolve",
+    "validate_delete",
+]
 
 
 REF_KEY: Final[str] = "__ref__"
@@ -90,3 +113,266 @@ def load_model_type(path: str) -> type[BaseModel]:
         )
 
     return cls
+
+
+def populate_refs(
+    node: Any,
+    repository: EntryRepository,
+    namespace: str,
+    _visiting: set[tuple[str, str]] | None = None,
+) -> Any:
+    """Recursively replace ref markers in ``node`` with their resolved payloads.
+
+    Walks the payload tree. A dict with a ``REF_KEY`` (``"__ref__"``) entry is
+    treated as a ref marker and replaced by the target entry's payload; ordinary
+    dicts and lists recurse structurally; every other value is returned
+    unchanged. The ``namespace`` is forwarded as-is to every recursive call —
+    cross-namespace resolution is structurally impossible at runtime.
+
+    Args:
+        node: Arbitrary payload subtree (dict, list, or leaf value).
+        repository: Entry repository used to resolve refs in ``namespace``.
+        namespace: The namespace used for every repository lookup in this call.
+        _visiting: Internal cycle-detection set of ``(namespace, target_id)``
+            pairs already traversed on the current ref chain. Callers pass
+            ``None`` (the default); the function builds a fresh set per call.
+
+    Returns:
+        A new payload subtree with every ref marker replaced by its resolved
+        target. Dict and list inputs are never mutated — fresh containers are
+        built for every recursion.
+
+    Raises:
+        CatalogValidationError: If a ref cycle is detected, the target id is
+            absent from ``repository``, or a ``TYPE_KEY`` hint does not match
+            the target entry's ``model_type``. The error carries a
+            single-element ``errors`` list with substring-stable messages
+            (``"cycle"``, ``"not found"``, or ``"expected X"`` + ``"got Y"``).
+    """
+    visiting: set[tuple[str, str]] = set() if _visiting is None else _visiting
+
+    if isinstance(node, dict):
+        if REF_KEY in node:
+            return _populate_ref_marker(node, repository, namespace, visiting)
+        return {k: populate_refs(v, repository, namespace, visiting) for k, v in node.items()}
+
+    if isinstance(node, list):
+        return [populate_refs(v, repository, namespace, visiting) for v in node]
+
+    return node
+
+
+def _populate_ref_marker(
+    node: dict[str, Any],
+    repository: EntryRepository,
+    namespace: str,
+    visiting: set[tuple[str, str]],
+) -> Any:
+    """Resolve a single ref-marker dict into the recursively-populated target.
+
+    Three checks run in order — cycle, missing target, ``__type__`` mismatch.
+    Cycle comes first to avoid a redundant repository lookup when we already
+    know we are looping; missing-target comes second because the ``__type__``
+    check needs the fetched target in hand. Every failure raises
+    ``CatalogValidationError`` with substring-stable messages per AC8-AC10.
+    """
+    target_id = node[REF_KEY]
+    expected = node.get(TYPE_KEY)
+    key = (namespace, target_id)
+
+    if key in visiting:
+        raise CatalogValidationError([f"Reference cycle detected at ({namespace}, {target_id})"])
+
+    target = repository.get(namespace, target_id)
+    if target is None:
+        raise CatalogValidationError([f"Ref '{target_id}' not found in namespace '{namespace}'"])
+
+    if expected is not None and target.model_type != expected:
+        raise CatalogValidationError(
+            [f"Ref '{target_id}' expected {expected}, got {target.model_type}"]
+        )
+
+    return populate_refs(target.payload, repository, namespace, visiting | {key})
+
+
+def resolve(entry: Entry, repository: EntryRepository) -> BaseModel:
+    """Hydrate ``entry`` into an instance of its declared runtime Pydantic class.
+
+    Composition: ``cls = load_model_type(entry.model_type)``; ``populated =
+    populate_refs(entry.payload, repository, entry.namespace)``; finally
+    ``cls.model_validate(populated)``. Errors from ``load_model_type`` and
+    ``populate_refs`` propagate unchanged (per AC14/AC15). Only the
+    Pydantic ``ValidationError`` from ``model_validate`` is converted to
+    ``CatalogValidationError``, preserving the original traceback via
+    ``raise ... from e`` (AC16).
+
+    Args:
+        entry: The catalog entry to hydrate.
+        repository: Entry repository used to resolve refs in ``entry.namespace``.
+
+    Returns:
+        A runtime instance of the class named by ``entry.model_type``.
+
+    Raises:
+        CatalogValidationError: From ``load_model_type`` (allowlist, BaseModel,
+            reserved-key checks), from ``populate_refs`` (cycle, missing, type
+            mismatch), or wrapping a ``pydantic.ValidationError`` from
+            ``model_validate`` with the substring ``"Payload does not validate
+            against"`` followed by the ``model_type`` string.
+    """
+    cls = load_model_type(entry.model_type)
+    populated = populate_refs(entry.payload, repository, entry.namespace)
+    try:
+        return cls.model_validate(populated)
+    except ValidationError as e:
+        raise CatalogValidationError(
+            [f"Payload does not validate against {entry.model_type}: {e}"]
+        ) from e
+
+
+def reconcile_refs(input_node: Any, dumped_node: Any) -> Any:
+    """Restore ref markers from ``input_node`` against a dumped Pydantic tree.
+
+    The dumped tree (from ``obj.model_dump(mode='python', exclude_unset=True)``)
+    is the authority for every non-ref field — it carries validator-normalised
+    values. Author-written ref markers in ``input_node`` must win verbatim so
+    that the stored payload round-trips back to itself when re-resolved.
+
+    Args:
+        input_node: The original payload subtree the author wrote (may carry
+            ``REF_KEY`` markers).
+        dumped_node: The corresponding subtree from ``model_dump``.
+
+    Returns:
+        A reconciled subtree: ref markers preserved verbatim from ``input_node``,
+        non-ref dict keys recursed pairwise, list elements zipped pairwise with
+        strict length, and leaves taken from ``dumped_node``. Neither input
+        tree is mutated.
+
+    Raises:
+        ValueError: If ``input_node`` and ``dumped_node`` are both lists but of
+            mismatched lengths (``zip(..., strict=True)`` raises).
+    """
+    if isinstance(input_node, dict):
+        if REF_KEY in input_node:
+            return input_node
+        return _reconcile_dict(input_node, dumped_node)
+
+    if isinstance(input_node, list) and isinstance(dumped_node, list):
+        return [reconcile_refs(i, d) for i, d in zip(input_node, dumped_node, strict=True)]
+
+    return dumped_node
+
+
+def _reconcile_dict(input_node: dict[str, Any], dumped_node: Any) -> dict[str, Any]:
+    """Reconcile a non-ref input dict against the dumped counterpart.
+
+    Iterates input keys in order. For each key: if it is present in
+    ``dumped_node``, recurse pairwise; otherwise, if the input value is itself
+    a ref-marker dict, preserve it verbatim (the "unset-but-refed" branch from
+    AC19); otherwise drop the key (the dumped tree is authoritative for
+    absent non-ref fields).
+    """
+    dumped_dict = dumped_node if isinstance(dumped_node, dict) else {}
+    result: dict[str, Any] = {}
+    for key, value in input_node.items():
+        if key in dumped_dict:
+            result[key] = reconcile_refs(value, dumped_dict[key])
+        elif isinstance(value, dict) and REF_KEY in value:
+            result[key] = value
+    return result
+
+
+def prepare_for_write(entry: Entry, repository: EntryRepository) -> Entry:
+    """Run the five-step write pipeline and return a ref-preserving ``Entry``.
+
+    Pipeline (each step's failure short-circuits the remainder, raising
+    ``CatalogValidationError`` before the next step runs):
+
+    1. ``resolved = populate_refs(entry.payload, repo, entry.namespace)``
+       — surfaces missing target, ``__type__`` mismatch, and cycle errors.
+    2. ``cls = load_model_type(entry.model_type)``
+       — surfaces allowlist / reserved-key / non-BaseModel errors.
+    3. ``obj = cls.model_validate(resolved)``
+       — ``ValidationError`` is converted to ``CatalogValidationError`` with
+       the substring ``"Payload does not validate against"`` and the
+       ``model_type`` string, chained via ``from e``.
+    4. ``dumped = obj.model_dump(mode="python", exclude_unset=True)``
+       — intent-preserving dump.
+    5. ``stored = reconcile_refs(entry.payload, dumped)``
+       — restore the author's ref markers on top of the dumped tree.
+
+    The returned ``Entry`` is ``entry.model_copy(update={"payload": stored})``
+    — a shallow copy; the input ``entry`` is not mutated.
+
+    Ownership enforcement (team-entry existence + ``user_id`` match) is
+    currently the ``Catalog`` service's responsibility and will remain outside
+    this function until Story 15.5 finalises the placement.
+
+    Args:
+        entry: Candidate entry to persist.
+        repository: Entry repository for ref resolution in ``entry.namespace``.
+
+    Returns:
+        A new ``Entry`` with the reconciled, intent-preserving payload.
+
+    Raises:
+        CatalogValidationError: From any pipeline step that fails.
+    """
+    resolved = populate_refs(entry.payload, repository, entry.namespace)
+    cls = load_model_type(entry.model_type)
+    obj = _validate_payload(cls, resolved, entry.model_type)
+    dumped = obj.model_dump(mode="python", exclude_unset=True)
+    stored = reconcile_refs(entry.payload, dumped)
+    return entry.model_copy(update={"payload": stored})
+
+
+def _validate_payload(cls: type[BaseModel], resolved: Any, model_type: str) -> BaseModel:
+    """Run ``cls.model_validate`` and convert Pydantic errors to catalog errors.
+
+    Extracted so ``prepare_for_write`` stays short; the substring
+    ``"Payload does not validate against"`` and the ``model_type`` string are
+    pinned by AC23 step 3 and AC16.
+    """
+    try:
+        return cls.model_validate(resolved)
+    except ValidationError as e:
+        raise CatalogValidationError(
+            [f"Payload does not validate against {model_type}: {e}"]
+        ) from e
+
+
+def validate_delete(namespace: str, id: str, repository: EntryRepository) -> list[str]:
+    """Return blocker messages for deleting ``(namespace, id)``; empty means safe.
+
+    Two-phase check:
+
+    1. If ``repository.get(namespace, id)`` returns ``None``, the target does
+       not exist — surface a single-element list containing ``"not found"``
+       and the offending ``(namespace, id)`` pair.
+    2. Otherwise, call ``repository.find_references(namespace, id)`` and build
+       one blocker message per inbound referrer, preserving repository order.
+
+    No branching on ``user_id``, ``parent_namespace``, or ``kind`` — the rule
+    is uniform across enterprise and user namespaces per ADR-007/ADR-008:
+    any inbound ref within the passed namespace blocks the delete, and
+    cross-namespace lineage is never policed by ``validate_delete``.
+
+    Args:
+        namespace: Namespace of the entry to delete.
+        id: Id of the entry to delete within ``namespace``.
+        repository: Entry repository providing ``get`` and ``find_references``.
+
+    Returns:
+        A list of human-readable blocker messages. An empty list is the
+        "safe to delete" signal.
+    """
+    target = repository.get(namespace, id)
+    if target is None:
+        return [f"Entry ({namespace}, {id}) not found"]
+
+    referrers = repository.find_references(namespace, id)
+    return [
+        f"Entry '{r.id}' (kind={r.kind}) in namespace '{namespace}' references '{id}'"
+        for r in referrers
+    ]

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -1,0 +1,92 @@
+"""Ref-sentinel constants and the allowlist-gated Pydantic-class loader.
+
+This module owns the v2 ref-sentinel sentinel keys (``REF_KEY``, ``TYPE_KEY``)
+and the ``load_model_type(path)`` function that imports a Pydantic
+``BaseModel`` class by dotted path, gated behind three defensive checks:
+
+1. The path must start with one of ``_ALLOWED_PREFIXES`` (storage + runtime
+   defence in depth — ``models.entry.AllowlistedPath`` enforces the same
+   prefix at Pydantic construction time).
+2. The resolved class must be a subclass of ``pydantic.BaseModel``.
+3. The resolved class must not declare Pydantic fields named ``__ref__`` or
+   ``__type__`` (the reserved keys used by the resolver's sentinel scheme —
+   collisions would break round-tripping).
+
+``populate_refs``, ``reconcile_refs``, ``prepare_for_write``,
+``validate_delete``, and ``resolve`` are deliberately NOT defined here — they
+land in Story 15.2.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from pydantic import BaseModel
+
+from akgentic.core.utils.deserializer import import_class
+
+from .models.errors import CatalogValidationError
+
+__all__ = ["REF_KEY", "TYPE_KEY", "load_model_type"]
+
+
+REF_KEY: Final[str] = "__ref__"
+"""Sentinel dict key marking a ref placeholder inside a resolved payload.
+
+A payload dict containing ``REF_KEY`` has been populated by the resolver and
+must be hydrated (looked up in the repository) before use at runtime.
+"""
+
+TYPE_KEY: Final[str] = "__type__"
+"""Sentinel dict key carrying the FQCN of a referenced entry's model type.
+
+Emitted next to ``REF_KEY`` so the resolver can validate the target's type
+without loading the target entry eagerly.
+"""
+
+# Runtime allowlist for ``load_model_type``. Duplicated intentionally in
+# ``models.entry`` for the annotation-layer defence — two layers, two
+# policies that only happen to agree today. See Story 15.1 Dev Notes.
+_ALLOWED_PREFIXES: tuple[str, ...] = ("akgentic.",)
+
+_RESERVED_KEYS: frozenset[str] = frozenset({REF_KEY, TYPE_KEY})
+
+
+def load_model_type(path: str) -> type[BaseModel]:
+    """Import and return a Pydantic ``BaseModel`` class by dotted path.
+
+    Three checks run in order:
+
+    1. ``path`` must start with one of ``_ALLOWED_PREFIXES``.
+    2. The resolved object must be a subclass of ``pydantic.BaseModel``.
+    3. The resolved class must not declare Pydantic fields named ``__ref__``
+       or ``__type__``.
+
+    Args:
+        path: Dotted class path (e.g. ``"akgentic.core.agent_card.AgentCard"``).
+
+    Returns:
+        The imported class.
+
+    Raises:
+        CatalogValidationError: If any of the three checks fails. The error
+            carries a single-element ``errors`` list with a substring-stable
+            message (``"outside allowlist"``, ``"is not a Pydantic BaseModel
+            subclass"``, or ``"reserved ref-sentinel fields"``) so callers
+            can assert on behaviour without loading the exception chain.
+    """
+    if not any(path.startswith(prefix) for prefix in _ALLOWED_PREFIXES):
+        raise CatalogValidationError([f"model_type '{path}' outside allowlist {_ALLOWED_PREFIXES}"])
+
+    cls = import_class(path)
+
+    if not (isinstance(cls, type) and issubclass(cls, BaseModel)):
+        raise CatalogValidationError([f"model_type '{path}' is not a Pydantic BaseModel subclass"])
+
+    collisions = sorted(_RESERVED_KEYS & set(cls.model_fields.keys()))
+    if collisions:
+        raise CatalogValidationError(
+            [f"model_type '{path}' declares reserved ref-sentinel fields: {collisions}"]
+        )
+
+    return cls

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog v2 test package — lives alongside v1 test modules during coexistence."""

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -16,12 +16,19 @@ from __future__ import annotations
 
 import sys
 import types
+from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from akgentic.catalog.catalog import Catalog
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.base import EntryRepository
+from akgentic.catalog.repositories.yaml_entry_repo import (
+    YamlEntryRepository,
+)
 from akgentic.catalog.repositories.yaml_entry_repo import (
     _payload_has_ref as _payload_has_ref,
 )
@@ -116,8 +123,31 @@ class FakeEntryRepository:
     def delete(self, namespace: str, id: str) -> None:
         self._store.pop((namespace, id), None)
 
-    def list(self, query: EntryQuery) -> list[Entry]:  # noqa: ARG002 — not needed for 15.2
-        raise NotImplementedError("FakeEntryRepository.list is not required for Story 15.2")
+    def list(self, query: EntryQuery) -> list[Entry]:
+        # Story 15.5 needs a minimal implementation so the Catalog service's
+        # list() pass-through can be counted. Applies AND semantics over the
+        # EntryQuery fields used by current tests; ignores filters not yet
+        # exercised to keep the fake honest about its minimality.
+        out: list[Entry] = list(self._store.values())
+        if query.namespace is not None:
+            out = [e for e in out if e.namespace == query.namespace]
+        if query.kind is not None:
+            out = [e for e in out if e.kind == query.kind]
+        if query.id is not None:
+            out = [e for e in out if e.id == query.id]
+        if query.user_id is not None:
+            out = [e for e in out if e.user_id == query.user_id]
+        if query.user_id_set is True:
+            out = [e for e in out if e.user_id is not None]
+        elif query.user_id_set is False:
+            out = [e for e in out if e.user_id is None]
+        if query.parent_namespace is not None:
+            out = [e for e in out if e.parent_namespace == query.parent_namespace]
+        if query.parent_id is not None:
+            out = [e for e in out if e.parent_id == query.parent_id]
+        if query.description_contains is not None:
+            out = [e for e in out if query.description_contains in e.description]
+        return out
 
     def list_by_namespace(self, namespace: str) -> list[Entry]:
         return [e for (ns, _), e in self._store.items() if ns == namespace]
@@ -134,3 +164,115 @@ class FakeEntryRepository:
             if ns == namespace and _payload_has_ref(e.payload, target_id):
                 out.append(e)
         return out
+
+
+class CountingEntryRepository:
+    """Decorator repository recording every method invocation.
+
+    Wraps any ``EntryRepository`` (in practice a ``FakeEntryRepository`` or one
+    of the production backends) and records each call into a public ``calls``
+    list as ``(method_name, args, kwargs)`` tuples. Tests use this to assert
+    "repository method X was called exactly once with arg Y" without touching
+    the production repositories.
+
+    The inner repository is accessible via ``inner`` for tests that need to
+    seed state directly without polluting the call log. Call ``reset()`` to
+    clear the recorded history (e.g. after seeding).
+    """
+
+    def __init__(self, inner: EntryRepository) -> None:
+        self.inner: EntryRepository = inner
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def reset(self) -> None:
+        """Clear the recorded call log."""
+        self.calls = []
+
+    def _record(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+        self.calls.append((name, args, kwargs))
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        self._record("get", (namespace, id), {})
+        return self.inner.get(namespace, id)
+
+    def put(self, entry: Entry) -> Entry:
+        self._record("put", (entry,), {})
+        return self.inner.put(entry)
+
+    def delete(self, namespace: str, id: str) -> None:
+        self._record("delete", (namespace, id), {})
+        self.inner.delete(namespace, id)
+
+    def list(self, query: EntryQuery) -> list[Entry]:
+        self._record("list", (query,), {})
+        return self.inner.list(query)
+
+    def list_by_namespace(self, namespace: str) -> list[Entry]:
+        self._record("list_by_namespace", (namespace,), {})
+        return self.inner.list_by_namespace(namespace)
+
+    def get_by_kind(self, namespace: str, kind: EntryKind) -> Entry | None:
+        self._record("get_by_kind", (namespace, kind), {})
+        return self.inner.get_by_kind(namespace, kind)
+
+    def find_references(self, namespace: str, target_id: str) -> list[Entry]:
+        self._record("find_references", (namespace, target_id), {})
+        return self.inner.find_references(namespace, target_id)
+
+    def count(self, method_name: str) -> int:
+        """Return the number of recorded calls to ``method_name``."""
+        return sum(1 for name, _, _ in self.calls if name == method_name)
+
+
+CatalogFactory = Callable[[], tuple[Catalog, EntryRepository]]
+
+
+@pytest.fixture(params=["yaml", "mongo"], ids=["yaml", "mongo"])
+def catalog_factory(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+) -> CatalogFactory:
+    """Yield a factory producing ``(Catalog, repository)`` for both backends.
+
+    Parametrised with ids ``yaml`` and ``mongo`` so pytest reports make the
+    backend obvious. Every catalog-service behavioural test runs against both
+    backends. The factory shape (callable rather than direct tuple) lets
+    individual tests build multiple repositories if they ever need to (e.g. a
+    src vs dst backend — though the current story does not need this).
+    """
+
+    def _make() -> tuple[Catalog, EntryRepository]:
+        repo: EntryRepository
+        if request.param == "yaml":
+            repo = YamlEntryRepository(tmp_path)
+        elif request.param == "mongo":
+            pytest.importorskip("pymongo")
+            from akgentic.catalog.repositories.mongo_entry_repo import (
+                MongoEntryRepository,
+            )
+
+            repo = MongoEntryRepository(entries_collection)
+        else:  # pragma: no cover — guarded by pytest.fixture params
+            raise AssertionError(f"Unexpected backend param: {request.param}")
+        return Catalog(repo), repo
+
+    return _make
+
+
+@pytest.fixture
+def counting_catalog() -> tuple[Catalog, CountingEntryRepository]:
+    """Build a ``Catalog`` backed by a ``CountingEntryRepository`` around a Fake.
+
+    Backend-agnostic — used by tests that need to assert on repository call
+    counts (AC5 pass-throughs, AC33 load_team single-query, AC41 clone
+    atomicity). Returns ``(Catalog, CountingEntryRepository)`` so tests can
+    reach into ``.calls`` directly.
+    """
+    fake = FakeEntryRepository()
+    # FakeEntryRepository.list raises NotImplementedError by design; extend it
+    # here for the counting double by delegating to list_by_namespace when a
+    # namespace filter is set. Tests that use counting_catalog only exercise
+    # methods Fake actually supports, so we do not wire list semantics.
+    counting = CountingEntryRepository(fake)
+    return Catalog(counting), counting

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -1,0 +1,65 @@
+"""Shared fixtures and factories for the v2 test suite.
+
+Factory functions are plain helpers (not pytest fixtures) per the project
+convention for stateless constructions. The one fixture-like helper
+(``register_akgentic_test_module``) is a plain function that accepts a
+``monkeypatch`` argument so test cleanup is handled by pytest's built-in
+fixture teardown without additional bookkeeping in the test body.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from akgentic.catalog.models.entry import Entry
+
+
+def make_entry(**overrides: Any) -> Entry:
+    """Build a minimal valid ``Entry`` with sensible defaults, overridable by kwargs.
+
+    Defaults model a fresh, global (no user_id), freshly minted (no lineage)
+    entry of kind ``tool`` pointing at a known-valid ``akgentic.*`` class.
+    Tests pass keyword overrides for the attribute under test.
+    """
+    base: dict[str, Any] = {
+        "id": "entry-1",
+        "kind": "tool",
+        "namespace": "ns-1",
+        "model_type": "akgentic.core.agent_card.AgentCard",
+        "description": "",
+        "payload": {},
+    }
+    base.update(overrides)
+    return Entry(**base)
+
+
+def register_akgentic_test_module(
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str,
+    **attributes: Any,
+) -> str:
+    """Register a throwaway module under ``sys.modules["akgentic.<suffix>"]``.
+
+    Builds a ``types.ModuleType`` carrying every attribute passed as a kwarg,
+    then installs it via ``monkeypatch.setitem`` so pytest's fixture teardown
+    un-registers it after the test finishes.
+
+    Args:
+        monkeypatch: Pytest's ``monkeypatch`` fixture.
+        suffix: The portion after ``"akgentic."`` used as the module name.
+        **attributes: Names to attach to the module (classes, functions, …).
+
+    Returns:
+        The fully-qualified module name (``"akgentic.<suffix>"``) so tests can
+        build class paths off it.
+    """
+    module_name = f"akgentic.{suffix}"
+    module = types.ModuleType(module_name)
+    for name, value in attributes.items():
+        setattr(module, name, value)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    return module_name

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -5,6 +5,11 @@ convention for stateless constructions. The one fixture-like helper
 (``register_akgentic_test_module``) is a plain function that accepts a
 ``monkeypatch`` argument so test cleanup is handled by pytest's built-in
 fixture teardown without additional bookkeeping in the test body.
+
+The ``FakeEntryRepository`` class is a stateful, in-memory
+``EntryRepository`` implementation used exclusively by Story 15.2 resolver
+tests. It is a testing utility — concrete production repositories ship in
+Stories 15.3 (YAML) and 15.4 (Mongo).
 """
 
 from __future__ import annotations
@@ -15,7 +20,8 @@ from typing import Any
 
 import pytest
 
-from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.entry import Entry, EntryKind
+from akgentic.catalog.models.queries import EntryQuery
 
 
 def make_entry(**overrides: Any) -> Entry:
@@ -63,3 +69,58 @@ def register_akgentic_test_module(
         setattr(module, name, value)
     monkeypatch.setitem(sys.modules, module_name, module)
     return module_name
+
+
+class FakeEntryRepository:
+    """In-memory ``EntryRepository`` for resolver + write-pipeline tests.
+
+    Stateful by design — each test that mutates the store instantiates its
+    own ``FakeEntryRepository()``. Satisfies the ``EntryRepository``
+    structural protocol for every method the Story 15.2 resolver pipeline
+    touches (``get``, ``put``, ``delete``, ``list_by_namespace``,
+    ``get_by_kind``, ``find_references``). ``list`` raises
+    ``NotImplementedError`` — no 15.2 code path consumes it.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], Entry] = {}
+
+    def get(self, namespace: str, id: str) -> Entry | None:
+        return self._store.get((namespace, id))
+
+    def put(self, entry: Entry) -> Entry:
+        self._store[(entry.namespace, entry.id)] = entry
+        return entry
+
+    def delete(self, namespace: str, id: str) -> None:
+        self._store.pop((namespace, id), None)
+
+    def list(self, query: EntryQuery) -> list[Entry]:  # noqa: ARG002 — not needed for 15.2
+        raise NotImplementedError("FakeEntryRepository.list is not required for Story 15.2")
+
+    def list_by_namespace(self, namespace: str) -> list[Entry]:
+        return [e for (ns, _), e in self._store.items() if ns == namespace]
+
+    def get_by_kind(self, namespace: str, kind: EntryKind) -> Entry | None:
+        for (ns, _), e in self._store.items():
+            if ns == namespace and e.kind == kind:
+                return e
+        return None
+
+    def find_references(self, namespace: str, target_id: str) -> list[Entry]:
+        out: list[Entry] = []
+        for (ns, _), e in self._store.items():
+            if ns == namespace and _payload_has_ref(e.payload, target_id):
+                out.append(e)
+        return out
+
+
+def _payload_has_ref(node: object, target_id: str) -> bool:
+    """Depth-first scan for any ``{"__ref__": target_id}`` marker in ``node``."""
+    if isinstance(node, dict):
+        if node.get("__ref__") == target_id:
+            return True
+        return any(_payload_has_ref(v, target_id) for v in node.values())
+    if isinstance(node, list):
+        return any(_payload_has_ref(v, target_id) for v in node)
+    return False

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -22,6 +22,9 @@ import pytest
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.yaml_entry_repo import (
+    _payload_has_ref as _payload_has_ref,
+)
 
 
 def make_entry(**overrides: Any) -> Entry:
@@ -113,14 +116,3 @@ class FakeEntryRepository:
             if ns == namespace and _payload_has_ref(e.payload, target_id):
                 out.append(e)
         return out
-
-
-def _payload_has_ref(node: object, target_id: str) -> bool:
-    """Depth-first scan for any ``{"__ref__": target_id}`` marker in ``node``."""
-    if isinstance(node, dict):
-        if node.get("__ref__") == target_id:
-            return True
-        return any(_payload_has_ref(v, target_id) for v in node.values())
-    if isinstance(node, list):
-        return any(_payload_has_ref(v, target_id) for v in node)
-    return False

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -25,6 +25,9 @@ from akgentic.catalog.models.queries import EntryQuery
 from akgentic.catalog.repositories.yaml_entry_repo import (
     _payload_has_ref as _payload_has_ref,
 )
+
+if TYPE_CHECKING:
+    import pymongo.collection
 
 
 def make_entry(**overrides: Any) -> Entry:
@@ -72,6 +75,21 @@ def register_akgentic_test_module(
         setattr(module, name, value)
     monkeypatch.setitem(sys.modules, module_name, module)
     return module_name
+
+
+@pytest.fixture
+def entries_collection() -> pymongo.collection.Collection:  # type: ignore[type-arg]
+    """Provide a fresh mongomock-backed ``catalog_entries`` collection per test.
+
+    Builds an in-memory ``mongomock.MongoClient`` on demand so tests that do
+    not touch Mongo pay no import cost. Each test gets an isolated collection
+    — no cross-test state. ``pymongo`` is an optional dep per the package
+    ``pyproject.toml``; ``mongomock`` ships under the ``dev`` extra.
+    """
+    import mongomock
+
+    client = mongomock.MongoClient()
+    return client["test_catalog"]["catalog_entries"]
 
 
 class FakeEntryRepository:

--- a/tests/v2/test_catalog_clone.py
+++ b/tests/v2/test_catalog_clone.py
@@ -1,0 +1,441 @@
+"""Tests for ``Catalog.clone`` — Story 15.5 ACs 21–30, 37, 38, 41.
+
+Clone is a structural deep-copy with ref rewriting and intra-call dedup. All
+tests run against both backends via ``catalog_factory``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+from .conftest import (
+    CatalogFactory,
+    CountingEntryRepository,
+    FakeEntryRepository,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+def _team_payload(manager_ref: bool = False, assistant_ref: bool = False) -> dict[str, Any]:
+    """Minimal valid ``TeamCard`` payload, optionally carrying refs in metadata slots."""
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+class _LeafModel(BaseModel):
+    provider: str = "openai"
+
+
+class _SubModel(BaseModel):
+    model_cfg: _LeafModel | None = None
+
+
+class _RootModel(BaseModel):
+    """Payload model carrying up to two ref slots — used to construct clone test graphs."""
+
+    manager: _SubModel | None = None
+    assistant: _SubModel | None = None
+    name: str = "root"
+
+
+def _register_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str, str]:
+    """Register leaf/sub/root under a fake ``akgentic.*`` path; return the three FQCNs."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_15_5_clone_models",
+        _LeafModel=_LeafModel,
+        _SubModel=_SubModel,
+        _RootModel=_RootModel,
+    )
+    return (
+        f"{module_name}._LeafModel",
+        f"{module_name}._SubModel",
+        f"{module_name}._RootModel",
+    )
+
+
+def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = None) -> None:
+    """Seed a minimal team entry to satisfy the bootstrap invariant."""
+    catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+def _seed_three_level_graph(
+    catalog: Catalog,
+    namespace: str,
+    leaf_type: str,
+    sub_type: str,
+    root_type: str,
+    user_id: str | None = None,
+) -> None:
+    """Seed a 3-level ref graph: root→id_mgr→id_gpt_41 (leaf)."""
+    _seed_team(catalog, namespace=namespace, user_id=user_id)
+    catalog.create(
+        Entry(
+            id="id_gpt_41",
+            kind="model",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=leaf_type,
+            payload={"provider": "openai"},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="id_mgr",
+            kind="agent",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=sub_type,
+            payload={"model_cfg": {"__ref__": "id_gpt_41"}},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="root",
+            kind="agent",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=root_type,
+            payload={"manager": {"__ref__": "id_mgr"}, "name": "root"},
+        )
+    )
+
+
+class TestCloneIdPolicy:
+    """AC21 — cross-ns preserves id; AC22 — same-ns suffixes (handling taken suffixes)."""
+
+    def test_cross_namespace_preserves_id(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+        stored = catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        assert stored.id == "root"
+        assert stored.namespace == "dst-ns"
+        assert stored.user_id == "alice"
+        assert stored.parent_namespace == "src-ns"
+        assert stored.parent_id == "root"
+
+    def test_same_namespace_suffixes_id(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "ns-1", leaf, sub, root, user_id="alice")
+        stored = catalog.clone(
+            src_namespace="ns-1",
+            src_id="root",
+            dst_namespace="ns-1",
+            dst_user_id="alice",
+        )
+        assert stored.id == "root-2"
+
+    def test_same_namespace_skips_taken_suffix(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "ns-2", leaf, sub, root, user_id="alice")
+        first = catalog.clone(
+            src_namespace="ns-2",
+            src_id="root",
+            dst_namespace="ns-2",
+            dst_user_id="alice",
+        )
+        assert first.id == "root-2"
+        second = catalog.clone(
+            src_namespace="ns-2",
+            src_id="root",
+            dst_namespace="ns-2",
+            dst_user_id="alice",
+        )
+        assert second.id == "root-3"
+
+
+class TestCloneDeepCopy:
+    """AC23 — three-level ref graph produces three cloned entries with rewired refs."""
+
+    def test_three_level_clone(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, repo = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        dst_entries = {e.id: e for e in repo.list_by_namespace("dst-ns")}
+        # team + 3 cloned = 4 entries in dst-ns.
+        assert set(dst_entries) == {"team", "root", "id_mgr", "id_gpt_41"}
+        # Ref markers rewired to point at newly-minted dst ids (same names here).
+        assert dst_entries["root"].payload["manager"] == {"__ref__": "id_mgr"}
+        assert dst_entries["id_mgr"].payload["model_cfg"] == {"__ref__": "id_gpt_41"}
+
+
+class TestCloneDedup:
+    """AC24 — shared sub-entries are cloned once (intra-call dedup map)."""
+
+    def test_shared_leaf_cloned_once(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, repo = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_team(catalog, namespace="src-ns", user_id=None)
+        catalog.create(
+            Entry(
+                id="id_gpt_41",
+                kind="model",
+                namespace="src-ns",
+                model_type=leaf,
+                payload={"provider": "openai"},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="id_mgr",
+                kind="agent",
+                namespace="src-ns",
+                model_type=sub,
+                payload={"model_cfg": {"__ref__": "id_gpt_41"}},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="id_asst",
+                kind="agent",
+                namespace="src-ns",
+                model_type=sub,
+                payload={"model_cfg": {"__ref__": "id_gpt_41"}},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="root",
+                kind="agent",
+                namespace="src-ns",
+                model_type=root,
+                payload={
+                    "manager": {"__ref__": "id_mgr"},
+                    "assistant": {"__ref__": "id_asst"},
+                },
+            )
+        )
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        dst_entries = {e.id for e in repo.list_by_namespace("dst-ns")}
+        # team + root + id_mgr + id_asst + id_gpt_41 = 5; but without team it's 4 clones.
+        assert dst_entries == {"team", "root", "id_mgr", "id_asst", "id_gpt_41"}
+
+
+class TestCloneLineage:
+    """AC25 — top-level entry carries parent_*; sub-entries do not."""
+
+    def test_root_only_lineage(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, repo = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        top = repo.get("dst-ns", "root")
+        assert top is not None
+        assert top.parent_namespace == "src-ns"
+        assert top.parent_id == "root"
+        for sub_id in ("id_mgr", "id_gpt_41"):
+            sub_entry = repo.get("dst-ns", sub_id)
+            assert sub_entry is not None
+            assert sub_entry.parent_namespace is None
+            assert sub_entry.parent_id is None
+
+
+class TestCloneUserIdPropagation:
+    """AC26 — dst_user_id is stamped on every cloned entry (including sub-entries)."""
+
+    def test_enterprise_to_user(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, repo = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        for eid in ("root", "id_mgr", "id_gpt_41"):
+            entry = repo.get("dst-ns", eid)
+            assert entry is not None
+            assert entry.user_id == "alice"
+
+    def test_enterprise_to_enterprise(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, repo = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id=None)
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id=None,
+        )
+        for eid in ("root", "id_mgr", "id_gpt_41"):
+            entry = repo.get("dst-ns", eid)
+            assert entry is not None
+            assert entry.user_id is None
+
+
+class TestCloneAtomicity:
+    """AC27, AC41 — missing-target failure leaves dst-ns untouched; zero put calls."""
+
+    def test_corrupted_source_raises_and_does_not_write(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        leaf, sub, root = _register_models(monkeypatch)
+        fake = FakeEntryRepository()
+        # Seed a corrupted source graph bypassing catalog validation.
+        for entry in (
+            Entry(
+                id="team",
+                kind="team",
+                namespace="src-ns",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            Entry(
+                id="id_mgr",
+                kind="agent",
+                namespace="src-ns",
+                model_type=sub,
+                payload={"model_cfg": {"__ref__": "id_missing"}},
+            ),
+            Entry(
+                id="root",
+                kind="agent",
+                namespace="src-ns",
+                model_type=root,
+                payload={"manager": {"__ref__": "id_mgr"}},
+            ),
+        ):
+            fake.put(entry)
+        counting = CountingEntryRepository(fake)
+        catalog = Catalog(counting)
+        counting.reset()
+        with pytest.raises(CatalogValidationError):
+            catalog.clone(
+                src_namespace="src-ns",
+                src_id="root",
+                dst_namespace="dst-ns",
+                dst_user_id="alice",
+            )
+        # Zero writes landed.
+        put_calls = [c for c in counting.calls if c[0] == "put"]
+        assert put_calls == []
+        assert fake.list_by_namespace("dst-ns") == []
+
+
+class TestCloneMissingSource:
+    """AC28 — clone with non-existent src_id raises ``EntryNotFoundError``."""
+
+    def test_missing_source_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        with pytest.raises(EntryNotFoundError) as exc:
+            catalog.clone(
+                src_namespace="nope",
+                src_id="ghost",
+                dst_namespace="anywhere",
+                dst_user_id="alice",
+            )
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "nope" in msg
+        assert "ghost" in msg
+
+
+class TestCloneSkipsPrepareForWrite:
+    """AC30 — clone does not invoke ``prepare_for_write``."""
+
+    def test_prepare_for_write_is_not_called(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        leaf, sub, root = _register_models(monkeypatch)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_team(catalog, namespace="dst-ns", user_id="alice")
+
+        import akgentic.catalog.catalog as catalog_module
+
+        calls: list[Entry] = []
+        real = catalog_module.prepare_for_write
+
+        def _spy(entry: Entry, repository: Any) -> Entry:
+            calls.append(entry)
+            return real(entry, repository)
+
+        monkeypatch.setattr(catalog_module, "prepare_for_write", _spy)
+        calls.clear()
+        catalog.clone(
+            src_namespace="src-ns",
+            src_id="root",
+            dst_namespace="dst-ns",
+            dst_user_id="alice",
+        )
+        assert calls == []

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -1,0 +1,574 @@
+"""Tests for ``Catalog`` CRUD semantics — Story 15.5 ACs 5–20, 37, 38, 40.
+
+Every behavioural test runs against both backends via the ``catalog_factory``
+fixture (yaml + mongo, parametrised with explicit ids). Spy / invocation
+counting tests use the backend-agnostic ``counting_catalog`` fixture built on
+``CountingEntryRepository`` around the ``FakeEntryRepository`` test double.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from akgentic.catalog.catalog import UNSET_NAMESPACE, Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.base import EntryRepository
+
+from .conftest import (
+    CatalogFactory,
+    CountingEntryRepository,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+def _team_payload() -> dict[str, Any]:
+    """Return a minimal valid ``TeamCard`` payload with no refs.
+
+    Uses the real ``TeamCard`` shape so ``prepare_for_write`` can hydrate it
+    end-to-end on both backends. The member list is empty (legal per
+    ``TeamCardMember.members`` default), and the entry_point carries a minimal
+    ``AgentCard`` with only required fields set.
+    """
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "entry",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+def _seed_team(
+    catalog: Catalog,
+    namespace: str,
+    user_id: str | None = None,
+    team_id: str = "team",
+) -> Entry:
+    """Seed a team entry in ``namespace`` and return the persisted entry."""
+    entry = Entry(
+        id=team_id,
+        kind="team",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_TEAM_TYPE,
+        payload=_team_payload(),
+    )
+    return catalog.create(entry)
+
+
+class _LeafPayloadModel(BaseModel):
+    """Leaf referent for ref-based sub-entry payload validation."""
+
+    provider: str = "openai"
+    temperature: float = 0.0
+
+
+class _AgentPayloadModel(BaseModel):
+    """Minimal payload model for non-team test entries (avoids real AgentCard deps)."""
+
+    provider: str = "openai"
+    temperature: float = 0.0
+    model_cfg: _LeafPayloadModel | None = None
+
+
+def _register_agent_model(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register the ``_AgentPayloadModel`` under a fake ``akgentic.*`` path."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_15_5_crud_agent",
+        _AgentPayloadModel=_AgentPayloadModel,
+        _LeafPayloadModel=_LeafPayloadModel,
+    )
+    return f"{module_name}._AgentPayloadModel"
+
+
+def _register_leaf_model(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Return the fully-qualified path for the leaf model (same registration)."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_15_5_crud_agent",
+        _AgentPayloadModel=_AgentPayloadModel,
+        _LeafPayloadModel=_LeafPayloadModel,
+    )
+    return f"{module_name}._LeafPayloadModel"
+
+
+# --- AC5 — pass-throughs via counting_catalog -------------------------------------
+
+
+class TestPassThroughs:
+    """AC5 — list, list_by_namespace, find_references are repository pass-throughs."""
+
+    def test_list_delegates_once(
+        self, counting_catalog: tuple[Catalog, CountingEntryRepository]
+    ) -> None:
+        catalog, counting = counting_catalog
+        counting.reset()
+        query = EntryQuery(namespace="ns-x")
+        result = catalog.list(query)
+        assert result == []
+        assert counting.count("list") == 1
+
+    def test_list_by_namespace_delegates_once(
+        self, counting_catalog: tuple[Catalog, CountingEntryRepository]
+    ) -> None:
+        catalog, counting = counting_catalog
+        counting.reset()
+        result = catalog.list_by_namespace("ns-x")
+        assert result == []
+        assert counting.count("list_by_namespace") == 1
+
+    def test_find_references_delegates_once(
+        self, counting_catalog: tuple[Catalog, CountingEntryRepository]
+    ) -> None:
+        catalog, counting = counting_catalog
+        counting.reset()
+        result = catalog.find_references("ns-x", "anything")
+        assert result == []
+        assert counting.count("find_references") == 1
+
+
+# --- AC6 — get -----------------------------------------------------------------
+
+
+class TestGet:
+    """AC6 — hit returns entry; miss raises ``EntryNotFoundError``."""
+
+    def test_get_hit_returns_entry(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        team = _seed_team(catalog, namespace="ns-get")
+        result = catalog.get("ns-get", team.id)
+        assert result.id == team.id
+        assert result.namespace == "ns-get"
+
+    def test_get_miss_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        with pytest.raises(EntryNotFoundError) as exc:
+            catalog.get("ns-missing", "no-such")
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "ns-missing" in msg
+        assert "no-such" in msg
+
+
+# --- AC7, AC8 — namespace minting and rejection ---------------------------------
+
+
+class TestCreateNamespaceMint:
+    """AC7 — team + UNSET_NAMESPACE mints a UUID; AC8 — non-team empty-ns rejected."""
+
+    def test_team_unset_namespace_mints_uuid(self, catalog_factory: CatalogFactory) -> None:
+        catalog, repo = catalog_factory()
+        entry = Entry(
+            id="team",
+            kind="team",
+            namespace=UNSET_NAMESPACE,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        stored = catalog.create(entry)
+        assert stored.namespace != UNSET_NAMESPACE
+        assert stored.namespace != ""
+        # uuid4() strings are 36 chars: 8-4-4-4-12.
+        assert len(stored.namespace) == 36
+        # Repository actually received the stored namespace, not the sentinel.
+        assert repo.get(stored.namespace, "team") is not None
+        assert repo.get(UNSET_NAMESPACE, "team") is None
+
+    def test_two_mints_yield_distinct_uuids(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        a = catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace=UNSET_NAMESPACE,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        b = catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace=UNSET_NAMESPACE,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        assert a.namespace != b.namespace
+
+    def test_team_with_concrete_namespace_is_honoured(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        catalog, _ = catalog_factory()
+        stored = _seed_team(catalog, namespace="chosen-ns")
+        assert stored.namespace == "chosen-ns"
+
+    def test_empty_string_namespace_rejected_at_entry_construction(self) -> None:
+        # AC8 — NonEmptyStr rejects empty strings at Pydantic layer.
+        with pytest.raises(ValidationError):
+            Entry(
+                id="assistant",
+                kind="agent",
+                namespace="",
+                model_type=_TEAM_TYPE,
+                payload={},
+            )
+
+
+# --- AC9 — duplicate -------------------------------------------------------------
+
+
+class TestCreateDuplicate:
+    """AC9 — create rejects duplicate (namespace, id)."""
+
+    def test_duplicate_raises_and_does_not_write(
+        self, counting_catalog: tuple[Catalog, CountingEntryRepository]
+    ) -> None:
+        catalog, counting = counting_catalog
+        _seed_team(catalog, namespace="ns-dup")
+        counting.reset()
+        with pytest.raises(CatalogValidationError) as exc:
+            _seed_team(catalog, namespace="ns-dup")
+        msg = str(exc.value)
+        assert "already exists" in msg
+        assert "ns-dup" in msg
+        assert "team" in msg  # id appears in the error
+        # No put during the failing call.
+        assert counting.count("put") == 0
+
+
+# --- AC10 — bootstrap ------------------------------------------------------------
+
+
+class TestCreateBootstrap:
+    """AC10 — non-team entry in a fresh namespace requires a team entry first."""
+
+    def test_agent_without_team_fails(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="fresh-ns",
+            user_id="alice",
+            model_type=agent_type,
+            payload={"provider": "openai"},
+        )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.create(agent)
+        msg = str(exc.value)
+        assert "no team entry" in msg
+        assert "fresh-ns" in msg
+
+
+# --- AC11 + AC40 — ownership ----------------------------------------------------
+
+
+class TestCreateOwnership:
+    """AC11 + AC40 — user_id on sub-entries must equal the team's user_id."""
+
+    def test_matching_user_id_accepted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-own", user_id="alice")
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-own",
+            user_id="alice",
+            model_type=agent_type,
+            payload={},
+        )
+        stored = catalog.create(agent)
+        assert stored.user_id == "alice"
+
+    def test_mismatched_user_ids_rejected(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-own", user_id="alice")
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-own",
+            user_id="bob",
+            model_type=agent_type,
+            payload={},
+        )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.create(agent)
+        msg = str(exc.value)
+        assert "bob" in msg
+        assert "alice" in msg
+        assert "ns-own" in msg
+
+    def test_none_sub_entry_when_team_is_user_rejected(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-own", user_id="alice")
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-own",
+            user_id=None,
+            model_type=agent_type,
+            payload={},
+        )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.create(agent)
+        msg = str(exc.value)
+        assert "alice" in msg
+        assert "None" in msg
+
+    def test_enterprise_none_none_accepted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-ent", user_id=None)
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-ent",
+            user_id=None,
+            model_type=agent_type,
+            payload={},
+        )
+        stored = catalog.create(agent)
+        assert stored.user_id is None
+
+
+# --- AC12 — prepare_for_write is invoked ---------------------------------------
+
+
+class TestCreateRunsPrepareForWrite:
+    """AC12 — ``prepare_for_write`` is invoked once before ``repository.put``."""
+
+    def test_prepare_for_write_called(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-pre", user_id="alice")
+        agent_type = _register_agent_model(monkeypatch)
+
+        calls: list[tuple[Entry, EntryRepository]] = []
+
+        import akgentic.catalog.catalog as catalog_module
+
+        real = catalog_module.prepare_for_write
+
+        def _spy(entry: Entry, repository: EntryRepository) -> Entry:
+            calls.append((entry, repository))
+            return real(entry, repository)
+
+        monkeypatch.setattr(catalog_module, "prepare_for_write", _spy)
+
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-pre",
+            user_id="alice",
+            model_type=agent_type,
+            payload={"provider": "openai"},
+        )
+        catalog.create(agent)
+        assert len(calls) == 1
+        assert calls[0][0].id == "assistant"
+
+
+# --- AC13 — team skips bootstrap + ownership ----------------------------------
+
+
+class TestCreateTeamSkipsInvariants:
+    """AC13 — team entry in a fresh namespace with user_id=None is accepted."""
+
+    def test_enterprise_team_in_fresh_namespace_accepted(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        catalog, repo = catalog_factory()
+        stored = _seed_team(catalog, namespace="fresh-ent", user_id=None)
+        assert stored.user_id is None
+        assert repo.get("fresh-ent", stored.id) is not None
+
+
+# --- AC14 — create returns stored shape ----------------------------------------
+
+
+class TestCreateReturnsStored:
+    """AC14 — return value is the persisted entry (minted namespace + reconciled payload)."""
+
+    def test_returned_entry_is_persisted_shape(self, catalog_factory: CatalogFactory) -> None:
+        catalog, repo = catalog_factory()
+        stored = _seed_team(catalog, namespace="ns-ret")
+        round_trip = repo.get("ns-ret", stored.id)
+        assert round_trip is not None
+        assert round_trip == stored
+
+
+# --- AC15 — update missing target ---------------------------------------------
+
+
+class TestUpdateMissing:
+    """AC15 — update on a non-existent (namespace, id) raises ``EntryNotFoundError``."""
+
+    def test_update_missing_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        entry = Entry(
+            id="team",
+            kind="team",
+            namespace="ns-missing",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        with pytest.raises(EntryNotFoundError) as exc:
+            catalog.update(entry)
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "ns-missing" in msg
+        assert "team" in msg
+
+
+# --- AC16 — update ownership re-check / team self-transfer --------------------
+
+
+class TestUpdateOwnership:
+    """AC16 — update re-runs ownership on sub-entries; team updates skip it."""
+
+    def test_update_sub_entry_user_id_mismatch_rejected(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-upd", user_id="alice")
+        agent_type = _register_agent_model(monkeypatch)
+        agent = Entry(
+            id="assistant",
+            kind="agent",
+            namespace="ns-upd",
+            user_id="alice",
+            model_type=agent_type,
+            payload={"provider": "openai"},
+        )
+        catalog.create(agent)
+        bad = agent.model_copy(update={"user_id": "bob"})
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.update(bad)
+        msg = str(exc.value)
+        assert "bob" in msg and "alice" in msg
+
+    def test_update_team_user_id_transfer_allowed(self, catalog_factory: CatalogFactory) -> None:
+        catalog, repo = catalog_factory()
+        team = _seed_team(catalog, namespace="ns-team-transfer", user_id="alice")
+        new = team.model_copy(update={"user_id": "bob"})
+        stored = catalog.update(new)
+        assert stored.user_id == "bob"
+        # Round-trip.
+        assert repo.get("ns-team-transfer", team.id).user_id == "bob"  # type: ignore[union-attr]
+
+
+# --- AC17 — update never mints --------------------------------------------------
+
+
+class TestUpdateDoesNotMint:
+    """AC17 — update never mints; sentinel namespace path is missing-target."""
+
+    def test_update_sentinel_namespace_raises_not_found(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        catalog, _ = catalog_factory()
+        entry = Entry(
+            id="team",
+            kind="team",
+            namespace=UNSET_NAMESPACE,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        with pytest.raises(EntryNotFoundError):
+            catalog.update(entry)
+
+
+# --- AC18, AC19, AC20 — delete -------------------------------------------------
+
+
+class TestDeleteInboundRefs:
+    """AC18 — delete is blocked by inbound refs and names every referrer."""
+
+    def test_delete_blocked_lists_all_referrers(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-del", user_id=None)
+        # Register agent and leaf models.
+        agent_type = _register_agent_model(monkeypatch)
+        leaf_type = _register_leaf_model(monkeypatch)
+        leaf = Entry(
+            id="id_gpt_41",
+            kind="model",
+            namespace="ns-del",
+            model_type=leaf_type,
+            payload={"provider": "openai"},
+        )
+        catalog.create(leaf)
+        for aid in ("agent-a", "agent-b"):
+            catalog.create(
+                Entry(
+                    id=aid,
+                    kind="agent",
+                    namespace="ns-del",
+                    model_type=agent_type,
+                    payload={"model_cfg": {"__ref__": "id_gpt_41"}},
+                )
+            )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.delete("ns-del", "id_gpt_41")
+        msg = str(exc.value)
+        assert "agent-a" in msg
+        assert "agent-b" in msg
+
+
+class TestDeleteMissing:
+    """AC19 — delete of a non-existent target raises ``EntryNotFoundError``."""
+
+    def test_delete_missing_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        with pytest.raises(EntryNotFoundError) as exc:
+            catalog.delete("ns-nope", "who")
+        msg = str(exc.value)
+        assert "not found" in msg
+        assert "ns-nope" in msg
+        assert "who" in msg
+
+
+class TestDeleteClean:
+    """AC20 — delete with no referrers removes the entry."""
+
+    def test_delete_removes_entry(self, catalog_factory: CatalogFactory) -> None:
+        catalog, repo = catalog_factory()
+        team = _seed_team(catalog, namespace="ns-clean", user_id=None)
+        # The team entry has no inbound refs (no other entries exist).
+        catalog.delete("ns-clean", team.id)
+        assert repo.get("ns-clean", team.id) is None

--- a/tests/v2/test_catalog_resolve.py
+++ b/tests/v2/test_catalog_resolve.py
@@ -1,0 +1,264 @@
+"""Tests for ``Catalog.resolve`` / ``resolve_by_id`` / ``load_team`` — ACs 31-35, 42.
+
+``load_team`` uses an in-memory wrapper repository so every per-ref ``get`` is
+served from the pre-loaded list; tests assert this via
+``CountingEntryRepository``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from akgentic.team.models import TeamCard
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+from .conftest import (
+    CatalogFactory,
+    CountingEntryRepository,
+    FakeEntryRepository,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+def _team_payload() -> dict[str, Any]:
+    """Minimal valid ``TeamCard`` payload."""
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+class _LeafModel(BaseModel):
+    provider: str = "openai"
+
+
+class _ParentModel(BaseModel):
+    name: str
+    child: _LeafModel | None = None
+
+
+def _register_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    """Register leaf + parent models, return FQCNs."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_15_5_resolve_models",
+        _LeafModel=_LeafModel,
+        _ParentModel=_ParentModel,
+    )
+    return f"{module_name}._LeafModel", f"{module_name}._ParentModel"
+
+
+def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = None) -> Entry:
+    """Seed a minimal team entry; return the stored Entry."""
+    return catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+class TestResolve:
+    """AC31 — resolve delegates to the resolver; inline and ref payloads both work."""
+
+    def test_resolve_inline_payload(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-r")
+        leaf_type, parent_type = _register_models(monkeypatch)
+        entry = Entry(
+            id="leaf-1",
+            kind="model",
+            namespace="ns-r",
+            model_type=leaf_type,
+            payload={"provider": "anthropic"},
+        )
+        catalog.create(entry)
+        result = catalog.resolve(entry)
+        assert isinstance(result, _LeafModel)
+        assert result.provider == "anthropic"
+
+    def test_resolve_with_refs(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-rr", user_id=None)
+        leaf_type, parent_type = _register_models(monkeypatch)
+        catalog.create(
+            Entry(
+                id="leaf",
+                kind="model",
+                namespace="ns-rr",
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        parent = catalog.create(
+            Entry(
+                id="parent",
+                kind="agent",
+                namespace="ns-rr",
+                model_type=parent_type,
+                payload={"name": "p", "child": {"__ref__": "leaf"}},
+            )
+        )
+        result = catalog.resolve(parent)
+        assert isinstance(result, _ParentModel)
+        assert result.child is not None
+        assert result.child.provider == "openai"
+
+
+class TestResolveById:
+    """AC32 — ``resolve_by_id`` composes ``get`` + ``resolve``; miss propagates."""
+
+    def test_resolve_by_id_matches_resolve_get(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-rbi")
+        leaf_type, _ = _register_models(monkeypatch)
+        catalog.create(
+            Entry(
+                id="leaf",
+                kind="model",
+                namespace="ns-rbi",
+                model_type=leaf_type,
+                payload={"provider": "azure"},
+            )
+        )
+        direct = catalog.resolve(catalog.get("ns-rbi", "leaf"))
+        via_id = catalog.resolve_by_id("ns-rbi", "leaf")
+        assert isinstance(via_id, _LeafModel)
+        assert via_id.provider == "azure"
+        assert type(direct) is type(via_id)
+
+    def test_resolve_by_id_miss_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        with pytest.raises(EntryNotFoundError):
+            catalog.resolve_by_id("ns-no", "nope")
+
+
+class TestLoadTeamOneListCall:
+    """AC33 + AC42 — load_team issues exactly one list_by_namespace; zero get calls."""
+
+    def test_one_list_zero_gets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = FakeEntryRepository()
+        counting = CountingEntryRepository(fake)
+        catalog = Catalog(counting)
+        _seed_team(catalog, namespace="ns-lt", user_id=None)
+        leaf_type, parent_type = _register_models(monkeypatch)
+        # Add a sub-entry with a ref, so load_team's populate_refs would issue
+        # a get() call if the in-memory wrapper were missing.
+        catalog.create(
+            Entry(
+                id="leaf",
+                kind="model",
+                namespace="ns-lt",
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        counting.reset()
+        result = catalog.load_team("ns-lt")
+        assert isinstance(result, TeamCard)
+        assert counting.count("list_by_namespace") == 1
+        assert counting.count("get") == 0
+
+
+class TestLoadTeamMissing:
+    """AC34 — empty or team-less namespaces raise with "no team entry"."""
+
+    def test_empty_namespace_raises(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.load_team("ns-empty")
+        msg = str(exc.value)
+        assert "no team entry" in msg
+        assert "ns-empty" in msg
+
+    def test_namespace_without_team_raises(self) -> None:
+        # Bypass the Catalog bootstrap check by seeding the fake directly.
+        leaf = _LeafModel.__name__  # just to keep linter quiet
+        assert leaf  # noqa: S101 — sentinel use
+        fake = FakeEntryRepository()
+        # Direct put: inject agent entry without a team in the namespace.
+        fake.put(
+            Entry(
+                id="lone-agent",
+                kind="agent",
+                namespace="ns-team-less",
+                model_type="akgentic.core.agent_card.AgentCard",
+                payload={},
+            )
+        )
+        catalog = Catalog(fake)
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.load_team("ns-team-less")
+        msg = str(exc.value)
+        assert "no team entry" in msg
+        assert "ns-team-less" in msg
+
+
+class TestLoadTeamTypedReturn:
+    """AC35 — load_team returns a TeamCard at both type-check and runtime levels."""
+
+    def test_returns_team_card_instance(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="ns-lt-typed")
+        result = catalog.load_team("ns-lt-typed")
+        assert isinstance(result, TeamCard)
+
+
+class TestLoadTeamMisconfigured:
+    """AC35 defensive check — wrong model_type on the team entry raises."""
+
+    def test_wrong_model_type_raises(self) -> None:
+        fake = FakeEntryRepository()
+        # Directly put a team-kind entry with the wrong model_type.
+        fake.put(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-wrong",
+                model_type="akgentic.core.agent_card.AgentCard",
+                payload={
+                    "role": "r",
+                    "description": "",
+                    "skills": [],
+                    "agent_class": "akgentic.core.agent.Akgent",
+                    "config": {"name": "r", "role": "r"},
+                    "routes_to": [],
+                    "metadata": {},
+                },
+            )
+        )
+        catalog = Catalog(fake)
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.load_team("ns-wrong")
+        msg = str(exc.value)
+        assert "expected TeamCard" in msg

--- a/tests/v2/test_entry.py
+++ b/tests/v2/test_entry.py
@@ -1,0 +1,156 @@
+"""Tests for the v2 ``Entry`` model, ``EntryKind``, and ``AllowlistedPath``."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from akgentic.catalog.models.entry import (
+    AllowlistedPath,
+    Entry,
+    EntryKind,
+    NonEmptyStr,
+)
+
+from .conftest import make_entry
+
+# Reference the re-exports so the imports are not flagged as unused; also doubles
+# as a smoke-level AC1 check that the names resolve to usable objects.
+assert NonEmptyStr is not None
+assert AllowlistedPath is not None
+assert EntryKind is not None  # type: ignore[truthy-function]
+
+
+class TestEntryImport:
+    """AC1 — public importability of the v2 entry-model surface."""
+
+    def test_entry_is_base_model_subclass(self) -> None:
+        assert issubclass(Entry, BaseModel)
+
+    def test_entry_kind_alias_has_expected_literal_values(self) -> None:
+        # ``Literal`` aliases expose their members via typing.get_args
+        from typing import get_args
+
+        assert set(get_args(EntryKind)) == {"team", "agent", "tool", "model", "prompt"}
+
+
+class TestEntryFields:
+    """AC7 — Entry.model_fields exposes exactly the specified fields."""
+
+    def test_field_set_is_exact(self) -> None:
+        expected_fields = {
+            "id",
+            "kind",
+            "namespace",
+            "user_id",
+            "parent_namespace",
+            "parent_id",
+            "model_type",
+            "description",
+            "payload",
+        }
+        assert set(Entry.model_fields.keys()) == expected_fields
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ["id", "kind", "namespace", "model_type", "payload"],
+    )
+    def test_required_fields(self, field_name: str) -> None:
+        assert Entry.model_fields[field_name].is_required()
+
+    @pytest.mark.parametrize(
+        ("field_name", "expected_default"),
+        [
+            ("user_id", None),
+            ("parent_namespace", None),
+            ("parent_id", None),
+            ("description", ""),
+        ],
+    )
+    def test_optional_field_defaults(self, field_name: str, expected_default: object) -> None:
+        field = Entry.model_fields[field_name]
+        assert not field.is_required()
+        assert field.default == expected_default
+
+    def test_every_field_has_description(self) -> None:
+        missing = [name for name, f in Entry.model_fields.items() if not f.description]
+        assert not missing, f"fields without description: {missing}"
+
+
+class TestEntryParentPairValidator:
+    """AC8 — lineage pair consistency validator."""
+
+    def test_both_none_is_valid(self) -> None:
+        entry = make_entry(parent_namespace=None, parent_id=None)
+        assert entry.parent_namespace is None
+        assert entry.parent_id is None
+
+    def test_parent_id_without_namespace_is_valid(self) -> None:
+        # Same-namespace duplicate case
+        entry = make_entry(parent_namespace=None, parent_id="parent-1")
+        assert entry.parent_id == "parent-1"
+
+    def test_both_set_is_valid(self) -> None:
+        entry = make_entry(parent_namespace="ns-parent", parent_id="parent-1")
+        assert entry.parent_namespace == "ns-parent"
+        assert entry.parent_id == "parent-1"
+
+    def test_namespace_without_id_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            make_entry(parent_namespace="ns-parent", parent_id=None)
+        assert "parent_namespace set but parent_id is None" in str(exc_info.value)
+
+
+class TestAllowlistedPath:
+    """AC9 — ``AllowlistedPath`` prefix enforcement."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "akgentic.llm.ModelConfig",
+            "akgentic.core.agent_card.AgentCard",
+            "akgentic.tool.search.SearchTool",
+        ],
+    )
+    def test_accepts_akgentic_prefixed_paths(self, path: str) -> None:
+        entry = make_entry(model_type=path)
+        assert entry.model_type == path
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "os.system",
+            "builtins.eval",
+            "",
+            "akgentic",  # missing trailing dot — prefix check is strict
+            "akgenticfake.Impersonator",
+        ],
+    )
+    def test_rejects_non_allowlisted_paths(self, path: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            make_entry(model_type=path)
+        assert "outside allowlist" in str(exc_info.value)
+
+
+class TestNamespaceRequired:
+    """The ``namespace`` field rejects None and empty string via ``NonEmptyStr``."""
+
+    def test_none_namespace_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Entry(
+                id="entry-1",
+                kind="tool",
+                namespace=None,  # type: ignore[arg-type]
+                model_type="akgentic.core.agent_card.AgentCard",
+                payload={},
+            )
+
+    def test_empty_namespace_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Entry(
+                id="entry-1",
+                kind="tool",
+                namespace="",
+                model_type="akgentic.core.agent_card.AgentCard",
+                payload={},
+            )

--- a/tests/v2/test_entry_repo_parity.py
+++ b/tests/v2/test_entry_repo_parity.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from akgentic.catalog.models.queries import EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
 
@@ -167,3 +168,26 @@ class TestEntryRepositoryParity:
 
         assert got is not None
         assert got.payload == payload
+
+    def test_user_id_and_user_id_set_combine_conjunctively(
+        self,
+        backend: EntryRepository,
+    ) -> None:
+        """AC13/AC21: user_id + user_id_set evaluate as AND on both backends."""
+        backend.put(
+            make_entry(
+                id="alice", kind="agent", namespace="ns-1", user_id="alice", payload={}
+            )
+        )
+        backend.put(
+            make_entry(
+                id="bob", kind="agent", namespace="ns-1", user_id=None, payload={}
+            )
+        )
+
+        # user_id="alice" AND user_id_set=True → alice satisfies both.
+        got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=True))
+        assert {e.id for e in got} == {"alice"}
+        # user_id="alice" AND user_id_set=False → contradiction; zero entries.
+        got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=False))
+        assert got == []

--- a/tests/v2/test_entry_repo_parity.py
+++ b/tests/v2/test_entry_repo_parity.py
@@ -1,0 +1,169 @@
+"""Cross-backend parity tests for the v2 ``EntryRepository`` protocol (AC21).
+
+Parametrised on a ``backend`` fixture that yields one instance of each
+concrete implementation: ``YamlEntryRepository(tmp_path)`` and
+``MongoEntryRepository(entries_collection)``. Every parity scenario is
+backend-agnostic in its assertions — no ``if backend is ...`` branching in the
+test body. Scenarios that legitimately differ between the two backends live in
+their respective backend-specific test files.
+
+If ``pymongo`` is not installed in the test environment, the ``mongo`` branch
+of the parametrisation is skipped via ``pytest.importorskip`` inside the
+fixture; the YAML branch continues to run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from akgentic.catalog.repositories.base import EntryRepository
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+from .conftest import make_entry
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+
+@pytest.fixture(params=["yaml", "mongo"])
+def backend(
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+) -> EntryRepository:
+    """Yield a fresh ``EntryRepository`` for each parametrised backend.
+
+    The ``yaml`` branch builds a ``YamlEntryRepository`` over pytest's
+    ``tmp_path``. The ``mongo`` branch imports ``pymongo`` via
+    ``pytest.importorskip`` so the test is skipped gracefully if the optional
+    dep is missing (the package does carry it under the ``dev`` extras, but
+    belt-and-braces); then it returns a ``MongoEntryRepository`` over the
+    mongomock-backed ``entries_collection`` fixture.
+    """
+    if request.param == "yaml":
+        return YamlEntryRepository(tmp_path)
+    if request.param == "mongo":
+        pytest.importorskip("pymongo")
+        from akgentic.catalog.repositories.mongo_entry_repo import MongoEntryRepository
+
+        return MongoEntryRepository(entries_collection)
+    raise AssertionError(f"Unexpected backend parameter: {request.param}")
+
+
+class TestEntryRepositoryParity:
+    """Shared acceptance scenarios pinned by AC21 against both backends."""
+
+    def test_put_get_round_trip(self, backend: EntryRepository) -> None:
+        """AC11, AC18: put → get returns an equal entry."""
+        entry = make_entry(
+            id="a",
+            kind="agent",
+            namespace="ns-1",
+            description="desc",
+            payload={"k": "v"},
+        )
+        backend.put(entry)
+        assert backend.get("ns-1", "a") == entry
+
+    def test_upsert_overwrites_existing(self, backend: EntryRepository) -> None:
+        """AC8: second put with same (namespace, id) replaces the first."""
+        first = make_entry(id="a", kind="agent", namespace="ns-1", description="v1")
+        second = make_entry(id="a", kind="agent", namespace="ns-1", description="v2")
+
+        backend.put(first)
+        backend.put(second)
+
+        got = backend.get("ns-1", "a")
+        assert got is not None
+        assert got.description == "v2"
+
+    def test_list_by_namespace_returns_every_entry(self, backend: EntryRepository) -> None:
+        """AC14: list_by_namespace returns every entry regardless of kind."""
+        backend.put(make_entry(id="t1", kind="team", namespace="team-abc"))
+        backend.put(make_entry(id="a1", kind="agent", namespace="team-abc"))
+        backend.put(make_entry(id="a2", kind="agent", namespace="team-abc"))
+        backend.put(make_entry(id="tool1", kind="tool", namespace="team-abc"))
+        # Cross-namespace noise.
+        backend.put(make_entry(id="other", kind="agent", namespace="team-xyz"))
+
+        got = backend.list_by_namespace("team-abc")
+
+        assert {e.id for e in got} == {"t1", "a1", "a2", "tool1"}
+
+    def test_get_by_kind_returns_singleton(self, backend: EntryRepository) -> None:
+        """AC15: get_by_kind returns the only entry of that kind in the namespace."""
+        team = make_entry(id="team", kind="team", namespace="team-abc")
+        backend.put(team)
+        backend.put(make_entry(id="a1", kind="agent", namespace="team-abc"))
+
+        got = backend.get_by_kind("team-abc", "team")
+
+        assert got == team
+
+    def test_find_references_at_arbitrary_depth(self, backend: EntryRepository) -> None:
+        """AC16: find_references walks payloads at arbitrary depth."""
+        backend.put(
+            make_entry(
+                id="a",
+                kind="agent",
+                namespace="ns-1",
+                payload={"config": {"model_cfg": {"__ref__": "target"}}},
+            )
+        )
+        backend.put(
+            make_entry(
+                id="b",
+                kind="agent",
+                namespace="ns-1",
+                payload={"config": {"tools": [{"__ref__": "target"}]}},
+            )
+        )
+        backend.put(
+            make_entry(
+                id="c",
+                kind="agent",
+                namespace="ns-1",
+                payload={"config": {"model_cfg": {"__ref__": "other"}}},
+            )
+        )
+
+        got = backend.find_references("ns-1", "target")
+
+        assert {e.id for e in got} == {"a", "b"}
+
+    def test_namespace_isolation_same_id_different_namespace(
+        self,
+        backend: EntryRepository,
+    ) -> None:
+        """AC17: same id in two namespaces coexists; no cross-namespace bleed."""
+        a = make_entry(id="shared", kind="agent", namespace="ns-a", payload={"which": "a"})
+        b = make_entry(id="shared", kind="agent", namespace="ns-b", payload={"which": "b"})
+
+        backend.put(a)
+        backend.put(b)
+
+        assert backend.get("ns-a", "shared") == a
+        assert backend.get("ns-b", "shared") == b
+        assert [e.id for e in backend.list_by_namespace("ns-a")] == ["shared"]
+        assert [e.id for e in backend.list_by_namespace("ns-b")] == ["shared"]
+
+    def test_nested_ref_markers_round_trip(self, backend: EntryRepository) -> None:
+        """AC20: nested dicts and list elements with ``__ref__`` / ``__type__`` round-trip."""
+        payload = {
+            "config": {
+                "tools": [
+                    {"__ref__": "id_tool_a"},
+                    {"__ref__": "id_tool_b", "__type__": "akgentic.tool.ToolCard"},
+                ]
+            }
+        }
+        entry = make_entry(id="agent", kind="agent", namespace="ns-1", payload=payload)
+
+        backend.put(entry)
+        got = backend.get("ns-1", "agent")
+
+        assert got is not None
+        assert got.payload == payload

--- a/tests/v2/test_mongo_entry_repo.py
+++ b/tests/v2/test_mongo_entry_repo.py
@@ -1,0 +1,743 @@
+"""Integration tests for ``MongoEntryRepository`` (Story 15.4).
+
+Covers AC3-AC20, AC22, AC23. AC1/AC2 (importability + re-export) are validated
+by module-level import checks below. AC21 (cross-backend parity) lives in
+``test_entry_repo_parity.py``. AC24-AC28 are quality-gate ACs validated by
+ruff, mypy, pytest, and CI themselves.
+
+Every test uses the ``entries_collection`` fixture from ``conftest.py`` — a
+fresh mongomock-backed collection per test, no shared state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pymongo")  # belt-and-braces: package already pulls pymongo in dev extras
+
+from akgentic.catalog import MongoEntryRepository as PublicMongoEntryRepository  # noqa: E402
+from akgentic.catalog.models.entry import Entry  # noqa: E402
+from akgentic.catalog.models.queries import EntryQuery  # noqa: E402
+from akgentic.catalog.repositories.base import EntryRepository  # noqa: E402
+from akgentic.catalog.repositories.mongo_entry_repo import MongoEntryRepository  # noqa: E402
+
+from .conftest import make_entry  # noqa: E402
+
+if TYPE_CHECKING:
+    import pymongo.collection
+
+# AC3: structural-protocol check at module load time — mypy strict must accept.
+_protocol_check: type[EntryRepository] = MongoEntryRepository
+
+
+class TestPackageReExport:
+    """AC2: the top-level package re-exports ``MongoEntryRepository`` when pymongo is installed."""
+
+    def test_public_reexport_is_the_same_class(self) -> None:
+        """``from akgentic.catalog import MongoEntryRepository`` resolves to the same class."""
+        assert PublicMongoEntryRepository is MongoEntryRepository
+
+
+class TestProtocolConformance:
+    """AC3-AC4: repository satisfies ``EntryRepository`` structurally; no pymongo at import."""
+
+    def test_instance_exposes_every_protocol_method(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """All seven protocol methods exist and are callable on a live instance."""
+        repo = MongoEntryRepository(entries_collection)
+        assert callable(repo.get)
+        assert callable(repo.put)
+        assert callable(repo.delete)
+        assert callable(repo.list)
+        assert callable(repo.list_by_namespace)
+        assert callable(repo.get_by_kind)
+        assert callable(repo.find_references)
+
+    def test_importable_without_touching_pymongo_collection_api(self) -> None:
+        """AC4: the module imports cleanly; top-level surface stays pymongo-free."""
+        import akgentic.catalog.repositories.mongo_entry_repo as module
+
+        # MongoEntryRepository is exported; no pymongo name is shadowed at module level.
+        assert hasattr(module, "MongoEntryRepository")
+
+
+class TestConstruction:
+    """AC5: constructor signature and zero-I/O construction semantics."""
+
+    def test_construct_does_not_touch_the_collection(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """``__init__`` performs no I/O — no documents, no indexes touched."""
+        with patch.object(entries_collection, "create_index") as create_index_spy:
+            repo = MongoEntryRepository(entries_collection)
+            # No writes happened — collection empty, create_index never invoked.
+            assert entries_collection.count_documents({}) == 0
+            assert create_index_spy.call_count == 0
+            # The stored collection is the passed object, not a coerced variant.
+            assert repo._collection is entries_collection
+            assert repo._indexes_created is False
+
+
+class TestPutWrites:
+    """AC6-AC9, AC19: document shape, put return value, upsert semantics, no re-dumping."""
+
+    def test_put_writes_compound_id_document(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC6: put writes a compound-``_id`` doc with duplicated top-level ``namespace``+``id``."""
+        repo = MongoEntryRepository(entries_collection)
+        entry = make_entry(
+            id="assistant",
+            kind="agent",
+            namespace="team-abc",
+            model_type="akgentic.core.agent_card.AgentCard",
+            description="Helpful assistant",
+            payload={"role": "assistant", "description": "Helpful assistant", "skills": []},
+        )
+        repo.put(entry)
+
+        doc = entries_collection.find_one(
+            {"_id": {"namespace": "team-abc", "id": "assistant"}},
+        )
+        assert doc is not None
+        assert doc["_id"] == {"namespace": "team-abc", "id": "assistant"}
+        assert doc["namespace"] == "team-abc"
+        assert doc["id"] == "assistant"
+        assert doc["kind"] == "agent"
+        assert doc["user_id"] is None
+        assert doc["parent_namespace"] is None
+        assert doc["parent_id"] is None
+        assert doc["model_type"] == "akgentic.core.agent_card.AgentCard"
+        assert doc["description"] == "Helpful assistant"
+        assert doc["payload"] == {
+            "role": "assistant",
+            "description": "Helpful assistant",
+            "skills": [],
+        }
+
+    def test_put_returns_the_stored_entry(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC7: put returns an Entry equal to the input (identity is not required)."""
+        repo = MongoEntryRepository(entries_collection)
+        entry = make_entry(id="a", kind="tool", namespace="ns-1")
+
+        returned = repo.put(entry)
+
+        assert returned == entry
+
+    def test_put_is_upsert_second_write_wins(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC8: put with the same (namespace, id) replaces the existing doc in place."""
+        repo = MongoEntryRepository(entries_collection)
+        first = make_entry(
+            id="assistant",
+            kind="agent",
+            namespace="team-abc",
+            description="first",
+            payload={"v": 1},
+        )
+        second = make_entry(
+            id="assistant",
+            kind="agent",
+            namespace="team-abc",
+            description="second",
+            payload={"v": 2},
+        )
+
+        repo.put(first)
+        repo.put(second)
+
+        assert entries_collection.count_documents({}) == 1
+        doc = entries_collection.find_one({"_id": {"namespace": "team-abc", "id": "assistant"}})
+        assert doc is not None
+        assert doc["description"] == "second"
+        assert doc["payload"] == {"v": 2}
+
+    def test_put_kind_change_updates_same_document(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC9: kind change preserves single doc at the compound ``_id``."""
+        repo = MongoEntryRepository(entries_collection)
+        as_agent = make_entry(
+            id="assistant", kind="agent", namespace="team-abc", payload={"role": "a"}
+        )
+        as_tool = make_entry(
+            id="assistant", kind="tool", namespace="team-abc", payload={"role": "t"}
+        )
+
+        repo.put(as_agent)
+        repo.put(as_tool)
+
+        assert entries_collection.count_documents({}) == 1
+        got = repo.get("team-abc", "assistant")
+        assert got is not None
+        assert got.kind == "tool"
+        assert got.payload == {"role": "t"}
+
+    def test_put_does_not_expand_ref_markers(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC19: repository never re-dumps payload; ``__ref__`` survives byte-for-byte."""
+        repo = MongoEntryRepository(entries_collection)
+        payload = {
+            "config": {
+                "model_cfg": {"__ref__": "id_gpt_41"},
+                "name": "Helper",
+            }
+        }
+        entry = make_entry(id="a", kind="agent", namespace="ns-1", payload=payload)
+
+        repo.put(entry)
+
+        doc = entries_collection.find_one({"_id": {"namespace": "ns-1", "id": "a"}})
+        assert doc is not None
+        assert doc["payload"] == payload
+
+
+class TestLazyIndexes:
+    """AC10, AC23: first put creates the two secondary indexes, once and only once."""
+
+    def test_first_put_creates_two_indexes(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC10: first put invokes create_index twice with the expected specs."""
+        from pymongo import ASCENDING
+
+        repo = MongoEntryRepository(entries_collection)
+        entry = make_entry(id="a", kind="tool", namespace="ns-1")
+
+        with patch.object(entries_collection, "create_index") as spy:
+            repo.put(entry)
+
+        assert spy.call_count == 2
+        specs = [call.args[0] for call in spy.call_args_list]
+        assert [("namespace", ASCENDING), ("kind", ASCENDING)] in specs
+        assert [("namespace", ASCENDING), ("parent_id", ASCENDING)] in specs
+
+    def test_second_put_does_not_recreate_indexes(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC10: the one-shot flag prevents re-invoking create_index on subsequent writes."""
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="a", kind="tool", namespace="ns-1"))
+
+        with patch.object(entries_collection, "create_index") as spy:
+            repo.put(make_entry(id="b", kind="tool", namespace="ns-1"))
+
+        assert spy.call_count == 0
+
+    def test_read_only_repo_never_calls_create_index(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC10: a repo that is only queried (no writes) does not create any index."""
+        with patch.object(entries_collection, "create_index") as spy:
+            repo = MongoEntryRepository(entries_collection)
+            repo.get("ns-1", "a")
+            repo.list(EntryQuery(namespace="ns-1"))
+            repo.list_by_namespace("ns-1")
+            repo.get_by_kind("ns-1", "tool")
+            repo.find_references("ns-1", "id_gpt_41")
+
+        assert spy.call_count == 0
+
+
+class TestGet:
+    """AC11: get hits, misses, and cross-namespace misses."""
+
+    def test_get_returns_existing_entry(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        entry = make_entry(id="assistant", kind="agent", namespace="team-abc", payload={"k": "v"})
+        repo.put(entry)
+
+        got = repo.get("team-abc", "assistant")
+
+        assert got == entry
+
+    def test_get_returns_none_on_miss(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="assistant", kind="agent", namespace="team-abc"))
+
+        assert repo.get("team-abc", "unknown") is None
+
+    def test_get_respects_namespace_isolation(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="assistant", kind="agent", namespace="team-abc"))
+
+        assert repo.get("other-namespace", "assistant") is None
+
+
+class TestDelete:
+    """AC12: delete removes the document and is idempotent on miss."""
+
+    def test_delete_removes_document(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="assistant", kind="agent", namespace="team-abc"))
+
+        repo.delete("team-abc", "assistant")
+
+        assert entries_collection.count_documents({}) == 0
+        assert repo.get("team-abc", "assistant") is None
+
+    def test_delete_is_idempotent_on_miss(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        # No setup; delete must not raise.
+        repo.delete("team-abc", "missing")
+
+
+class TestList:
+    """AC13: list applies every filter via a server-side Mongo filter."""
+
+    def _seed(
+        self,
+        collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> MongoEntryRepository:
+        repo = MongoEntryRepository(collection)
+        repo.put(
+            make_entry(
+                id="alice",
+                kind="agent",
+                namespace="ns-1",
+                user_id="alice",
+                description="first agent",
+                payload={},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="bob",
+                kind="agent",
+                namespace="ns-1",
+                user_id=None,
+                description="second agent",
+                payload={},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="hammer",
+                kind="tool",
+                namespace="ns-1",
+                user_id=None,
+                description="a tool for striking",
+                payload={},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="carol",
+                kind="agent",
+                namespace="ns-2",
+                user_id="carol",
+                description="other namespace",
+                payload={},
+            )
+        )
+        return repo
+
+    def test_list_filters_by_namespace(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(EntryQuery(namespace="ns-1"))
+        assert {e.id for e in got} == {"alice", "bob", "hammer"}
+
+    def test_list_filters_by_kind(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(EntryQuery(kind="tool"))
+        assert [e.id for e in got] == ["hammer"]
+
+    def test_list_filters_by_id_exact_match(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(EntryQuery(id="alice"))
+        assert [e.namespace for e in got] == ["ns-1"]
+        # Exact, not substring — "ali" must not match "alice".
+        assert repo.list(EntryQuery(id="ali")) == []
+
+    def test_list_filters_by_user_id(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(EntryQuery(user_id="alice"))
+        assert [e.id for e in got] == ["alice"]
+
+    def test_list_user_id_set_tri_state(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        # None = no filter — all 4 entries.
+        assert len(repo.list(EntryQuery(user_id_set=None))) == 4
+        # True = user_id set — alice, carol.
+        assert {e.id for e in repo.list(EntryQuery(user_id_set=True))} == {"alice", "carol"}
+        # False = user_id is None — bob, hammer.
+        assert {e.id for e in repo.list(EntryQuery(user_id_set=False))} == {"bob", "hammer"}
+
+    def test_list_filters_by_parent_namespace_and_id(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="clone",
+                kind="agent",
+                namespace="dst",
+                parent_namespace="src",
+                parent_id="origin",
+            )
+        )
+        repo.put(make_entry(id="other", kind="agent", namespace="dst"))
+
+        got = repo.list(EntryQuery(parent_namespace="src"))
+        assert [e.id for e in got] == ["clone"]
+        got = repo.list(EntryQuery(parent_id="origin"))
+        assert [e.id for e in got] == ["clone"]
+
+    def test_list_description_contains_case_sensitive(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(EntryQuery(description_contains="agent"))
+        # "first agent" + "second agent" — tool striking / other namespace excluded.
+        assert {e.id for e in got} == {"alice", "bob"}
+        # Case-sensitive — "AGENT" must not match.
+        assert repo.list(EntryQuery(description_contains="AGENT")) == []
+
+    def test_list_description_contains_defuses_regex_metacharacters(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """re.escape neutralises regex metacharacters so user strings match literally."""
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="x",
+                kind="tool",
+                namespace="ns",
+                description="price is $99.",
+                payload={},
+            )
+        )
+        # "$" is a regex anchor; re.escape makes it literal.
+        assert [e.id for e in repo.list(EntryQuery(description_contains="$99"))] == ["x"]
+        # "." is a regex wildcard; re.escape makes it literal.
+        assert [e.id for e in repo.list(EntryQuery(description_contains="99."))] == ["x"]
+
+    def test_list_combines_filters_with_and(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = self._seed(entries_collection)
+        got = repo.list(
+            EntryQuery(namespace="ns-1", kind="agent", user_id_set=False),
+        )
+        # ns-1 AND agent AND user_id=None → only bob.
+        assert [e.id for e in got] == ["bob"]
+
+
+class TestListByNamespace:
+    """AC14: list_by_namespace returns every entry in one find call."""
+
+    def test_returns_every_entry_in_namespace(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="t1", kind="team", namespace="team-abc"))
+        repo.put(make_entry(id="a1", kind="agent", namespace="team-abc"))
+        repo.put(make_entry(id="a2", kind="agent", namespace="team-abc"))
+        repo.put(make_entry(id="tool1", kind="tool", namespace="team-abc"))
+        repo.put(make_entry(id="p1", kind="prompt", namespace="team-abc"))
+        # Cross-namespace noise that must not leak in.
+        repo.put(make_entry(id="other", kind="agent", namespace="team-xyz"))
+
+        got = repo.list_by_namespace("team-abc")
+
+        assert {e.id for e in got} == {"t1", "a1", "a2", "tool1", "p1"}
+
+    def test_missing_namespace_returns_empty_list(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        assert repo.list_by_namespace("nonexistent") == []
+
+    def test_issues_exactly_one_find_call(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC14: one find call, no per-kind fan-out."""
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="a", kind="tool", namespace="ns-1"))
+
+        real_find = entries_collection.find
+        with patch.object(entries_collection, "find", wraps=real_find) as spy:
+            repo.list_by_namespace("ns-1")
+        assert spy.call_count == 1
+
+
+class TestGetByKind:
+    """AC15: get_by_kind returns the singleton or None; deterministic on duplicates."""
+
+    def test_returns_singleton_entry(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        team = make_entry(id="team", kind="team", namespace="team-abc")
+        repo.put(team)
+        repo.put(make_entry(id="a1", kind="agent", namespace="team-abc"))
+
+        got = repo.get_by_kind("team-abc", "team")
+
+        assert got == team
+
+    def test_returns_none_when_no_match(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="a1", kind="agent", namespace="team-abc"))
+
+        assert repo.get_by_kind("team-abc", "team") is None
+
+    def test_returns_alphabetically_first_on_duplicates(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """Two docs sharing (namespace, kind) — return lowest ``_id.id``, no raise."""
+        repo = MongoEntryRepository(entries_collection)
+        # Insert b first to prove order is by id, not by insert order.
+        repo.put(make_entry(id="b", kind="agent", namespace="team-abc"))
+        repo.put(make_entry(id="a", kind="agent", namespace="team-abc"))
+
+        got = repo.get_by_kind("team-abc", "agent")
+
+        assert got is not None
+        assert got.id == "a"
+
+
+class TestFindReferences:
+    """AC16: find_references walks payloads in memory with the shared helper."""
+
+    def test_finds_ref_at_nested_dict_depth(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="agent-a",
+                kind="agent",
+                namespace="team-abc",
+                payload={"config": {"model_cfg": {"__ref__": "id_gpt_41"}}},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="agent-b",
+                kind="agent",
+                namespace="team-abc",
+                payload={"config": {"tools": [{"__ref__": "id_gpt_41"}]}},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="agent-c",
+                kind="agent",
+                namespace="team-abc",
+                payload={"config": {"model_cfg": {"__ref__": "id_other"}}},
+            )
+        )
+
+        got = repo.find_references("team-abc", "id_gpt_41")
+
+        assert {e.id for e in got} == {"agent-a", "agent-b"}
+
+    def test_finds_ref_inside_list_element(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="agent",
+                kind="agent",
+                namespace="ns-1",
+                payload={
+                    "config": {
+                        "prompt": {"params": {"X": {"__ref__": "id_tool_a"}}},
+                    }
+                },
+            )
+        )
+
+        got = repo.find_references("ns-1", "id_tool_a")
+
+        assert [e.id for e in got] == ["agent"]
+
+    def test_standalone_string_ref_key_is_not_matched(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """Only dict keys named ``__ref__`` count — a plain string value does not."""
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="noise",
+                kind="agent",
+                namespace="ns-1",
+                payload={"text": "__ref__"},
+            )
+        )
+
+        assert repo.find_references("ns-1", "__ref__") == []
+
+    def test_respects_namespace_isolation(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(
+            make_entry(
+                id="a",
+                kind="agent",
+                namespace="ns-a",
+                payload={"__ref__": "target"},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="b",
+                kind="agent",
+                namespace="ns-b",
+                payload={"__ref__": "target"},
+            )
+        )
+
+        got_a = repo.find_references("ns-a", "target")
+        got_b = repo.find_references("ns-b", "target")
+
+        assert [e.id for e in got_a] == ["a"]
+        assert [e.id for e in got_b] == ["b"]
+
+    def test_uses_shared_helper_from_yaml_module(self) -> None:
+        """Import-path assertion: the walker comes from ``yaml_entry_repo``."""
+        from akgentic.catalog.repositories import mongo_entry_repo
+        from akgentic.catalog.repositories.yaml_entry_repo import _payload_has_ref
+
+        assert mongo_entry_repo._payload_has_ref is _payload_has_ref
+
+
+class TestNamespaceIsolation:
+    """AC17: same id across two namespaces coexists; cross-namespace bleed never happens."""
+
+    def test_same_id_in_two_namespaces_coexists(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        a = make_entry(id="shared", kind="agent", namespace="ns-a", payload={"which": "a"})
+        b = make_entry(id="shared", kind="agent", namespace="ns-b", payload={"which": "b"})
+
+        repo.put(a)
+        repo.put(b)
+
+        assert entries_collection.count_documents({}) == 2
+        assert repo.get("ns-a", "shared") == a
+        assert repo.get("ns-b", "shared") == b
+        assert [e.id for e in repo.list_by_namespace("ns-a")] == ["shared"]
+        assert [e.id for e in repo.list_by_namespace("ns-b")] == ["shared"]
+
+
+class TestRoundTrip:
+    """AC18, AC20: ``Entry.model_validate`` round-trip preserves every field and nested refs."""
+
+    def test_round_trip_reconstructs_entry_exactly(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        entry = make_entry(
+            id="assistant",
+            kind="agent",
+            namespace="team-abc",
+            user_id="geoff",
+            parent_namespace="source-ns",
+            parent_id="source-id",
+            model_type="akgentic.core.agent_card.AgentCard",
+            description="Helpful",
+            payload={"role": "assistant", "skills": ["a", "b"]},
+        )
+        repo.put(entry)
+
+        got = repo.get("team-abc", "assistant")
+
+        assert got == entry
+        assert isinstance(got, Entry)
+        assert got.user_id == "geoff"
+        assert got.parent_namespace == "source-ns"
+        assert got.parent_id == "source-id"
+        assert got.payload == {"role": "assistant", "skills": ["a", "b"]}
+
+    def test_nested_ref_markers_round_trip_at_arbitrary_depth(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """AC20: ``__ref__`` and ``__type__`` survive nested dicts and list elements."""
+        repo = MongoEntryRepository(entries_collection)
+        payload = {
+            "config": {
+                "tools": [
+                    {"__ref__": "id_tool_a"},
+                    {"__ref__": "id_tool_b", "__type__": "akgentic.tool.ToolCard"},
+                ]
+            }
+        }
+        entry = make_entry(id="agent", kind="agent", namespace="ns-1", payload=payload)
+        repo.put(entry)
+
+        got = repo.get("ns-1", "agent")
+
+        assert got is not None
+        assert got.payload == payload

--- a/tests/v2/test_mongo_entry_repo.py
+++ b/tests/v2/test_mongo_entry_repo.py
@@ -474,6 +474,19 @@ class TestList:
         # ns-1 AND agent AND user_id=None → only bob.
         assert [e.id for e in got] == ["bob"]
 
+    def test_list_user_id_and_user_id_set_combine_with_and(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        """user_id and user_id_set combine conjunctively — parity with YAML's _matches."""
+        repo = self._seed(entries_collection)
+        # user_id="alice" AND user_id_set=True → alice satisfies both (her user_id is non-None).
+        got = repo.list(EntryQuery(user_id="alice", user_id_set=True))
+        assert {e.id for e in got} == {"alice"}
+        # user_id="alice" AND user_id_set=False → contradiction; zero entries.
+        got = repo.list(EntryQuery(user_id="alice", user_id_set=False))
+        assert got == []
+
 
 class TestListByNamespace:
     """AC14: list_by_namespace returns every entry in one find call."""

--- a/tests/v2/test_populate_refs.py
+++ b/tests/v2/test_populate_refs.py
@@ -1,0 +1,245 @@
+"""Tests for ``akgentic.catalog.resolver.populate_refs`` — AC3 through AC12."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.resolver import populate_refs
+
+from .conftest import FakeEntryRepository, make_entry
+
+
+class TestLeafPassthrough:
+    """AC4 — non-dict / non-list leaves pass through unchanged."""
+
+    @pytest.mark.parametrize(
+        "leaf",
+        ["text", 42, 3.14, True, False, None],
+    )
+    def test_scalar_leaves_identity(self, leaf: Any) -> None:
+        repo = FakeEntryRepository()
+        result = populate_refs(leaf, repo, "ns-1")
+        assert result == leaf
+        assert type(result) is type(leaf)
+
+    def test_empty_dict(self) -> None:
+        repo = FakeEntryRepository()
+        result = populate_refs({}, repo, "ns-1")
+        assert result == {}
+
+    def test_empty_list(self) -> None:
+        repo = FakeEntryRepository()
+        result = populate_refs([], repo, "ns-1")
+        assert result == []
+
+
+class TestDictRecursion:
+    """AC5 — plain dicts recurse into values and build a fresh container."""
+
+    def test_plain_dict_unchanged_values(self) -> None:
+        repo = FakeEntryRepository()
+        node = {"provider": "openai", "model": "gpt-4.1"}
+        result = populate_refs(node, repo, "ns-1")
+        assert result == node
+        # Recursion builds a fresh dict — input is not mutated.
+        node["provider"] = "mutated"
+        assert result["provider"] == "openai"
+
+    def test_nested_dicts_recurse(self) -> None:
+        repo = FakeEntryRepository()
+        node = {"outer": {"inner": {"deep": 1}}}
+        result = populate_refs(node, repo, "ns-1")
+        assert result == {"outer": {"inner": {"deep": 1}}}
+        # Distinct containers at each level.
+        assert result is not node
+        assert result["outer"] is not node["outer"]
+
+
+class TestListRecursion:
+    """AC6 — lists recurse element-wise and build a fresh container."""
+
+    def test_mixed_list(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="x", namespace="ns-1", payload={"k": 1}))
+        node = [{"__ref__": "x"}, "literal", 42]
+        result = populate_refs(node, repo, "ns-1")
+        assert result == [{"k": 1}, "literal", 42]
+
+    def test_nested_lists(self) -> None:
+        repo = FakeEntryRepository()
+        node: Any = [[1, 2], [3, [4, 5]]]
+        result = populate_refs(node, repo, "ns-1")
+        assert result == [[1, 2], [3, [4, 5]]]
+        assert result is not node
+
+
+class TestRefReplacement:
+    """AC7 — ref dict replaced by target payload (recursive)."""
+
+    def test_flat_ref_replaced(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target-id",
+                namespace="ns-1",
+                payload={"provider": "openai", "model": "gpt-4.1"},
+            )
+        )
+        result = populate_refs({"__ref__": "target-id"}, repo, "ns-1")
+        assert result == {"provider": "openai", "model": "gpt-4.1"}
+
+    def test_nested_ref_in_target_resolves_recursively(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="leaf", namespace="ns-1", payload={"value": 7}))
+        repo.put(
+            make_entry(
+                id="middle",
+                namespace="ns-1",
+                payload={"child": {"__ref__": "leaf"}},
+            )
+        )
+        result = populate_refs({"__ref__": "middle"}, repo, "ns-1")
+        assert result == {"child": {"value": 7}}
+
+
+class TestTypeMismatch:
+    """AC8 — ``__type__`` mismatch raises ``CatalogValidationError``."""
+
+    def test_type_mismatch_raises(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target-id",
+                namespace="ns-1",
+                model_type="akgentic.llm.OtherConfig",
+                payload={},
+            )
+        )
+        marker = {"__ref__": "target-id", "__type__": "akgentic.llm.ModelConfig"}
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(marker, repo, "ns-1")
+        assert len(exc_info.value.errors) == 1
+        msg = exc_info.value.errors[0]
+        assert "expected akgentic.llm.ModelConfig" in msg
+        assert "got akgentic.llm.OtherConfig" in msg
+        assert "target-id" in msg
+
+    def test_type_match_succeeds(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target-id",
+                namespace="ns-1",
+                model_type="akgentic.llm.ModelConfig",
+                payload={"provider": "openai"},
+            )
+        )
+        marker = {"__ref__": "target-id", "__type__": "akgentic.llm.ModelConfig"}
+        result = populate_refs(marker, repo, "ns-1")
+        assert result == {"provider": "openai"}
+
+    def test_absent_type_skips_check(self) -> None:
+        """Match-all case: no ``__type__`` in marker → no type check runs."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target-id",
+                namespace="ns-1",
+                model_type="akgentic.llm.AnyConfig",
+                payload={"k": 1},
+            )
+        )
+        result = populate_refs({"__ref__": "target-id"}, repo, "ns-1")
+        assert result == {"k": 1}
+
+
+class TestMissingTarget:
+    """AC9 — missing target raises ``CatalogValidationError``."""
+
+    def test_missing_target_raises(self) -> None:
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs({"__ref__": "missing-id"}, repo, "ns-1")
+        assert len(exc_info.value.errors) == 1
+        msg = exc_info.value.errors[0]
+        assert "not found" in msg
+        assert "missing-id" in msg
+        assert "ns-1" in msg
+
+
+class TestCycleDetection:
+    """AC10 — ref cycles raise ``CatalogValidationError``."""
+
+    def test_three_hop_cycle_raises(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-1", payload={"x": {"__ref__": "B"}}))
+        repo.put(make_entry(id="B", namespace="ns-1", payload={"y": {"__ref__": "C"}}))
+        repo.put(make_entry(id="C", namespace="ns-1", payload={"z": {"__ref__": "A"}}))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs({"__ref__": "A"}, repo, "ns-1")
+        msg = exc_info.value.errors[0].lower()
+        assert "cycle" in msg
+        assert "a" in msg  # id of the entry closing the cycle
+        assert "ns-1" in msg
+
+    def test_self_cycle_raises(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-1", payload={"self": {"__ref__": "A"}}))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs({"__ref__": "A"}, repo, "ns-1")
+        msg = exc_info.value.errors[0].lower()
+        assert "cycle" in msg
+        assert "a" in msg
+        assert "ns-1" in msg
+
+    def test_one_hop_ref_does_not_raise(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-1", payload={"v": 1}))
+        result = populate_refs({"__ref__": "A"}, repo, "ns-1")
+        assert result == {"v": 1}
+
+
+class TestVisitingNotShared:
+    """AC11 — ``_visiting`` is per-ref-chain, not global across siblings."""
+
+    def test_same_target_on_two_siblings_is_not_a_cycle(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="shared", namespace="ns-1", payload={"provider": "openai"}))
+        node = {"left": {"__ref__": "shared"}, "right": {"__ref__": "shared"}}
+        result = populate_refs(node, repo, "ns-1")
+        assert result == {
+            "left": {"provider": "openai"},
+            "right": {"provider": "openai"},
+        }
+
+    def test_caller_visiting_set_not_mutated(self) -> None:
+        """A fresh set passed by a caller is never mutated by populate_refs."""
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-1", payload={"k": 1}))
+        caller_set: set[tuple[str, str]] = set()
+        populate_refs({"__ref__": "A"}, repo, "ns-1", caller_set)
+        assert caller_set == set()
+
+
+class TestNamespaceForwarding:
+    """AC12 — namespace is forwarded unchanged; never derived from target."""
+
+    def test_namespace_forwarded_through_nested_refs(self) -> None:
+        """The recursion must keep calling repo.get with the original namespace."""
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-alpha", payload={"v": {"__ref__": "B"}}))
+        repo.put(make_entry(id="B", namespace="ns-alpha", payload={"leaf": 1}))
+        result = populate_refs({"__ref__": "A"}, repo, "ns-alpha")
+        assert result == {"v": {"leaf": 1}}
+
+    def test_target_in_other_namespace_invisible(self) -> None:
+        """Cross-namespace resolution is structurally impossible."""
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="A", namespace="ns-beta", payload={"v": 1}))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs({"__ref__": "A"}, repo, "ns-alpha")
+        assert "not found" in exc_info.value.errors[0]
+        assert "ns-alpha" in exc_info.value.errors[0]

--- a/tests/v2/test_prepare_for_write.py
+++ b/tests/v2/test_prepare_for_write.py
@@ -1,0 +1,268 @@
+"""Tests for ``akgentic.catalog.resolver.prepare_for_write`` — AC22 through AC25."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog import resolver as resolver_module
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.resolver import populate_refs, prepare_for_write
+
+from .conftest import FakeEntryRepository, make_entry, register_akgentic_test_module
+
+
+class TestPipelineOrdering:
+    """AC23 — the five pipeline steps run in order, short-circuiting on failure."""
+
+    def test_steps_run_in_order(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Simple(BaseModel):
+            x: int = 0
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_prepare_order", Simple=Simple
+        )
+
+        call_log: list[str] = []
+
+        real_populate = resolver_module.populate_refs
+        real_load = resolver_module.load_model_type
+        real_reconcile = resolver_module.reconcile_refs
+
+        def spy_populate(node: Any, repo: Any, ns: str, visiting: Any = None) -> Any:
+            call_log.append("populate_refs")
+            return real_populate(node, repo, ns, visiting)
+
+        def spy_load(path: str) -> Any:
+            call_log.append("load_model_type")
+            return real_load(path)
+
+        original_validate = Simple.model_validate.__func__  # type: ignore[attr-defined]
+
+        def spy_validate(cls_arg: Any, data: Any, **kwargs: Any) -> Any:
+            call_log.append("model_validate")
+            return original_validate(cls_arg, data, **kwargs)
+
+        def spy_reconcile(inp: Any, dumped: Any) -> Any:
+            call_log.append("reconcile_refs")
+            return real_reconcile(inp, dumped)
+
+        monkeypatch.setattr(resolver_module, "populate_refs", spy_populate)
+        monkeypatch.setattr(resolver_module, "load_model_type", spy_load)
+        monkeypatch.setattr(resolver_module, "reconcile_refs", spy_reconcile)
+        monkeypatch.setattr(Simple, "model_validate", classmethod(spy_validate))
+
+        entry = make_entry(
+            model_type=f"{module_name}.Simple",
+            payload={"x": 1},
+        )
+        repo = FakeEntryRepository()
+        prepare_for_write(entry, repo)
+
+        # ``populate_refs`` is recursive, so it may appear multiple times at
+        # the head; ``reconcile_refs`` is similarly recursive at the tail. What
+        # matters for AC23 is that the FIRST occurrence of each step is in the
+        # documented order.
+        firsts: list[str] = []
+        for step in call_log:
+            if step not in firsts:
+                firsts.append(step)
+        assert firsts == [
+            "populate_refs",
+            "load_model_type",
+            "model_validate",
+            "reconcile_refs",
+        ]
+        # Also assert every step was seen at least once.
+        assert set(call_log) >= {
+            "populate_refs",
+            "load_model_type",
+            "model_validate",
+            "reconcile_refs",
+        }
+
+    def test_short_circuit_on_populate_failure(self) -> None:
+        repo = FakeEntryRepository()
+        entry = make_entry(payload={"value": {"__ref__": "missing"}})
+        with pytest.raises(CatalogValidationError) as exc_info:
+            prepare_for_write(entry, repo)
+        assert "not found" in exc_info.value.errors[0]
+
+    def test_short_circuit_on_load_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-BaseModel attribute surfaces ``is not a Pydantic BaseModel subclass``."""
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_prepare_bad_load", not_a_model=42
+        )
+        entry = make_entry(model_type=f"{module_name}.not_a_model", payload={})
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            prepare_for_write(entry, repo)
+        assert "is not a Pydantic BaseModel subclass" in exc_info.value.errors[0]
+
+    def test_short_circuit_on_validate_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class StrictModel(BaseModel):
+            count: int
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_prepare_bad_validate", StrictModel=StrictModel
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.StrictModel",
+            payload={"count": "not-an-int"},
+        )
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            prepare_for_write(entry, repo)
+        msg = exc_info.value.errors[0]
+        assert "Payload does not validate against" in msg
+        assert f"{module_name}.StrictModel" in msg
+
+
+class TestRoundTripInvariant:
+    """AC24 — ``populate_refs(stored) == obj.model_dump(exclude_unset=True)``."""
+
+    def test_round_trip_with_inline_and_ref_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Child(BaseModel):
+            provider: str
+            temperature: float = 0.7
+
+        class Parent(BaseModel):
+            name: str
+            child: Child
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_15_2_prepare_round_trip",
+            Child=Child,
+            Parent=Parent,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="child-id",
+                namespace="ns-1",
+                model_type=f"{module_name}.Child",
+                payload={"provider": "openai"},  # temperature unset → default 0.7
+            )
+        )
+        input_payload: dict[str, Any] = {
+            "name": "parent",
+            "child": {"__ref__": "child-id"},
+        }
+        entry = make_entry(
+            model_type=f"{module_name}.Parent",
+            payload=input_payload,
+        )
+        prepared = prepare_for_write(entry, repo)
+
+        # Rehydrate the stored payload — result must match the runtime instance's
+        # exclude_unset dump of the populated tree.
+        rehydrated = populate_refs(prepared.payload, repo, prepared.namespace)
+        obj = Parent.model_validate(populate_refs(entry.payload, repo, entry.namespace))
+        expected = obj.model_dump(mode="python", exclude_unset=True)
+        assert rehydrated == expected
+
+    def test_ref_marker_preserved_in_stored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Child(BaseModel):
+            provider: str
+
+        class Parent(BaseModel):
+            name: str
+            child: Child
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_15_2_prepare_ref_preserved",
+            Child=Child,
+            Parent=Parent,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="child-id",
+                namespace="ns-1",
+                model_type=f"{module_name}.Child",
+                payload={"provider": "openai"},
+            )
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.Parent",
+            payload={"name": "p", "child": {"__ref__": "child-id"}},
+        )
+        prepared = prepare_for_write(entry, repo)
+        assert prepared.payload["child"] == {"__ref__": "child-id"}
+
+
+class TestImmutability:
+    """AC22 — ``prepare_for_write`` returns a new ``Entry`` and does not mutate input."""
+
+    def test_returns_new_entry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Simple(BaseModel):
+            x: int = 0
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_prepare_new_entry", Simple=Simple
+        )
+        entry = make_entry(model_type=f"{module_name}.Simple", payload={"x": 1})
+        repo = FakeEntryRepository()
+        prepared = prepare_for_write(entry, repo)
+        assert prepared is not entry
+
+    def test_input_entry_not_mutated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Child(BaseModel):
+            provider: str
+            temperature: float = 0.7
+
+        class Parent(BaseModel):
+            name: str
+            child: Child
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_15_2_prepare_immut",
+            Child=Child,
+            Parent=Parent,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="child-id",
+                namespace="ns-1",
+                model_type=f"{module_name}.Child",
+                payload={"provider": "openai"},
+            )
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.Parent",
+            payload={"name": "p", "child": {"__ref__": "child-id"}},
+        )
+        payload_snapshot = copy.deepcopy(entry.payload)
+        prepare_for_write(entry, repo)
+        assert entry.payload == payload_snapshot
+
+
+class TestOwnershipNotRun:
+    """AC25 — ``prepare_for_write`` does NOT invoke ``get_by_kind`` / ownership check."""
+
+    def test_get_by_kind_not_called(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Simple(BaseModel):
+            x: int = 0
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_prepare_no_ownership", Simple=Simple
+        )
+
+        called: list[str] = []
+
+        class SpyRepo(FakeEntryRepository):
+            def get_by_kind(self, namespace: str, kind: Any) -> Any:
+                called.append("get_by_kind")
+                return super().get_by_kind(namespace, kind)
+
+        entry = make_entry(model_type=f"{module_name}.Simple", payload={"x": 1})
+        repo = SpyRepo()
+        prepare_for_write(entry, repo)
+        assert called == []

--- a/tests/v2/test_queries.py
+++ b/tests/v2/test_queries.py
@@ -1,0 +1,94 @@
+"""Tests for the v2 ``EntryQuery`` and ``CloneRequest`` models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.catalog.models.queries import CloneRequest, EntryQuery
+
+
+class TestEntryQueryImport:
+    """AC3 — EntryQuery imports and every field defaults to None."""
+
+    def test_default_construction_all_none(self) -> None:
+        query = EntryQuery()
+        expected_fields = {
+            "namespace",
+            "kind",
+            "id",
+            "user_id",
+            "user_id_set",
+            "parent_namespace",
+            "parent_id",
+            "description_contains",
+        }
+        assert set(EntryQuery.model_fields.keys()) == expected_fields
+        for name in expected_fields:
+            assert getattr(query, name) is None, f"{name} should default to None"
+
+
+class TestEntryQueryUserIdSetTriState:
+    """AC3 — ``user_id_set`` accepts all three tri-state values."""
+
+    @pytest.mark.parametrize("value", [None, True, False])
+    def test_tri_state_values_validate(self, value: bool | None) -> None:
+        query = EntryQuery(user_id_set=value)
+        assert query.user_id_set is value
+
+
+class TestEntryQueryFieldShapes:
+    """Spot-checks on constraints inherited from the v2 NonEmptyStr alias."""
+
+    def test_empty_namespace_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            EntryQuery(namespace="")
+
+    def test_kind_literal_constrained(self) -> None:
+        with pytest.raises(ValidationError):
+            EntryQuery(kind="unknown-kind")  # type: ignore[arg-type]
+
+    def test_description_contains_is_plain_str(self) -> None:
+        # description_contains is a plain str | None — empty string is allowed
+        # (substring containment against an empty string is a separate concern).
+        query = EntryQuery(description_contains="")
+        assert query.description_contains == ""
+
+
+class TestCloneRequestImport:
+    """AC4 — CloneRequest required/optional field set."""
+
+    def test_minimal_clone_request(self) -> None:
+        req = CloneRequest(src_namespace="ns-a", src_id="entry-1", dst_namespace="ns-b")
+        assert req.src_namespace == "ns-a"
+        assert req.src_id == "entry-1"
+        assert req.dst_namespace == "ns-b"
+        assert req.dst_user_id is None
+
+    def test_dst_user_id_accepts_value(self) -> None:
+        req = CloneRequest(
+            src_namespace="ns-a",
+            src_id="entry-1",
+            dst_namespace="ns-b",
+            dst_user_id="alice",
+        )
+        assert req.dst_user_id == "alice"
+
+    @pytest.mark.parametrize(
+        "missing",
+        ["src_namespace", "src_id", "dst_namespace"],
+    )
+    def test_required_fields_missing_raises(self, missing: str) -> None:
+        kwargs: dict[str, str] = {
+            "src_namespace": "ns-a",
+            "src_id": "entry-1",
+            "dst_namespace": "ns-b",
+        }
+        kwargs.pop(missing)
+        with pytest.raises(ValidationError):
+            CloneRequest(**kwargs)  # type: ignore[arg-type]
+
+    def test_empty_dst_namespace_rejected(self) -> None:
+        # dst_namespace must be NonEmptyStr — empty is rejected.
+        with pytest.raises(ValidationError):
+            CloneRequest(src_namespace="ns-a", src_id="entry-1", dst_namespace="")

--- a/tests/v2/test_reconcile_refs.py
+++ b/tests/v2/test_reconcile_refs.py
@@ -1,0 +1,125 @@
+"""Tests for ``akgentic.catalog.resolver.reconcile_refs`` — AC17 through AC21."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from akgentic.catalog.resolver import reconcile_refs
+
+
+class TestLeafRules:
+    """AC17 — leaves on the input side take the ``dumped_node`` value."""
+
+    def test_leaf_string_dumped_wins(self) -> None:
+        assert reconcile_refs("input-literal", "dumped-literal") == "dumped-literal"
+
+    def test_leaf_int_dumped_wins(self) -> None:
+        assert reconcile_refs(1, 2) == 2
+
+    def test_both_none(self) -> None:
+        assert reconcile_refs(None, None) is None
+
+
+class TestRefWinsVerbatim:
+    """AC18 — ``{"__ref__": ...}`` markers win verbatim over any dumped value."""
+
+    def test_flat_ref_identity_preserved(self) -> None:
+        input_node = {"__ref__": "X"}
+        dumped_node = {"some": "dumped", "thing": 1}
+        result = reconcile_refs(input_node, dumped_node)
+        assert result is input_node  # identity preserved
+
+    def test_ref_with_type_hint(self) -> None:
+        input_node = {"__ref__": "X", "__type__": "akgentic.llm.ModelConfig"}
+        result = reconcile_refs(input_node, {"unrelated": True})
+        assert result is input_node
+
+    def test_nested_ref_wins(self) -> None:
+        input_node = {"outer": {"__ref__": "X"}}
+        dumped = {"outer": {"provider": "openai"}}
+        result = reconcile_refs(input_node, dumped)
+        # Top-level is a fresh dict, but the nested ref identity is preserved.
+        assert result["outer"] is input_node["outer"]
+
+
+class TestDictBranches:
+    """AC19 — input keys recursed; unset-but-refed keys preserved; others dropped."""
+
+    def test_key_in_dumped_recurses(self) -> None:
+        input_node = {"provider": "openai"}
+        dumped = {"provider": "normalised", "temperature": 0.7}
+        result = reconcile_refs(input_node, dumped)
+        assert result == {"provider": "normalised"}  # dumped wins for non-ref leaf
+
+    def test_key_missing_with_ref_value_preserved(self) -> None:
+        """Classic unset-but-refed branch: ref-valued key absent from dumped."""
+        input_node = {"routes_to": [], "model_cfg": {"__ref__": "id_gpt_41"}}
+        dumped = {"routes_to": []}  # model_cfg omitted by exclude_unset=True
+        result = reconcile_refs(input_node, dumped)
+        assert result == {"routes_to": [], "model_cfg": {"__ref__": "id_gpt_41"}}
+
+    def test_key_missing_non_ref_is_dropped(self) -> None:
+        input_node = {"a": "present", "b": "unset-in-dumped"}
+        dumped = {"a": "dumped-a"}
+        result = reconcile_refs(input_node, dumped)
+        assert result == {"a": "dumped-a"}
+
+    def test_dumped_has_extra_keys_those_are_dropped(self) -> None:
+        """Only input keys are iterated — dumped extras never appear."""
+        input_node = {"a": 1}
+        dumped = {"a": 9, "extra": "ignored"}
+        result = reconcile_refs(input_node, dumped)
+        assert result == {"a": 9}
+
+    def test_dumped_not_a_dict_all_keys_missing(self) -> None:
+        """When dumped shape mismatches a dict input, only ref keys survive."""
+        input_node = {"value": "something", "ref": {"__ref__": "X"}}
+        dumped = "not-a-dict"
+        result = reconcile_refs(input_node, dumped)
+        # "value" key is non-ref and missing from (non-dict) dumped → dropped.
+        # "ref" key is a ref marker and missing from dumped → preserved verbatim.
+        assert result == {"ref": {"__ref__": "X"}}
+
+
+class TestListPairwise:
+    """AC20 — lists walked pairwise with strict length; mismatched shape falls through."""
+
+    def test_equal_length_lists_recurse(self) -> None:
+        input_node = [{"a": 1}, "literal"]
+        dumped = [{"a": 9}, "dumped-literal"]
+        result = reconcile_refs(input_node, dumped)
+        assert result == [{"a": 9}, "dumped-literal"]
+
+    def test_mismatched_length_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            reconcile_refs([1, 2, 3], [1, 2])
+
+    def test_list_with_refs(self) -> None:
+        input_node = [{"__ref__": "X"}, {"a": 1}]
+        dumped = [{"ignored": True}, {"a": 9}]
+        result = reconcile_refs(input_node, dumped)
+        assert result == [{"__ref__": "X"}, {"a": 9}]
+
+    def test_shape_mismatch_falls_through_to_leaf(self) -> None:
+        """Input is a list but dumped is not → dumped leaf wins (AC20 final sentence)."""
+        result = reconcile_refs([1, 2], "dumped-scalar")
+        assert result == "dumped-scalar"
+
+
+class TestNoMutation:
+    """AC21 — neither input nor dumped tree is mutated by reconcile_refs."""
+
+    def test_input_and_dumped_unchanged(self) -> None:
+        input_node = {
+            "routes_to": [],
+            "model_cfg": {"__ref__": "id_gpt_41"},
+            "agents": [{"role": "R1"}],
+        }
+        dumped = {"routes_to": [], "agents": [{"role": "R1-normed"}]}
+        input_snapshot = copy.deepcopy(input_node)
+        dumped_snapshot = copy.deepcopy(dumped)
+        reconcile_refs(input_node, dumped)
+        assert input_node == input_snapshot
+        assert dumped == dumped_snapshot

--- a/tests/v2/test_resolve.py
+++ b/tests/v2/test_resolve.py
@@ -1,0 +1,186 @@
+"""Tests for ``akgentic.catalog.resolver.resolve`` — AC13 through AC16."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.resolver import resolve
+
+from .conftest import FakeEntryRepository, make_entry, register_akgentic_test_module
+
+
+class TestResolveHappyPath:
+    """AC13 — happy path: model_type names a BaseModel; payload validates."""
+
+    def test_resolves_to_model_instance(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class SimpleModel(BaseModel):
+            name: str
+            count: int = 0
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_simple", SimpleModel=SimpleModel
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.SimpleModel",
+            payload={"name": "alpha", "count": 3},
+        )
+        repo = FakeEntryRepository()
+        result = resolve(entry, repo)
+        assert isinstance(result, SimpleModel)
+        assert result.name == "alpha"
+        assert result.count == 3
+
+    def test_resolves_with_nested_refs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class ChildModel(BaseModel):
+            provider: str
+
+        class ParentModel(BaseModel):
+            name: str
+            child: ChildModel
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_15_2_resolve_nested",
+            ChildModel=ChildModel,
+            ParentModel=ParentModel,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="child-id",
+                namespace="ns-1",
+                model_type=f"{module_name}.ChildModel",
+                payload={"provider": "openai"},
+            )
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.ParentModel",
+            payload={"name": "parent", "child": {"__ref__": "child-id"}},
+        )
+        result = resolve(entry, repo)
+        assert isinstance(result, ParentModel)
+        assert result.child.provider == "openai"
+
+
+class TestResolveAllowlistPassthrough:
+    """AC14 — errors from ``load_model_type`` propagate unchanged."""
+
+    def test_non_allowlisted_raises_from_loader(self) -> None:
+        repo = FakeEntryRepository()
+        # Build an Entry with a known-good model_type, then mutate to test loader rejection.
+        # We need to bypass the storage-side allowlist — use model_construct to skip validation.
+        from akgentic.catalog.models.entry import Entry
+
+        entry = Entry.model_construct(
+            id="e",
+            kind="tool",
+            namespace="ns-1",
+            model_type="os.system",
+            description="",
+            payload={},
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            resolve(entry, repo)
+        assert "outside allowlist" in exc_info.value.errors[0]
+
+    def test_non_basemodel_raises_from_loader(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-BaseModel attributes surface the BaseModel subclass check unchanged."""
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_non_bm", not_a_model=42
+        )
+        entry = make_entry(model_type=f"{module_name}.not_a_model")
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            resolve(entry, repo)
+        assert "is not a Pydantic BaseModel subclass" in exc_info.value.errors[0]
+
+
+class TestResolvePopulateFailures:
+    """AC15 — errors from ``populate_refs`` propagate unchanged."""
+
+    def test_missing_ref_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Model(BaseModel):
+            value: dict[str, int]
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_missing", Model=Model
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.Model",
+            payload={"value": {"__ref__": "missing"}},
+        )
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            resolve(entry, repo)
+        assert "not found" in exc_info.value.errors[0]
+
+    def test_cycle_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class Model(BaseModel):
+            value: dict[str, int]
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_cycle", Model=Model
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="A",
+                namespace="ns-1",
+                model_type=f"{module_name}.Model",
+                payload={"value": {"__ref__": "A"}},
+            )
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.Model",
+            payload={"value": {"__ref__": "A"}},
+        )
+        # Put entry itself into repo so it can be found — then cycle through A.
+        with pytest.raises(CatalogValidationError) as exc_info:
+            resolve(entry, repo)
+        assert "cycle" in exc_info.value.errors[0].lower()
+
+
+class TestResolveValidationFailure:
+    """AC16 — Pydantic ValidationError is wrapped with substring-stable message."""
+
+    def test_model_validate_failure_wrapped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class StrictModel(BaseModel):
+            count: int
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_strict", StrictModel=StrictModel
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.StrictModel",
+            payload={"count": "not-an-int"},
+        )
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            resolve(entry, repo)
+        msg = exc_info.value.errors[0]
+        assert "Payload does not validate against" in msg
+        assert f"{module_name}.StrictModel" in msg
+
+    def test_validation_error_chained(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The original ``ValidationError`` is retained via ``raise ... from e``."""
+        from pydantic import ValidationError
+
+        class StrictModel(BaseModel):
+            count: int
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_2_resolve_chain", StrictModel=StrictModel
+        )
+        entry = make_entry(
+            model_type=f"{module_name}.StrictModel",
+            payload={"count": "bad"},
+        )
+        repo = FakeEntryRepository()
+        try:
+            resolve(entry, repo)
+        except CatalogValidationError as e:
+            assert isinstance(e.__cause__, ValidationError)
+        else:
+            pytest.fail("resolve did not raise CatalogValidationError")

--- a/tests/v2/test_resolver_allowlist.py
+++ b/tests/v2/test_resolver_allowlist.py
@@ -1,0 +1,131 @@
+"""Tests for ``akgentic.catalog.resolver.load_model_type`` and constants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.resolver import REF_KEY, TYPE_KEY, load_model_type
+
+from .conftest import register_akgentic_test_module
+
+
+def _model_with_reserved_field(reserved_name: str) -> type[BaseModel]:
+    """Return a throwaway BaseModel subclass with ``reserved_name`` in ``model_fields``.
+
+    Pydantic 2 silently drops dunder-named fields through both the normal class
+    body and ``create_model``. We sidestep the limitation by manually inserting
+    a ``FieldInfo`` into ``model_fields`` on a plain subclass — good enough for
+    the resolver's ``reserved_name in cls.model_fields`` check.
+    """
+
+    class _Host(BaseModel):
+        placeholder: str = ""
+
+    _Host.model_fields[reserved_name] = FieldInfo(annotation=str, default="")
+    return _Host
+
+
+class TestResolverConstants:
+    """AC6 — REF_KEY / TYPE_KEY have the expected literal values."""
+
+    def test_ref_key_value(self) -> None:
+        assert REF_KEY == "__ref__"
+
+    def test_type_key_value(self) -> None:
+        assert TYPE_KEY == "__type__"
+
+
+class TestLoadModelTypeAllowlist:
+    """AC10 — non-allowlisted paths are rejected by ``load_model_type``."""
+
+    def test_rejects_os_system(self) -> None:
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type("os.system")
+        assert len(exc_info.value.errors) == 1
+        message = exc_info.value.errors[0]
+        assert "outside allowlist" in message
+        assert "os.system" in message
+
+    def test_rejects_builtins_eval(self) -> None:
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type("builtins.eval")
+        assert "outside allowlist" in exc_info.value.errors[0]
+        assert "builtins.eval" in exc_info.value.errors[0]
+
+
+class TestLoadModelTypeReservedKeys:
+    """AC11 — classes declaring ``__ref__`` or ``__type__`` fields are rejected."""
+
+    def test_ref_key_collision_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        colliding_model = _model_with_reserved_field(REF_KEY)
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_1_ref", CollidingRefModel=colliding_model
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type(f"{module_name}.CollidingRefModel")
+
+        message = exc_info.value.errors[0]
+        assert "reserved ref-sentinel fields" in message
+        assert REF_KEY in message
+
+    def test_type_key_collision_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        colliding_model = _model_with_reserved_field(TYPE_KEY)
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_15_1_type",
+            CollidingTypeModel=colliding_model,
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type(f"{module_name}.CollidingTypeModel")
+
+        message = exc_info.value.errors[0]
+        assert "reserved ref-sentinel fields" in message
+        assert TYPE_KEY in message
+
+
+class TestLoadModelTypeNonBaseModel:
+    """AC12 — non-BaseModel classes are rejected."""
+
+    def test_rejects_dataclass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        @dataclass
+        class NotAModel:
+            x: int = 0
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_1_notmodel", NotAModel=NotAModel
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type(f"{module_name}.NotAModel")
+
+        assert "is not a Pydantic BaseModel subclass" in exc_info.value.errors[0]
+
+    def test_rejects_plain_function(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def some_function() -> None:  # noqa: ANN401 — irrelevant; test fixture
+            return None
+
+        module_name = register_akgentic_test_module(
+            monkeypatch, "tests_fixture_15_1_fn", some_function=some_function
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type(f"{module_name}.some_function")
+
+        assert "is not a Pydantic BaseModel subclass" in exc_info.value.errors[0]
+
+
+class TestLoadModelTypeHappyPath:
+    """AC13 — a real akgentic.* BaseModel class resolves by identity."""
+
+    def test_loads_agent_card(self) -> None:
+        from akgentic.core.agent_card import AgentCard
+
+        result = load_model_type("akgentic.core.agent_card.AgentCard")
+        assert result is AgentCard

--- a/tests/v2/test_validate_delete.py
+++ b/tests/v2/test_validate_delete.py
@@ -1,0 +1,122 @@
+"""Tests for ``akgentic.catalog.resolver.validate_delete`` — AC26 through AC29."""
+
+from __future__ import annotations
+
+from akgentic.catalog.resolver import validate_delete
+
+from .conftest import FakeEntryRepository, make_entry
+
+
+class TestNotFound:
+    """AC26 — target missing → single-element list with ``"not found"``."""
+
+    def test_missing_target_returns_not_found_message(self) -> None:
+        repo = FakeEntryRepository()
+        result = validate_delete("ns-1", "missing-id", repo)
+        assert len(result) == 1
+        assert "not found" in result[0]
+        assert "ns-1" in result[0]
+        assert "missing-id" in result[0]
+
+
+class TestNoReferrers:
+    """AC27 — existing entry with no inbound refs → empty list (safe to delete)."""
+
+    def test_no_inbound_refs_returns_empty(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="target", namespace="ns-1", payload={"v": 1}))
+        result = validate_delete("ns-1", "target", repo)
+        assert result == []
+
+
+class TestOneReferrer:
+    """AC28 — single inbound referrer → one blocker message."""
+
+    def test_single_referrer_blocks(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="target", namespace="ns-1", payload={"v": 1}))
+        repo.put(
+            make_entry(
+                id="ref-1",
+                kind="agent",
+                namespace="ns-1",
+                payload={"ptr": {"__ref__": "target"}},
+            )
+        )
+        result = validate_delete("ns-1", "target", repo)
+        assert len(result) == 1
+        msg = result[0]
+        assert "ref-1" in msg
+        assert "agent" in msg
+        assert "target" in msg
+        assert "ns-1" in msg
+
+
+class TestMultipleReferrers:
+    """AC28 — multiple referrers → one message each, order mirrors find_references."""
+
+    def test_multiple_referrers_all_listed(self) -> None:
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="target", namespace="ns-1", payload={"v": 1}))
+        # Insert in a deterministic order — FakeEntryRepository.find_references
+        # returns in insertion (dict) order.
+        repo.put(
+            make_entry(
+                id="ref-a",
+                kind="team",
+                namespace="ns-1",
+                payload={"ptr": {"__ref__": "target"}},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="ref-b",
+                kind="agent",
+                namespace="ns-1",
+                payload={"ptr": {"__ref__": "target"}},
+            )
+        )
+        result = validate_delete("ns-1", "target", repo)
+        assert len(result) == 2
+        # Order mirrors find_references' output (insertion order for the fake).
+        assert "ref-a" in result[0]
+        assert "team" in result[0]
+        assert "ref-b" in result[1]
+        assert "agent" in result[1]
+
+
+class TestUniformRule:
+    """AC29 — no branching on ``user_id``, ``parent_namespace``, or ``kind``."""
+
+    def test_enterprise_target_with_user_inbound_blocks(self) -> None:
+        """Enterprise entry (user_id=None) with a user-owned inbound ref is blocked."""
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="target", namespace="ns-shared", user_id=None, payload={"v": 1}))
+        repo.put(
+            make_entry(
+                id="user-ref",
+                kind="agent",
+                namespace="ns-shared",
+                user_id="user-42",
+                payload={"ptr": {"__ref__": "target"}},
+            )
+        )
+        result = validate_delete("ns-shared", "target", repo)
+        assert len(result) == 1
+        assert "user-ref" in result[0]
+        assert "ns-shared" in result[0]
+
+    def test_cross_namespace_inbound_is_not_consulted(self) -> None:
+        """A ref in namespace M must never count against a delete in namespace N."""
+        repo = FakeEntryRepository()
+        repo.put(make_entry(id="target", namespace="ns-N", payload={"v": 1}))
+        repo.put(
+            make_entry(
+                id="ref-in-M",
+                kind="agent",
+                namespace="ns-M",
+                payload={"ptr": {"__ref__": "target"}},
+            )
+        )
+        result = validate_delete("ns-N", "target", repo)
+        assert result == []

--- a/tests/v2/test_yaml_entry_repo.py
+++ b/tests/v2/test_yaml_entry_repo.py
@@ -1,0 +1,656 @@
+"""Integration tests for ``YamlEntryRepository`` (Story 15.3).
+
+Covers AC3-AC23 (AC1-AC2 are importability checks validated by the module-load
+phase; AC24-AC28 are quality-gate ACs validated by pytest, ruff, mypy, and CI
+themselves). Every test uses pytest's ``tmp_path`` fixture for an isolated
+filesystem root — no shared state between tests.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from akgentic.catalog import YamlEntryRepository as PublicYamlEntryRepository
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.base import EntryRepository
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+from .conftest import make_entry
+
+# The annotated binding exercises mypy's structural-protocol check at module
+# load time (AC3); mypy strict must accept it without inheritance.
+_protocol_check: type[EntryRepository] = YamlEntryRepository
+
+
+class TestPackageReExport:
+    """AC2: the top-level package re-exports ``YamlEntryRepository``."""
+
+    def test_public_reexport_is_the_same_class(self) -> None:
+        """`from akgentic.catalog import YamlEntryRepository` resolves to the same class."""
+        assert PublicYamlEntryRepository is YamlEntryRepository
+
+
+class TestProtocolConformance:
+    """AC3: the repository satisfies ``EntryRepository`` structurally."""
+
+    def test_instance_exposes_every_protocol_method(self, tmp_path: Path) -> None:
+        """All seven protocol methods exist and are callable on a live instance."""
+        repo = YamlEntryRepository(tmp_path)
+        assert callable(repo.get)
+        assert callable(repo.put)
+        assert callable(repo.delete)
+        assert callable(repo.list)
+        assert callable(repo.list_by_namespace)
+        assert callable(repo.get_by_kind)
+        assert callable(repo.find_references)
+
+
+class TestConstruction:
+    """AC4: constructor signature and lazy-create semantics."""
+
+    def test_construct_with_missing_root_does_not_create_directory(self, tmp_path: Path) -> None:
+        """Root dir is created only on first write, not in ``__init__``."""
+        missing = tmp_path / "does-not-exist"
+        assert not missing.exists()
+        repo = YamlEntryRepository(missing)
+        assert not missing.exists()
+        # `root` attribute round-trips as Path (not string-coerced).
+        assert isinstance(repo._root, Path)
+        assert repo._root == missing
+
+
+class TestPutWrites:
+    """AC5-AC9: put writes, upsert, kind-change move, verbatim serialization."""
+
+    def test_put_creates_file_at_namespace_kind_id_path(self, tmp_path: Path) -> None:
+        """AC5: put writes to root/{namespace}/{kind}/{id}.yaml."""
+        repo = YamlEntryRepository(tmp_path)
+        entry = make_entry(
+            id="assistant",
+            kind="agent",
+            namespace="team-abc",
+            payload={"role": "assistant"},
+        )
+        repo.put(entry)
+        path = tmp_path / "team-abc" / "agent" / "assistant.yaml"
+        assert path.exists()
+        on_disk = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert Entry.model_validate(on_disk) == entry
+
+    def test_put_returns_stored_entry_equal_to_input(self, tmp_path: Path) -> None:
+        """AC6: ``put`` returns an ``Entry`` equal to the input."""
+        repo = YamlEntryRepository(tmp_path)
+        entry = make_entry(namespace="ns", id="e1", kind="tool")
+        returned = repo.put(entry)
+        assert returned == entry
+
+    def test_put_is_upsert_for_same_namespace_id_and_kind(self, tmp_path: Path) -> None:
+        """AC7: repeat ``put`` with the same (namespace, id, kind) overwrites."""
+        repo = YamlEntryRepository(tmp_path)
+        first = make_entry(
+            namespace="ns",
+            id="entry",
+            kind="tool",
+            payload={"v": 1},
+        )
+        second = make_entry(
+            namespace="ns",
+            id="entry",
+            kind="tool",
+            payload={"v": 2},
+        )
+        repo.put(first)
+        repo.put(second)
+        got = repo.get("ns", "entry")
+        assert got is not None
+        assert got.payload == {"v": 2}
+
+    def test_put_kind_change_moves_file_and_prunes_old_kind_dir(self, tmp_path: Path) -> None:
+        """AC8: changing kind removes the old file and the empty old kind dir."""
+        repo = YamlEntryRepository(tmp_path)
+        old = make_entry(namespace="ns", id="assistant", kind="agent")
+        new = make_entry(namespace="ns", id="assistant", kind="tool")
+        repo.put(old)
+        old_path = tmp_path / "ns" / "agent" / "assistant.yaml"
+        assert old_path.exists()
+        repo.put(new)
+        assert not old_path.exists()
+        # The old kind dir was empty, so it was pruned.
+        assert not (tmp_path / "ns" / "agent").exists()
+        new_path = tmp_path / "ns" / "tool" / "assistant.yaml"
+        assert new_path.exists()
+        got = repo.get("ns", "assistant")
+        assert got is not None
+        assert got.kind == "tool"
+
+    def test_put_writes_payload_with_ref_marker_verbatim(self, tmp_path: Path) -> None:
+        """AC9: ``__ref__`` markers survive on disk byte-for-byte after YAML parse."""
+        repo = YamlEntryRepository(tmp_path)
+        entry = make_entry(
+            namespace="ns",
+            id="e1",
+            kind="agent",
+            payload={"config": {"__ref__": "target-id"}},
+        )
+        repo.put(entry)
+        path = tmp_path / "ns" / "agent" / "e1.yaml"
+        on_disk = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert on_disk["payload"] == {"config": {"__ref__": "target-id"}}
+
+
+class TestGet:
+    """AC10: ``get`` returns hit, miss, or wrong-namespace miss."""
+
+    def test_get_returns_stored_entry(self, tmp_path: Path) -> None:
+        """Hit: a stored (namespace, id) returns the exact entry."""
+        repo = YamlEntryRepository(tmp_path)
+        entry = make_entry(namespace="team-abc", id="assistant", kind="agent")
+        repo.put(entry)
+        assert repo.get("team-abc", "assistant") == entry
+
+    def test_get_missing_id_returns_none(self, tmp_path: Path) -> None:
+        """Miss: unknown id in a known namespace returns None."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        assert repo.get("team-abc", "unknown") is None
+
+    def test_get_wrong_namespace_returns_none(self, tmp_path: Path) -> None:
+        """Namespace isolation: same id in a different namespace returns None."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        assert repo.get("other-ns", "assistant") is None
+
+    def test_get_on_missing_namespace_dir_returns_none(self, tmp_path: Path) -> None:
+        """Missing namespace directory does not raise; returns None."""
+        repo = YamlEntryRepository(tmp_path)
+        assert repo.get("never-materialised", "x") is None
+
+
+class TestDelete:
+    """AC11, AC12: delete removes file, prunes empty dirs, no-op on miss."""
+
+    def test_delete_removes_file_and_all_empty_parents_up_to_root(self, tmp_path: Path) -> None:
+        """AC11: a lone entry's delete prunes kind dir and namespace dir."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        repo.delete("team-abc", "assistant")
+        assert not (tmp_path / "team-abc" / "agent" / "assistant.yaml").exists()
+        assert not (tmp_path / "team-abc" / "agent").exists()
+        assert not (tmp_path / "team-abc").exists()
+        # Root is preserved.
+        assert tmp_path.exists()
+
+    def test_delete_preserves_sibling_kind_and_namespace_dirs(self, tmp_path: Path) -> None:
+        """AC11: deleting one entry with a sibling leaves namespace + sibling dir."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        repo.put(make_entry(namespace="team-abc", id="workspace", kind="tool"))
+        repo.delete("team-abc", "assistant")
+        assert not (tmp_path / "team-abc" / "agent").exists()
+        assert (tmp_path / "team-abc" / "tool" / "workspace.yaml").exists()
+        assert (tmp_path / "team-abc").exists()
+
+    def test_delete_missing_entry_is_noop(self, tmp_path: Path) -> None:
+        """AC12: delete with no matching file completes without raising."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.delete("team-abc", "missing")  # Should not raise.
+        # Also works when namespace dir exists but file does not.
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        repo.delete("team-abc", "missing")  # Should not raise.
+        # The real entry is still there.
+        assert repo.get("team-abc", "assistant") is not None
+
+
+class TestList:
+    """AC13: every EntryQuery filter is applied; combines with AND."""
+
+    def _seed(self, repo: YamlEntryRepository) -> None:
+        """Seed two namespaces with varied kinds, user_ids, lineage, descriptions."""
+        repo.put(
+            make_entry(
+                namespace="ns-a",
+                id="a1",
+                kind="agent",
+                user_id="alice",
+                description="alpha one",
+            )
+        )
+        repo.put(
+            make_entry(
+                namespace="ns-a",
+                id="a2",
+                kind="tool",
+                user_id=None,
+                description="alpha two",
+            )
+        )
+        repo.put(
+            make_entry(
+                namespace="ns-b",
+                id="b1",
+                kind="agent",
+                user_id="bob",
+                parent_namespace="ns-a",
+                parent_id="a1",
+                description="beta one",
+            )
+        )
+
+    def test_list_filter_by_namespace(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(namespace="ns-a"))
+        assert sorted(e.id for e in got) == ["a1", "a2"]
+
+    def test_list_filter_by_kind(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(kind="agent"))
+        assert sorted(e.id for e in got) == ["a1", "b1"]
+
+    def test_list_filter_by_id_is_exact_match(self, tmp_path: Path) -> None:
+        """AC13: ``id`` is exact match, not substring."""
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(id="a1"))
+        assert len(got) == 1
+        assert got[0].id == "a1"
+        # Substring of "a1" — should return nothing.
+        assert repo.list(EntryQuery(id="a")) == []
+
+    def test_list_filter_by_user_id_exact(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(user_id="alice"))
+        assert sorted(e.id for e in got) == ["a1"]
+
+    def test_list_filter_user_id_set_true_keeps_only_scoped(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(user_id_set=True))
+        assert sorted(e.id for e in got) == ["a1", "b1"]
+
+    def test_list_filter_user_id_set_false_keeps_only_global(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(user_id_set=False))
+        assert sorted(e.id for e in got) == ["a2"]
+
+    def test_list_filter_by_parent_pair(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(parent_namespace="ns-a", parent_id="a1"))
+        assert sorted(e.id for e in got) == ["b1"]
+
+    def test_list_filter_description_contains_substring(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(description_contains="beta"))
+        assert [e.id for e in got] == ["b1"]
+
+    def test_list_combined_filters_use_and_semantics(self, tmp_path: Path) -> None:
+        """AC13: multiple fields combine with AND."""
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery(namespace="ns-a", kind="tool", user_id_set=False))
+        assert [e.id for e in got] == ["a2"]
+
+    def test_list_no_filters_spans_every_namespace(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        self._seed(repo)
+        got = repo.list(EntryQuery())
+        assert sorted(e.id for e in got) == ["a1", "a2", "b1"]
+
+    def test_list_with_no_root_dir_returns_empty(self, tmp_path: Path) -> None:
+        missing = tmp_path / "missing-root"
+        repo = YamlEntryRepository(missing)
+        assert repo.list(EntryQuery()) == []
+
+
+class TestListByNamespace:
+    """AC14: return every entry in a namespace regardless of kind."""
+
+    def test_returns_every_kind_in_namespace(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="team", kind="team"))
+        repo.put(make_entry(namespace="team-abc", id="manager", kind="agent"))
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        repo.put(make_entry(namespace="team-abc", id="workspace", kind="tool"))
+        repo.put(make_entry(namespace="team-abc", id="greeting", kind="prompt"))
+        got = repo.list_by_namespace("team-abc")
+        assert {e.id for e in got} == {
+            "team",
+            "manager",
+            "assistant",
+            "workspace",
+            "greeting",
+        }
+        assert len(got) == 5
+
+    def test_missing_namespace_returns_empty_list(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        assert repo.list_by_namespace("never-materialised") == []
+
+
+class TestGetByKind:
+    """AC15: get_by_kind returns a single entry, first in sorted order, or None."""
+
+    def test_returns_singleton_when_exactly_one(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        entry = make_entry(namespace="team-abc", id="team", kind="team")
+        repo.put(entry)
+        got = repo.get_by_kind("team-abc", "team")
+        assert got == entry
+
+    def test_returns_none_when_kind_dir_absent(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        # Put an entry of a different kind so the namespace dir exists.
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        assert repo.get_by_kind("team-abc", "team") is None
+
+    def test_returns_none_when_namespace_dir_absent(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        assert repo.get_by_kind("never-materialised", "team") is None
+
+    def test_returns_alphabetically_first_on_duplicate_kind(self, tmp_path: Path) -> None:
+        """AC15: multiple files in a kind dir return the first by filename sort."""
+        repo = YamlEntryRepository(tmp_path)
+        # Deliberately write two team entries (corruption state) to the same kind dir.
+        # ``put`` would never produce this because a single (namespace, id) is the
+        # key — we write by hand to exercise the read path.
+        kind_dir = tmp_path / "team-abc" / "team"
+        kind_dir.mkdir(parents=True)
+        team_b = make_entry(namespace="team-abc", id="team-b", kind="team")
+        team_a = make_entry(namespace="team-abc", id="team-a", kind="team")
+        for entry in (team_a, team_b):
+            path = kind_dir / f"{entry.id}.yaml"
+            path.write_text(
+                yaml.dump(
+                    entry.model_dump(mode="json"),
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                ),
+                encoding="utf-8",
+            )
+        got = repo.get_by_kind("team-abc", "team")
+        assert got is not None
+        assert got.id == "team-a"  # alphabetically first
+
+
+class TestFindReferences:
+    """AC16: walk every payload, match dict __ref__ keys, namespace-isolated."""
+
+    def test_finds_ref_at_nested_dict_depth(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-1",
+                kind="agent",
+                payload={"config": {"model_cfg": {"__ref__": "id_gpt_41"}}},
+            )
+        )
+        got = repo.find_references("team-abc", "id_gpt_41")
+        assert [e.id for e in got] == ["agent-1"]
+
+    def test_finds_ref_inside_list(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-2",
+                kind="agent",
+                payload={"config": {"tools": [{"__ref__": "id_gpt_41"}]}},
+            )
+        )
+        got = repo.find_references("team-abc", "id_gpt_41")
+        assert [e.id for e in got] == ["agent-2"]
+
+    def test_finds_multiple_references(self, tmp_path: Path) -> None:
+        """AC16: two refs in one namespace return two entries (unordered)."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-1",
+                kind="agent",
+                payload={"config": {"model_cfg": {"__ref__": "id_gpt_41"}}},
+            )
+        )
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-2",
+                kind="agent",
+                payload={"config": {"tools": [{"__ref__": "id_gpt_41"}]}},
+            )
+        )
+        got = repo.find_references("team-abc", "id_gpt_41")
+        assert sorted(e.id for e in got) == ["agent-1", "agent-2"]
+
+    def test_does_not_match_wrong_target_id(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-1",
+                kind="agent",
+                payload={"config": {"model_cfg": {"__ref__": "other-target"}}},
+            )
+        )
+        assert repo.find_references("team-abc", "id_gpt_41") == []
+
+    def test_does_not_match_raw_string_payload(self, tmp_path: Path) -> None:
+        """AC16: a plain string equal to ``__ref__`` is not a match (must be dict key)."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-1",
+                kind="agent",
+                payload={"note": "__ref__", "other": "id_gpt_41"},
+            )
+        )
+        assert repo.find_references("team-abc", "id_gpt_41") == []
+
+    def test_namespace_isolation(self, tmp_path: Path) -> None:
+        """Refs in another namespace are not returned."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(
+            make_entry(
+                namespace="team-abc",
+                id="agent-1",
+                kind="agent",
+                payload={"config": {"model_cfg": {"__ref__": "id_gpt_41"}}},
+            )
+        )
+        repo.put(
+            make_entry(
+                namespace="other-ns",
+                id="agent-2",
+                kind="agent",
+                payload={"config": {"model_cfg": {"__ref__": "id_gpt_41"}}},
+            )
+        )
+        got = repo.find_references("team-abc", "id_gpt_41")
+        assert [e.id for e in got] == ["agent-1"]
+
+
+class TestDuplicateDetection:
+    """AC17, AC18: duplicate stems and path/body mismatches raise on scan."""
+
+    def _write_yaml(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            yaml.dump(payload, default_flow_style=False, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+
+    def test_duplicate_id_across_kinds_raises_on_first_read(self, tmp_path: Path) -> None:
+        """AC17: same id under agent/ and tool/ raises CatalogValidationError."""
+        repo = YamlEntryRepository(tmp_path)
+        agent = make_entry(namespace="team-abc", id="assistant", kind="agent")
+        tool = make_entry(namespace="team-abc", id="assistant", kind="tool")
+        self._write_yaml(
+            tmp_path / "team-abc" / "agent" / "assistant.yaml",
+            agent.model_dump(mode="json"),
+        )
+        self._write_yaml(
+            tmp_path / "team-abc" / "tool" / "assistant.yaml",
+            tool.model_dump(mode="json"),
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            repo.list_by_namespace("team-abc")
+        msg = str(exc_info.value)
+        assert "Duplicate id 'assistant'" in msg
+        assert str(tmp_path / "team-abc" / "agent" / "assistant.yaml") in msg
+        assert str(tmp_path / "team-abc" / "tool" / "assistant.yaml") in msg
+
+    def test_namespace_mismatch_in_file_body_raises(self, tmp_path: Path) -> None:
+        """AC18: file under ns-a/ whose YAML says namespace: ns-b raises."""
+        repo = YamlEntryRepository(tmp_path)
+        bad = make_entry(namespace="different-ns", id="assistant", kind="agent")
+        path = tmp_path / "team-abc" / "agent" / "assistant.yaml"
+        self._write_yaml(path, bad.model_dump(mode="json"))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            repo.list_by_namespace("team-abc")
+        msg = str(exc_info.value)
+        assert str(path) in msg
+        assert "different-ns" in msg
+        assert "team-abc" in msg
+
+    def test_kind_mismatch_in_file_body_raises(self, tmp_path: Path) -> None:
+        """AC18: file under agent/ whose YAML says kind: tool raises."""
+        repo = YamlEntryRepository(tmp_path)
+        bad = make_entry(namespace="team-abc", id="assistant", kind="tool")
+        path = tmp_path / "team-abc" / "agent" / "assistant.yaml"
+        self._write_yaml(path, bad.model_dump(mode="json"))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            repo.list_by_namespace("team-abc")
+        msg = str(exc_info.value)
+        assert str(path) in msg
+        assert "tool" in msg
+        assert "agent" in msg
+
+    def test_id_mismatch_between_file_body_and_stem_raises(self, tmp_path: Path) -> None:
+        """AC18: file body id != filename stem raises."""
+        repo = YamlEntryRepository(tmp_path)
+        bad = make_entry(namespace="team-abc", id="different-id", kind="agent")
+        path = tmp_path / "team-abc" / "agent" / "assistant.yaml"
+        self._write_yaml(path, bad.model_dump(mode="json"))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            repo.list_by_namespace("team-abc")
+        msg = str(exc_info.value)
+        assert str(path) in msg
+        assert "different-id" in msg
+        assert "assistant" in msg
+
+
+class TestEmptyYaml:
+    """AC19: empty files are skipped with a warning, not an error."""
+
+    def test_empty_file_skipped_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="team-abc", id="assistant", kind="agent"))
+        # Hand-write an empty file alongside the valid one.
+        empty_path = tmp_path / "team-abc" / "agent" / "empty.yaml"
+        empty_path.write_text("", encoding="utf-8")
+        repo.reload()  # Invalidate cache so the next read rescans.
+        with caplog.at_level(logging.WARNING):
+            got = repo.list_by_namespace("team-abc")
+        assert [e.id for e in got] == ["assistant"]
+        assert "empty YAML file skipped" in caplog.text
+        assert str(empty_path) in caplog.text
+
+    def test_whitespace_only_file_skipped(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        path = tmp_path / "team-abc" / "agent" / "ws.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("   \n   \n", encoding="utf-8")
+        assert repo.list_by_namespace("team-abc") == []
+
+    def test_tilde_only_file_skipped(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        path = tmp_path / "team-abc" / "agent" / "nil.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("~\n", encoding="utf-8")
+        assert repo.list_by_namespace("team-abc") == []
+
+
+class TestRoundTrip:
+    """AC20, AC21: no re-dumping; ref markers and __type__ round-trip at depth."""
+
+    def test_mixed_inline_and_ref_payload_round_trips(self, tmp_path: Path) -> None:
+        """AC20: inline + ref payload survives put/get byte-exactly (dict equality)."""
+        repo = YamlEntryRepository(tmp_path)
+        payload: dict[str, Any] = {
+            "config": {
+                "model_cfg": {"__ref__": "id_gpt_41"},
+                "name": "Helper",
+                "description": "",  # explicit empty must survive (no dropping)
+            }
+        }
+        entry = make_entry(namespace="ns", id="agent", kind="agent", payload=payload)
+        repo.put(entry)
+        got = repo.get("ns", "agent")
+        assert got is not None
+        assert got.payload == payload
+
+    def test_nested_type_key_plus_ref_round_trip(self, tmp_path: Path) -> None:
+        """AC21: __type__ alongside __ref__ survives in list positions."""
+        repo = YamlEntryRepository(tmp_path)
+        payload: dict[str, Any] = {
+            "config": {
+                "tools": [
+                    {"__ref__": "id_tool_a"},
+                    {"__ref__": "id_tool_b", "__type__": "akgentic.tool.ToolCard"},
+                ]
+            }
+        }
+        entry = make_entry(namespace="ns", id="agent", kind="agent", payload=payload)
+        repo.put(entry)
+        got = repo.get("ns", "agent")
+        assert got is not None
+        assert got.payload == payload
+
+
+class TestReadConsistency:
+    """AC22, AC23: writes invalidate cache; reload is a public invalidator."""
+
+    def test_second_put_is_visible_on_next_read(self, tmp_path: Path) -> None:
+        """AC22: put -> read -> put -> read yields the second put's state."""
+        repo = YamlEntryRepository(tmp_path)
+        first = make_entry(namespace="ns", id="e1", kind="tool", payload={"v": 1})
+        repo.put(first)
+        read1 = repo.get("ns", "e1")
+        assert read1 is not None and read1.payload == {"v": 1}
+        second = make_entry(namespace="ns", id="e1", kind="tool", payload={"v": 2})
+        repo.put(second)
+        read2 = repo.get("ns", "e1")
+        assert read2 is not None and read2.payload == {"v": 2}
+
+    def test_reload_with_no_args_is_callable(self, tmp_path: Path) -> None:
+        """AC23: reload(None) works and does not raise."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(namespace="ns", id="e1", kind="tool"))
+        repo.reload()
+        # After reload, reads still work.
+        assert repo.get("ns", "e1") is not None
+
+    def test_reload_with_namespace_is_callable(self, tmp_path: Path) -> None:
+        """AC23: reload("ns") works and does not raise (missing key is fine)."""
+        repo = YamlEntryRepository(tmp_path)
+        repo.reload("never-touched")  # Missing-key branch.
+        repo.put(make_entry(namespace="ns", id="e1", kind="tool"))
+        repo.reload("ns")
+        assert repo.get("ns", "e1") is not None


### PR DESCRIPTION
Umbrella PR for Epic 15 — Catalog v2: Unified Entry, Resolver, Repositories. This PR is stacked: base is `master`; subsequent epic umbrella PRs (16, 17, 19) will stack on top of this branch.

## Stories

- [x] 15-1-entry-model-errors-and-allowlist-loader (Relates to #105)
- [x] 15-2-populate-refs-resolver-with-cycle-detection (Relates to #108)
- [x] 15-3-yaml-repository-single-namespace-file-per-entry (Relates to #109)
- [x] 15-4-mongo-repository-single-collection-compound-id (Relates to #110)
- [x] 15-5-catalog-service-crud-clone-resolve-load-team (Relates to #111)

## Review status

**15-1 — PASS** (Rex review, 2026-04-20)

Verdict: no fix-worthy issues found. The v2 type skeleton landed clean:

- `Entry`, `EntryKind`, `AllowlistedPath`, `NonEmptyStr` re-export in `models/entry.py`.
- `EntryQuery` (with tri-state `user_id_set`) and `CloneRequest` in `models/queries.py`.
- `EntryRepository` `typing.Protocol` in `repositories/base.py` alongside the v1 ABCs.
- `REF_KEY`, `TYPE_KEY`, `load_model_type` with the three-check sequence in `resolver.py`.
- `__init__.py` re-exports the seven new v2 names while keeping all v1 names.
- Tests live under `tests/v2/` (49 new tests + 676 pre-existing v1 = 725 total).

All 21 ACs satisfied (AC21 waived per the local-only override). Two LOW-severity cosmetic notes (misdirected `# noqa: ANN401` on a fixture function, module-level smoke assertions in `test_entry.py`) are not fix-worthy.

- 15-2 review: PASS — all 34 ACs implemented; 789 tests pass; resolver.py at 100% line+branch coverage; lint + mypy clean; scope confined to `packages/akgentic-catalog/`.
- 15-3 review: PASS — all 28 ACs implemented; 839 tests pass; `yaml_entry_repo.py` at 97% line+branch coverage (total 92.95%); lint + mypy clean; scope confined to `packages/akgentic-catalog/`; no fixup commit required.
- 15-4 review: 1 MEDIUM fix applied — `_build_filter` silently overwrote the `user_id` exact-match clause when `user_id_set` was also set, breaking AND semantics and YAML parity. Extracted `_apply_user_id_clauses` emitting a conjunctive clause (exact match when both agree, `{"$in": []}` on the contradictory pair so the result matches YAML's zero-row outcome). Added two new Mongo-specific assertions and one parity scenario. All 896 tests pass; `mongo_entry_repo.py` at 100% line+branch coverage (total 93.18%); lint + mypy clean; scope confined to `packages/akgentic-catalog/`.
- 15-5 review: PASS — no fix-worthy issues. All 42 ACs covered; 977 tests pass (81 new); `catalog.py` at 94% line+branch coverage (total 93.24%); Pydantic discipline, atomicity, ownership, bootstrap, and ADR hygiene all clean; lint + mypy clean; scope confined to `packages/akgentic-catalog/`; no fixup commit required.

## Scope guard

All changes confined to `packages/akgentic-catalog/`.

## CI policy

Local verification only this run (pytest + ruff + mypy). CI gates are stripped per user override.

- `uv run pytest packages/akgentic-catalog/tests/ --cov=packages/akgentic-catalog/src --cov-fail-under=80` — 977 passed, coverage 93.24% (gate 80%).
- `uv run ruff check packages/akgentic-catalog/src packages/akgentic-catalog/tests` — all checks passed.
- `uv run mypy packages/akgentic-catalog/src` — no issues in 52 source files.

## Epic 15 slice complete

All five stories of Epic 15 (Catalog v2 — Unified Entry, Resolver, Repositories) have landed on this umbrella branch.

Story -> issue map:

| Story | Issue |
| --- | --- |
| 15-1 entry model, errors, allowlist loader | #105 |
| 15-2 populate_refs resolver with cycle detection | #108 |
| 15-3 YAML repository (single namespace file per entry) | #109 |
| 15-4 Mongo repository (single collection, compound id) | #110 |
| 15-5 Catalog service (CRUD, clone, resolve, load_team) | #111 |

Rex fixup count per story:

| Story | Fixups |
| --- | --- |
| 15-1 | 0 |
| 15-2 | 0 |
| 15-3 | 0 |
| 15-4 | 1 (MEDIUM — Mongo `_build_filter` AND semantics for `user_id` / `user_id_set`) |
| 15-5 | 0 |

Final local gate: 977 tests pass, 93.24% coverage, ruff + mypy green, scope confined to `packages/akgentic-catalog/`.

Epic 16 (REST API & Schema) umbrella PR will stack on this branch.
