### PR TITLE
feat(catalog): epic 17 — Unified CLI (17-1 → 17-4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
 ]
 
 [project.scripts]
-ak-catalog = "akgentic.catalog.cli.main:app"
+ak-catalog = "akgentic.catalog.cli.v2:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -30,17 +30,15 @@ dynamic ``/{kind}`` family so literal paths take precedence over the
 from __future__ import annotations
 
 import logging
-import sys
 from typing import TYPE_CHECKING, Any
 
 import yaml
 from fastapi import APIRouter, HTTPException, Query, Request, Response
-from pydantic import BaseModel
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import CloneRequest, EntryQuery
-from akgentic.catalog.resolver import load_model_type
+from akgentic.catalog.resolver import enumerate_allowlisted_model_types, load_model_type
 from akgentic.catalog.validation import NamespaceValidationReport
 
 if TYPE_CHECKING:
@@ -121,7 +119,7 @@ async def list_model_types() -> list[str]:
     known-existing" (see architecture shard 07). AC18.
     """
     logger.debug("GET /catalog/model_types")
-    return _enumerate_allowlisted_model_types()
+    return enumerate_allowlisted_model_types()
 
 
 @router.get("/team/{namespace}/resolve")
@@ -174,9 +172,7 @@ async def import_namespace(request: Request) -> list[Entry]:
     try:
         yaml.safe_load(yaml_text)
     except yaml.YAMLError as exc:
-        raise HTTPException(
-            status_code=422, detail=f"failed to parse bundle YAML: {exc}"
-        ) from exc
+        raise HTTPException(status_code=422, detail=f"failed to parse bundle YAML: {exc}") from exc
     return _get_catalog().import_namespace_yaml(yaml_text)
 
 
@@ -216,9 +212,7 @@ async def validate_namespace_post(request: Request) -> NamespaceValidationReport
     try:
         yaml.safe_load(yaml_text)
     except yaml.YAMLError as exc:
-        raise HTTPException(
-            status_code=422, detail=f"failed to parse bundle YAML: {exc}"
-        ) from exc
+        raise HTTPException(status_code=422, detail=f"failed to parse bundle YAML: {exc}") from exc
     return _get_catalog().validate_namespace_yaml(yaml_text)
 
 
@@ -345,43 +339,3 @@ async def delete_entry(
         raise EntryNotFoundError(f"Entry ({namespace}, {id}, kind={kind}) not found")
     catalog.delete(namespace, id)
     return Response(status_code=204)
-
-
-# --- Helpers ----------------------------------------------------------------
-
-
-def _enumerate_allowlisted_model_types() -> list[str]:
-    """Enumerate allowlisted ``BaseModel`` subclasses loaded under ``akgentic.*``.
-
-    Walks a snapshot of ``sys.modules`` to avoid mutation-during-iteration
-    issues. Any per-module introspection error is swallowed — optional
-    dependencies may be absent, partially imported, or raise on attribute
-    access. ``load_model_type`` is used as the authoritative allowlist +
-    BaseModel + reserved-key gate.
-    """
-    results: set[str] = set()
-    modules_snapshot = list(sys.modules.items())
-    for module_name, module in modules_snapshot:
-        if not module_name.startswith("akgentic.") or module is None:
-            continue
-        _collect_allowlisted(module, results)
-    return sorted(results)
-
-
-def _collect_allowlisted(module: Any, results: set[str]) -> None:
-    """Add every allowlisted ``BaseModel`` from ``module`` into ``results``."""
-    try:
-        items = list(vars(module).items())
-    except Exception:  # noqa: BLE001 — defensive; partially imported modules
-        return
-    for _name, value in items:
-        if not isinstance(value, type) or not issubclass(value, BaseModel):
-            continue
-        path = f"{value.__module__}.{value.__name__}"
-        if not path.startswith("akgentic.") or path in results:
-            continue
-        try:
-            load_model_type(path)
-        except Exception:  # noqa: BLE001 — swallow reserved-key or import errors
-            continue
-        results.add(path)

--- a/src/akgentic/catalog/cli/v2.py
+++ b/src/akgentic/catalog/cli/v2.py
@@ -784,6 +784,13 @@ def _require_non_empty_namespace(value: str) -> str:
     return value
 
 
+def _require_non_empty_namespace_optional(value: str | None) -> str | None:
+    """Typer callback — tolerates an omitted ``--namespace`` (passes ``None`` through)."""
+    if value is None:
+        return None
+    return _require_non_empty_namespace(value)
+
+
 def _render_global_errors(table: Table, errors: _list[str]) -> None:
     """Fill ``table`` with one row per global error, or a placeholder when empty."""
     if not errors:
@@ -890,17 +897,28 @@ def _import_persistence_mode(catalog: Catalog, yaml_text: str) -> None:
     err_console.print(f"imported {len(persisted)} entries into namespace {ns}")
 
 
+def _emit_validation_failure(report: NamespaceValidationReport) -> None:
+    """Print the canonical validation-failure summary line to stderr and exit 1.
+
+    Shared between the bundle ``import --dry-run`` verb (Story 17.3) and the
+    root-level ``validate`` verb (Story 17.4) so both paths emit an identical
+    grep-able stderr line. The caller is responsible for rendering the full
+    report to stdout before invoking this helper.
+    """
+    global_count = len(report.global_errors)
+    entry_count = sum(1 for i in report.entry_issues if i.errors)
+    err_console.print(
+        f"validation failed: {global_count} global error(s), {entry_count} entry issue(s)"
+    )
+    raise typer.Exit(code=1)
+
+
 def _import_dry_run_mode(catalog: Catalog, yaml_text: str, fmt: str) -> None:
     """Run ``catalog.validate_namespace_yaml``; render the report; derive exit code."""
     report = catalog.validate_namespace_yaml(yaml_text)
     _render_validation_report(report, fmt)
     if not report.ok:
-        global_count = len(report.global_errors)
-        entry_count = sum(1 for i in report.entry_issues if i.errors)
-        err_console.print(
-            f"validation failed: {global_count} global error(s), {entry_count} entry issue(s)"
-        )
-        raise typer.Exit(code=1)
+        _emit_validation_failure(report)
 
 
 @app.command("import")
@@ -932,6 +950,70 @@ def _import_cmd(
         _import_dry_run_mode(catalog, yaml_text, state.output_format)
         return
     _import_persistence_mode(catalog, yaml_text)
+
+
+# --------------------------------------------------------------------------- #
+# Namespace validation verb (Story 17.4): validate
+# --------------------------------------------------------------------------- #
+
+
+def _validate_persisted(catalog: Catalog, namespace: str, fmt: str) -> None:
+    """Run ``catalog.validate_namespace`` and derive CLI output + exit code."""
+    report = catalog.validate_namespace(namespace)
+    _render_validation_report(report, fmt)
+    if not report.ok:
+        _emit_validation_failure(report)
+
+
+def _validate_bundle(catalog: Catalog, bundle_file: Path, fmt: str) -> None:
+    """Read a bundle file and dry-run-validate it via ``validate_namespace_yaml``."""
+    yaml_text = _read_bundle_text(bundle_file)
+    report = catalog.validate_namespace_yaml(yaml_text)
+    _render_validation_report(report, fmt)
+    if not report.ok:
+        _emit_validation_failure(report)
+
+
+@app.command("validate")
+def _validate_cmd(
+    ctx: typer.Context,
+    bundle_file: Path | None = typer.Argument(
+        None,
+        exists=False,
+        help="Path to a bundle YAML file (dry-run flavor).",
+    ),
+    namespace: str | None = typer.Option(
+        None,
+        "--namespace",
+        help="Persisted namespace to validate.",
+        callback=_require_non_empty_namespace_optional,
+    ),
+) -> None:
+    """Validate a namespace — persisted state or dry-run bundle.
+
+    Exactly one of ``--namespace <ns>`` or a positional ``<bundle-file>`` must
+    be supplied. The verb delegates to :meth:`Catalog.validate_namespace` or
+    :meth:`Catalog.validate_namespace_yaml` respectively; neither service
+    method raises, so the exit code is derived from ``report.ok`` alone
+    (``0`` when True, ``1`` when False). Usage errors (zero-or-both args,
+    missing / non-UTF-8 / malformed-YAML bundle file) exit 2 with a stderr
+    diagnostic.
+    """
+    if namespace is None and bundle_file is None:
+        err_console.print("validate requires either --namespace <ns> or a bundle file path")
+        raise typer.Exit(code=2)
+    if namespace is not None and bundle_file is not None:
+        err_console.print(
+            "validate accepts either --namespace <ns> or a bundle file path, not both"
+        )
+        raise typer.Exit(code=2)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    if namespace is not None:
+        _validate_persisted(catalog, namespace, state.output_format)
+        return
+    assert bundle_file is not None  # exclusivity guard above
+    _validate_bundle(catalog, bundle_file, state.output_format)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/akgentic/catalog/cli/v2.py
+++ b/src/akgentic/catalog/cli/v2.py
@@ -25,8 +25,9 @@ from rich.table import Table
 from akgentic.catalog.catalog import Catalog
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
-from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
+from akgentic.catalog.resolver import enumerate_allowlisted_model_types, load_model_type
 
 __all__ = ["app"]
 
@@ -524,6 +525,249 @@ _ENTRY_KINDS: tuple[EntryKind, ...] = ("team", "agent", "tool", "model", "prompt
 # Register one sub-app per EntryKind. The literal order matches EntryKind.
 for _kind in _ENTRY_KINDS:
     app.add_typer(_make_kind_app(_kind), name=_kind)
+
+
+# --------------------------------------------------------------------------- #
+# Generic resolved-model renderer (Story 17.2)
+# --------------------------------------------------------------------------- #
+
+
+def _dump_model_json(model: BaseModel) -> str:
+    """Return ``model.model_dump(mode='json')`` as a pretty-printed JSON string."""
+    return json.dumps(model.model_dump(mode="json"), indent=2)
+
+
+def _render_model(model: BaseModel, fmt: str) -> None:
+    """Render a resolved Pydantic ``BaseModel`` to stdout per ``fmt``.
+
+    ``table`` → two-column key/value table (``type`` + truncated ``payload``).
+    ``json`` → ``json.dumps(model.model_dump(mode='json'), indent=2)``.
+    ``yaml`` → ``yaml.safe_dump(model.model_dump(mode='json'), sort_keys=False)``.
+
+    Truncation (table only): JSON payload is trimmed to 4 KiB with a
+    ``… (N more chars)`` suffix when longer — mirroring ``_render_entry``.
+    """
+    if fmt == "json":
+        _stdout.print(_dump_model_json(model))
+        return
+    if fmt == "yaml":
+        _stdout.print(yaml.safe_dump(model.model_dump(mode="json"), sort_keys=False).rstrip("\n"))
+        return
+    type_path = f"{model.__class__.__module__}.{model.__class__.__name__}"
+    payload_json = _dump_model_json(model)
+    table = Table(title=f"model {type_path}", show_header=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    table.add_row("type", type_path)
+    if len(payload_json) > 4096:
+        kept = payload_json[:4096]
+        suffix = len(payload_json) - 4096
+        table.add_row("payload", f"{kept}… ({suffix} more chars)")
+    else:
+        table.add_row("payload", payload_json)
+    _stdout.print(table)
+
+
+# --------------------------------------------------------------------------- #
+# Graph verbs (Story 17.2): clone / references / resolve / load-team
+# --------------------------------------------------------------------------- #
+
+
+@app.command("clone")
+def _clone_cmd(
+    ctx: typer.Context,
+    src_namespace: str = typer.Option(..., "--src-namespace", help="Source namespace."),
+    src_id: str = typer.Option(..., "--src-id", help="Source entry id."),
+    dst_namespace: str = typer.Option(..., "--dst-namespace", help="Destination namespace."),
+    dst_user_id: str = typer.Option(
+        ...,
+        "--dst-user-id",
+        help="Destination user_id; empty string '' targets enterprise (user_id=None).",
+    ),
+) -> None:
+    """Deep-copy an entry tree into ``--dst-namespace`` (ADR-007 ownership semantics).
+
+    The empty-string sentinel ``--dst-user-id ""`` means "clone into
+    enterprise" — normalised to ``None`` before constructing ``CloneRequest``.
+    """
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    # Empty string is the canonical "enterprise" sentinel at the CLI boundary;
+    # CloneRequest.dst_user_id is NonEmptyStr | None and rejects empty strings.
+    normalized_user_id: str | None = dst_user_id if dst_user_id != "" else None
+    try:
+        req = CloneRequest(
+            src_namespace=src_namespace,
+            src_id=src_id,
+            dst_namespace=dst_namespace,
+            dst_user_id=normalized_user_id,
+        )
+    except ValidationError as exc:
+        err_console.print(f"validation error: {exc}")
+        raise typer.Exit(code=2) from None
+    try:
+        entry = catalog.clone(req.src_namespace, req.src_id, req.dst_namespace, req.dst_user_id)
+    except EntryNotFoundError as exc:
+        err_console.print(str(exc))
+        raise typer.Exit(code=1) from None
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_entry(entry, state.output_format)
+
+
+@app.command("references")
+def _references_cmd(
+    ctx: typer.Context,
+    id: str = typer.Argument(..., help="Target entry id."),
+    namespace: str = typer.Option(..., "--namespace", help="Namespace of the target entry."),
+) -> None:
+    """List entries in ``--namespace`` that reference ``<id>``.
+
+    The service's ``find_references`` is tolerant: a missing target id
+    yields an empty list, rendered as ``(no entries)`` / ``[]`` per format.
+    """
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        entries = catalog.find_references(namespace, id)
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_entries(entries, state.output_format)
+
+
+@app.command("resolve")
+def _resolve_cmd(
+    ctx: typer.Context,
+    kind: EntryKind = typer.Argument(..., help="Entry kind (team/agent/tool/model/prompt)."),
+    id: str = typer.Argument(..., help="Entry id."),
+    namespace: str = typer.Option(..., "--namespace", help="Entry namespace."),
+) -> None:
+    """Resolve a single entry into its fully-populated runtime ``BaseModel``.
+
+    The ``<kind>`` argument acts as a typo guard (same shape as ``get``):
+    a stored entry whose kind disagrees exits with code 1 rather than
+    silently resolving against the stored kind.
+    """
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        entry = catalog.get(namespace, id)
+    except EntryNotFoundError:
+        err_console.print(f"Entry ({namespace}, {id}, {kind}) not found")
+        raise typer.Exit(code=1) from None
+    if entry.kind != kind:
+        err_console.print(
+            f"Entry at (namespace={namespace}, id={id}) has kind={entry.kind}, expected {kind}"
+        )
+        raise typer.Exit(code=1)
+    try:
+        model = catalog.resolve_by_id(namespace, id)
+    except EntryNotFoundError as exc:
+        err_console.print(str(exc))
+        raise typer.Exit(code=1) from None
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_model(model, state.output_format)
+
+
+@app.command("load-team")
+def _load_team_cmd(
+    ctx: typer.Context,
+    namespace: str = typer.Option(..., "--namespace", help="Namespace to load the team from."),
+) -> None:
+    """Resolve the team entry in ``--namespace`` into a fully-populated ``TeamCard``."""
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        team = catalog.load_team(namespace)
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_model(team, state.output_format)
+
+
+# --------------------------------------------------------------------------- #
+# Schema-introspection verbs (Story 17.2)
+# --------------------------------------------------------------------------- #
+
+
+def _render_schema(schema: dict[str, Any], fmt: str) -> None:
+    """Render a JSON Schema dict. ``table`` falls through to JSON rendering.
+
+    Rationale: JSON Schema is inherently nested; a flat Rich table would be a
+    worse UX than the raw schema, so the ``table`` format is documented to
+    print pretty-printed JSON (same bytes as ``--format json``).
+    """
+    if fmt == "yaml":
+        print(yaml.safe_dump(schema, sort_keys=False).rstrip("\n"))
+        return
+    print(json.dumps(schema, indent=2))
+
+
+@app.command("schema")
+def _schema_cmd(
+    ctx: typer.Context,
+    model_type: str = typer.Argument(..., help="Dotted path of an allowlisted BaseModel class."),
+) -> None:
+    """Print the JSON Schema for an allowlisted Pydantic model class.
+
+    Delegates to :func:`akgentic.catalog.resolver.load_model_type`, which owns
+    the ``akgentic.*`` allowlist gate. ``ImportError`` / ``AttributeError``
+    raised by dynamic import are re-raised as ``CatalogValidationError`` for
+    consistency with the REST ``GET /catalog/schema`` handler.
+
+    ``--format table`` falls through to JSON rendering because JSON Schema is
+    inherently nested; a rich Table would not add clarity.
+    """
+    state = _state_from_ctx(ctx)
+    try:
+        try:
+            cls = load_model_type(model_type)
+        except (ImportError, AttributeError) as exc:
+            raise CatalogValidationError(
+                [f"model_type '{model_type}' could not be imported: {exc}"]
+            ) from exc
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    schema = cls.model_json_schema()
+    _render_schema(schema, state.output_format)
+
+
+@app.command("model-types")
+def _model_types_cmd(ctx: typer.Context) -> None:
+    """List allowlisted Pydantic model classes currently imported in this process.
+
+    Uses the shared reflection helper
+    :func:`akgentic.catalog.resolver.enumerate_allowlisted_model_types` — the
+    same helper consumed by the REST ``GET /catalog/model_types`` endpoint,
+    so CLI and REST output for a given ``sys.modules`` snapshot agree.
+    """
+    state = _state_from_ctx(ctx)
+    paths = enumerate_allowlisted_model_types()
+    fmt = state.output_format
+    if fmt == "json":
+        _stdout.print(json.dumps(paths, indent=2))
+        return
+    if fmt == "yaml":
+        _stdout.print(yaml.safe_dump(paths, sort_keys=False).rstrip("\n"))
+        return
+    if not paths:
+        _stdout.print("(no model types imported)")
+        return
+    table = Table(title="Allowlisted model types")
+    table.add_column("path")
+    for path in paths:
+        table.add_row(path)
+    _stdout.print(table)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/akgentic/catalog/cli/v2.py
+++ b/src/akgentic/catalog/cli/v2.py
@@ -28,6 +28,7 @@ from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFound
 from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.resolver import enumerate_allowlisted_model_types, load_model_type
+from akgentic.catalog.validation import EntryValidationIssue, NamespaceValidationReport
 
 __all__ = ["app"]
 
@@ -768,6 +769,169 @@ def _model_types_cmd(ctx: typer.Context) -> None:
     for path in paths:
         table.add_row(path)
     _stdout.print(table)
+
+
+# --------------------------------------------------------------------------- #
+# Namespace bundle verbs (Story 17.3): export / import
+# --------------------------------------------------------------------------- #
+
+
+def _require_non_empty_namespace(value: str) -> str:
+    """Typer callback — reject empty-string ``--namespace`` at parse time."""
+    if value == "":
+        err_console.print("--namespace must be a non-empty string")
+        raise typer.Exit(code=2)
+    return value
+
+
+def _render_global_errors(table: Table, errors: _list[str]) -> None:
+    """Fill ``table`` with one row per global error, or a placeholder when empty."""
+    if not errors:
+        table.add_row("(no global errors)")
+        return
+    for err in errors:
+        table.add_row(err)
+
+
+def _render_entry_issues(table: Table, issues: _list[EntryValidationIssue]) -> None:
+    """Fill ``table`` with one row per entry issue, or a placeholder when empty."""
+    if not issues:
+        table.add_row("(no entry issues)", "", "")
+        return
+    for issue in issues:
+        table.add_row(issue.entry_id, issue.kind, "\n".join(issue.errors))
+
+
+def _render_validation_report(report: NamespaceValidationReport, fmt: str) -> None:
+    """Render a ``NamespaceValidationReport`` to stdout per ``fmt``.
+
+    ``json`` / ``yaml`` use stdlib serialisers to avoid Rich line-wrapping on
+    structured payloads. ``table`` renders a two-line header plus two Rich
+    tables (global errors + entry issues).
+    """
+    if fmt == "json":
+        print(json.dumps(report.model_dump(mode="json"), indent=2))
+        return
+    if fmt == "yaml":
+        print(yaml.safe_dump(report.model_dump(mode="json"), sort_keys=False).rstrip("\n"))
+        return
+    _stdout.print(f"namespace: {report.namespace}")
+    _stdout.print(f"ok: {report.ok}")
+    global_table = Table(title="global errors")
+    global_table.add_column("error")
+    _render_global_errors(global_table, report.global_errors)
+    _stdout.print(global_table)
+    issues_table = Table(title="entry issues")
+    for col in ("entry_id", "kind", "errors"):
+        issues_table.add_column(col)
+    _render_entry_issues(issues_table, report.entry_issues)
+    _stdout.print(issues_table)
+
+
+@app.command("export")
+def _export_cmd(
+    ctx: typer.Context,
+    namespace: str = typer.Option(
+        ...,
+        "--namespace",
+        help="Namespace to export as a single bundle YAML document.",
+        callback=_require_non_empty_namespace,
+    ),
+) -> None:
+    """Emit the given ``--namespace`` as a single bundle YAML document on stdout.
+
+    The bundle is always emitted verbatim as the YAML produced by
+    :meth:`Catalog.export_namespace_yaml` — ``--format`` is IGNORED here
+    because the bundle is the canonical authored form and a JSON or table
+    rendering would break the round-trip contract
+    (``export > bundle.yaml; import bundle.yaml``).
+    """
+    catalog = _repo_from_ctx(ctx)
+    try:
+        yaml_text = catalog.export_namespace_yaml(namespace)
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    # Byte-exact stdout write — no Rich wrapping, no trailing-newline
+    # manipulation — preserves `export > bundle.yaml` round-trip fidelity.
+    print(yaml_text, end="")
+
+
+def _read_bundle_text(path: Path) -> str:
+    """Load bundle YAML text from ``path``; map usage-level failures to exit 2."""
+    if not path.is_file():
+        err_console.print(f"file not found: {path}")
+        raise typer.Exit(code=2)
+    try:
+        yaml_text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        err_console.print(f"file is not valid UTF-8: {exc}")
+        raise typer.Exit(code=2) from None
+    # Fail-fast parse check — the Python object is discarded; the service
+    # consumes the raw YAML text.
+    try:
+        yaml.safe_load(yaml_text)
+    except yaml.YAMLError as exc:
+        err_console.print(f"YAML parse error: {exc}")
+        raise typer.Exit(code=2) from None
+    return yaml_text
+
+
+def _import_persistence_mode(catalog: Catalog, yaml_text: str) -> None:
+    """Run ``catalog.import_namespace_yaml`` and report the outcome."""
+    try:
+        persisted = catalog.import_namespace_yaml(yaml_text)
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    ns = persisted[0].namespace
+    err_console.print(f"imported {len(persisted)} entries into namespace {ns}")
+
+
+def _import_dry_run_mode(catalog: Catalog, yaml_text: str, fmt: str) -> None:
+    """Run ``catalog.validate_namespace_yaml``; render the report; derive exit code."""
+    report = catalog.validate_namespace_yaml(yaml_text)
+    _render_validation_report(report, fmt)
+    if not report.ok:
+        global_count = len(report.global_errors)
+        entry_count = sum(1 for i in report.entry_issues if i.errors)
+        err_console.print(
+            f"validation failed: {global_count} global error(s), {entry_count} entry issue(s)"
+        )
+        raise typer.Exit(code=1)
+
+
+@app.command("import")
+def _import_cmd(
+    ctx: typer.Context,
+    bundle_file: Path = typer.Argument(
+        ...,
+        exists=False,
+        help="Path to a bundle YAML file (document-level namespace + entries).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run/--no-dry-run",
+        help="Validate only; do not persist.",
+    ),
+) -> None:
+    """Import a namespace bundle YAML file into the catalog.
+
+    In persistence mode, delegates to :meth:`Catalog.import_namespace_yaml`
+    (atomic replace of the namespace declared at document level). In
+    ``--dry-run`` mode, delegates to :meth:`Catalog.validate_namespace_yaml`
+    and renders the resulting ``NamespaceValidationReport`` per ``--format``
+    — exit 0 iff ``report.ok`` is True.
+    """
+    yaml_text = _read_bundle_text(bundle_file)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    if dry_run:
+        _import_dry_run_mode(catalog, yaml_text, state.output_format)
+        return
+    _import_persistence_mode(catalog, yaml_text)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/akgentic/catalog/cli/v2.py
+++ b/src/akgentic/catalog/cli/v2.py
@@ -1,0 +1,538 @@
+"""Typer CLI (v2) for the unified catalog — ``ak-catalog <kind> <verb>``.
+
+This module is the Epic 17 Story 17.1 scaffold: a single flat CLI module
+exposing a Typer ``app`` mounted on the ``ak-catalog`` console-script entry
+point. Every verb is a thin dispatcher into :class:`akgentic.catalog.catalog.Catalog`
+— no business logic lives here.
+
+Coexists with ``cli/main.py`` (v1) until Epic 19 deletes v1 and renames
+``cli/v2.py`` back to ``cli/main.py``.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import typer
+import yaml
+from pydantic import BaseModel, ConfigDict, ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry, EntryKind
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.base import EntryRepository
+
+__all__ = ["app"]
+
+_V2_ENTRIES_COLLECTION = "catalog_entries"
+
+_list = builtins.list  # Alias kept because ``list`` is a Typer verb name.
+
+_stdout = Console()
+err_console = Console(stderr=True)
+
+
+# --------------------------------------------------------------------------- #
+# CLI state
+# --------------------------------------------------------------------------- #
+
+
+class CliState(BaseModel):
+    """Global CLI state stashed on ``ctx.obj`` by the root callback."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=False)
+
+    backend: Literal["yaml", "mongo"] = "yaml"
+    root: Path = Path("./catalog")
+    uri: str | None = None
+    db: str | None = None
+    output_format: Literal["table", "json", "yaml"] = "table"
+
+
+# --------------------------------------------------------------------------- #
+# Typer app + global callback
+# --------------------------------------------------------------------------- #
+
+
+app = typer.Typer(
+    name="ak-catalog",
+    help="Unified Akgentic catalog CLI (v2) — manage entries across kinds.",
+    no_args_is_help=True,
+)
+
+
+def _validate_mongo_options(state: CliState) -> None:
+    """Guard mongo-only options; raises ``typer.Exit(code=2)`` on failure."""
+    if state.backend != "mongo":
+        return
+    if state.uri is None:
+        err_console.print("--uri is required when --backend=mongo")
+        raise typer.Exit(code=2)
+    if state.db is None:
+        err_console.print("--db is required when --backend=mongo")
+        raise typer.Exit(code=2)
+    if not (state.uri.startswith("mongodb://") or state.uri.startswith("mongodb+srv://")):
+        err_console.print("--uri must start with 'mongodb://' or 'mongodb+srv://'")
+        raise typer.Exit(code=2)
+
+
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    backend: str = typer.Option(
+        "yaml",
+        "--backend",
+        help="Storage backend: yaml or mongo.",
+        case_sensitive=False,
+    ),
+    root: Path = typer.Option(
+        Path("./catalog"),
+        "--root",
+        help="Root directory for YAML entries (only when --backend=yaml).",
+    ),
+    uri: str | None = typer.Option(
+        None,
+        "--uri",
+        help="MongoDB connection URI (required when --backend=mongo).",
+    ),
+    db: str | None = typer.Option(
+        None,
+        "--db",
+        help="MongoDB database name (required when --backend=mongo).",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--format",
+        help="Output format: table, json, or yaml.",
+        case_sensitive=False,
+    ),
+) -> None:
+    """Parse global options and stash a ``CliState`` on ``ctx.obj``."""
+    if backend not in ("yaml", "mongo"):
+        err_console.print(f"Invalid backend '{backend}'. Must be 'yaml' or 'mongo'.")
+        raise typer.Exit(code=2)
+    if output_format not in ("table", "json", "yaml"):
+        err_console.print(f"Invalid format '{output_format}'. Must be 'table', 'json', or 'yaml'.")
+        raise typer.Exit(code=2)
+
+    state = CliState(
+        backend=backend,  # type: ignore[arg-type]
+        root=root,
+        uri=uri,
+        db=db,
+        output_format=output_format,  # type: ignore[arg-type]
+    )
+    _validate_mongo_options(state)
+    ctx.obj = state
+
+
+# --------------------------------------------------------------------------- #
+# Backend wiring
+# --------------------------------------------------------------------------- #
+
+
+def _build_catalog(state: CliState) -> Catalog:
+    """Construct a ``Catalog`` from the active ``CliState``.
+
+    YAML: creates ``state.root`` if absent and wraps a ``YamlEntryRepository``.
+
+    Mongo: lazy-imports the Mongo repository so YAML-only users never trip a
+    missing ``pymongo``. A missing extra is re-surfaced as an "optional extra"
+    usage error (exit 2) rather than a cryptic ``ImportError``.
+    """
+    if state.backend == "yaml":
+        from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+        state.root.mkdir(parents=True, exist_ok=True)
+        return Catalog(YamlEntryRepository(state.root))
+
+    # state.backend == "mongo" — options pre-validated by the root callback.
+    try:
+        from akgentic.catalog.repositories.mongo._config import MongoCatalogConfig
+        from akgentic.catalog.repositories.mongo_entry_repo import MongoEntryRepository
+    except ImportError:
+        err_console.print(
+            "--backend=mongo requires the 'mongo' optional extra: "
+            "pip install akgentic-catalog[mongo]"
+        )
+        raise typer.Exit(code=2) from None
+
+    assert state.uri is not None  # guarded by _validate_mongo_options
+    assert state.db is not None
+    config = MongoCatalogConfig(connection_string=state.uri, database=state.db)
+    client = config.create_client()
+    collection = config.get_collection(client, _V2_ENTRIES_COLLECTION)
+    return Catalog(MongoEntryRepository(collection))
+
+
+def _repo_from_ctx(ctx: typer.Context) -> Catalog:
+    """Helper: pull ``CliState`` off the context and build a Catalog."""
+    state = ctx.obj
+    assert isinstance(state, CliState), "CliState missing from ctx.obj"
+    return _build_catalog(state)
+
+
+def _state_from_ctx(ctx: typer.Context) -> CliState:
+    state = ctx.obj
+    assert isinstance(state, CliState), "CliState missing from ctx.obj"
+    return state
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def _truncate(text: str, max_len: int = 60) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _render_entries(entries: _list[Entry], fmt: str) -> None:
+    """Render a list of entries to stdout per ``fmt``."""
+    if fmt == "json":
+        _stdout.print(json.dumps([e.model_dump(mode="json") for e in entries], indent=2))
+        return
+    if fmt == "yaml":
+        payload = [e.model_dump(mode="json") for e in entries]
+        _stdout.print(yaml.safe_dump(payload, sort_keys=False).rstrip("\n"))
+        return
+    # table
+    if not entries:
+        _stdout.print("(no entries)")
+        return
+    table = Table(title="entries")
+    for col in ("id", "namespace", "kind", "user_id", "description"):
+        table.add_column(col)
+    for e in entries:
+        table.add_row(
+            e.id,
+            e.namespace,
+            e.kind,
+            e.user_id or "",
+            _truncate(e.description or ""),
+        )
+    _stdout.print(table)
+
+
+def _render_entry(entry: Entry, fmt: str) -> None:
+    """Render a single entry to stdout per ``fmt``."""
+    if fmt == "json":
+        _stdout.print(json.dumps(entry.model_dump(mode="json"), indent=2))
+        return
+    if fmt == "yaml":
+        _stdout.print(yaml.safe_dump(entry.model_dump(mode="json"), sort_keys=False).rstrip("\n"))
+        return
+    table = Table(title=f"entry {entry.id}", show_header=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    rows = (
+        ("id", entry.id),
+        ("kind", entry.kind),
+        ("namespace", entry.namespace),
+        ("user_id", entry.user_id or ""),
+        ("parent_namespace", entry.parent_namespace or ""),
+        ("parent_id", entry.parent_id or ""),
+        ("model_type", entry.model_type),
+        ("description", entry.description or ""),
+    )
+    for key, value in rows:
+        table.add_row(key, value)
+    _stdout.print(table)
+    payload_json = json.dumps(entry.model_dump(mode="json")["payload"], indent=2)
+    if len(payload_json) > 4096:
+        kept = payload_json[:4096]
+        suffix = len(payload_json) - 4096
+        _stdout.print(f"{kept}… ({suffix} more chars)")
+    else:
+        _stdout.print(payload_json)
+
+
+# --------------------------------------------------------------------------- #
+# Verb helpers
+# --------------------------------------------------------------------------- #
+
+
+def _parse_tri_state(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    err_console.print(f"--user-id-set must be 'true' or 'false'; got {value!r}")
+    raise typer.Exit(code=2)
+
+
+def _list_impl(
+    ctx: typer.Context,
+    kind: EntryKind,
+    namespace: str | None,
+    user_id: str | None,
+    user_id_set: str | None,
+    parent_namespace: str | None,
+    parent_id: str | None,
+) -> None:
+    tri = _parse_tri_state(user_id_set)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    query = EntryQuery(
+        kind=kind,
+        namespace=namespace,
+        user_id=user_id,
+        user_id_set=tri,
+        parent_namespace=parent_namespace,
+        parent_id=parent_id,
+    )
+    entries = catalog.list(query)
+    _render_entries(entries, state.output_format)
+
+
+def _get_impl(ctx: typer.Context, kind: EntryKind, id: str, namespace: str) -> None:
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        entry = catalog.get(namespace, id)
+    except EntryNotFoundError:
+        err_console.print(f"Entry ({namespace}, {id}, {kind}) not found")
+        raise typer.Exit(code=1) from None
+    if entry.kind != kind:
+        err_console.print(
+            f"Entry at (namespace={namespace}, id={id}) has kind={entry.kind}, expected {kind}"
+        )
+        raise typer.Exit(code=1)
+    _render_entry(entry, state.output_format)
+
+
+def _load_entry_yaml(path: Path) -> Entry:
+    if not path.is_file():
+        err_console.print(f"file not found: {path}")
+        raise typer.Exit(code=2)
+    try:
+        text = path.read_text()
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        err_console.print(f"YAML parse error: {exc}")
+        raise typer.Exit(code=2) from None
+    if not isinstance(data, dict):
+        err_console.print(f"YAML file must contain a mapping; got {type(data).__name__}")
+        raise typer.Exit(code=2)
+    try:
+        return Entry(**data)
+    except ValidationError as exc:
+        err_console.print(f"entry validation error: {exc}")
+        raise typer.Exit(code=2) from None
+
+
+def _create_impl(ctx: typer.Context, kind: EntryKind, yaml_file: Path) -> None:
+    entry = _load_entry_yaml(yaml_file)
+    if entry.kind != kind:
+        err_console.print(f"entry kind={entry.kind} does not match sub-app kind={kind}")
+        raise typer.Exit(code=2)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        saved = catalog.create(entry)
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_entry(saved, state.output_format)
+
+
+def _update_impl(ctx: typer.Context, kind: EntryKind, yaml_file: Path) -> None:
+    entry = _load_entry_yaml(yaml_file)
+    if entry.kind != kind:
+        err_console.print(f"entry kind={entry.kind} does not match sub-app kind={kind}")
+        raise typer.Exit(code=2)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        saved = catalog.update(entry)
+    except EntryNotFoundError as exc:
+        err_console.print(str(exc))
+        raise typer.Exit(code=1) from None
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(f"validation error: {err}")
+        raise typer.Exit(code=1) from None
+    _render_entry(saved, state.output_format)
+
+
+def _delete_impl(ctx: typer.Context, kind: EntryKind, id: str, namespace: str) -> None:
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    try:
+        catalog.delete(namespace, id)
+    except EntryNotFoundError as exc:
+        err_console.print(str(exc))
+        raise typer.Exit(code=1) from None
+    except CatalogValidationError as exc:
+        for err in exc.errors:
+            err_console.print(str(err))
+        _surface_referrers_if_any(catalog, namespace, id, state.output_format)
+        raise typer.Exit(code=1) from None
+    err_console.print(f"deleted {kind} {id} from namespace {namespace}")
+
+
+def _surface_referrers_if_any(catalog: Catalog, namespace: str, id: str, fmt: str) -> None:
+    """Render referrers of (namespace, id) if any — best-effort, no raise."""
+    try:
+        referrers = catalog.find_references(namespace, id)
+    except Exception:  # pragma: no cover - defensive
+        return
+    if referrers:
+        _render_entries(referrers, fmt)
+
+
+def _search_impl(
+    ctx: typer.Context,
+    kind: EntryKind,
+    namespace: str | None,
+    user_id: str | None,
+    user_id_set: str | None,
+    parent_namespace: str | None,
+    parent_id: str | None,
+    description_contains: str | None,
+    id: str | None,
+) -> None:
+    tri = _parse_tri_state(user_id_set)
+    catalog = _repo_from_ctx(ctx)
+    state = _state_from_ctx(ctx)
+    query = EntryQuery(
+        kind=kind,
+        namespace=namespace,
+        user_id=user_id,
+        user_id_set=tri,
+        parent_namespace=parent_namespace,
+        parent_id=parent_id,
+        description_contains=description_contains,
+        id=id,
+    )
+    entries = catalog.list(query)
+    _render_entries(entries, state.output_format)
+
+
+def _not_implemented_repo_handler(exc: Exception) -> None:  # pragma: no cover
+    """Safety net for NotImplementedError from degraded repositories."""
+    err_console.print(f"repository does not support this operation: {exc}")
+
+
+def _ensure_repo(_: EntryRepository) -> None:  # pragma: no cover - hook placeholder
+    """Placeholder helper to keep EntryRepository imported for type use."""
+
+
+# --------------------------------------------------------------------------- #
+# Per-kind sub-apps — one Typer() per EntryKind, registered on app
+# --------------------------------------------------------------------------- #
+
+
+def _make_kind_app(kind: EntryKind) -> typer.Typer:
+    """Build a Typer sub-app with the six verbs bound to ``kind``."""
+    sub = typer.Typer(name=kind, help=f"Manage '{kind}' entries.", no_args_is_help=True)
+
+    @sub.command("list")
+    def _list_cmd(
+        ctx: typer.Context,
+        namespace: str | None = typer.Option(None, "--namespace"),
+        user_id: str | None = typer.Option(None, "--user-id"),
+        user_id_set: str | None = typer.Option(None, "--user-id-set"),
+        parent_namespace: str | None = typer.Option(None, "--parent-namespace"),
+        parent_id: str | None = typer.Option(None, "--parent-id"),
+    ) -> None:
+        """List entries of this kind matching the provided filters."""
+        _list_impl(
+            ctx,
+            kind,
+            namespace=namespace,
+            user_id=user_id,
+            user_id_set=user_id_set,
+            parent_namespace=parent_namespace,
+            parent_id=parent_id,
+        )
+
+    @sub.command("get")
+    def _get_cmd(
+        ctx: typer.Context,
+        id: str = typer.Argument(..., help="Entry id."),
+        namespace: str = typer.Option(..., "--namespace", help="Entry namespace."),
+    ) -> None:
+        """Fetch a single entry by ``(namespace, id)``."""
+        _get_impl(ctx, kind, id, namespace)
+
+    @sub.command("create")
+    def _create_cmd(
+        ctx: typer.Context,
+        yaml_file: Path = typer.Argument(..., help="Path to single-entry YAML file."),
+    ) -> None:
+        """Create an entry from a single-entry YAML file."""
+        _create_impl(ctx, kind, yaml_file)
+
+    @sub.command("update")
+    def _update_cmd(
+        ctx: typer.Context,
+        yaml_file: Path = typer.Argument(..., help="Path to single-entry YAML file."),
+    ) -> None:
+        """Update an existing entry from a single-entry YAML file."""
+        _update_impl(ctx, kind, yaml_file)
+
+    @sub.command("delete")
+    def _delete_cmd(
+        ctx: typer.Context,
+        id: str = typer.Argument(..., help="Entry id."),
+        namespace: str = typer.Option(..., "--namespace", help="Entry namespace."),
+    ) -> None:
+        """Delete an entry; surfaces inbound referrers on failure."""
+        _delete_impl(ctx, kind, id, namespace)
+
+    @sub.command("search")
+    def _search_cmd(
+        ctx: typer.Context,
+        namespace: str | None = typer.Option(None, "--namespace"),
+        user_id: str | None = typer.Option(None, "--user-id"),
+        user_id_set: str | None = typer.Option(None, "--user-id-set"),
+        parent_namespace: str | None = typer.Option(None, "--parent-namespace"),
+        parent_id: str | None = typer.Option(None, "--parent-id"),
+        description_contains: str | None = typer.Option(None, "--description-contains"),
+        id: str | None = typer.Option(None, "--id"),
+    ) -> None:
+        """Structured search across every ``EntryQuery`` filter."""
+        _search_impl(
+            ctx,
+            kind,
+            namespace=namespace,
+            user_id=user_id,
+            user_id_set=user_id_set,
+            parent_namespace=parent_namespace,
+            parent_id=parent_id,
+            description_contains=description_contains,
+            id=id,
+        )
+
+    return sub
+
+
+_ENTRY_KINDS: tuple[EntryKind, ...] = ("team", "agent", "tool", "model", "prompt")
+# Register one sub-app per EntryKind. The literal order matches EntryKind.
+for _kind in _ENTRY_KINDS:
+    app.add_typer(_make_kind_app(_kind), name=_kind)
+
+
+# --------------------------------------------------------------------------- #
+# Helper — used by tests & silencing "unused import" warnings at module level.
+# --------------------------------------------------------------------------- #
+
+
+def _unused(_e: Any) -> None:  # pragma: no cover - trivial
+    """Retain references to imports used only for typing."""
+
+
+_unused(EntryRepository)

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -31,6 +31,7 @@ right place to decide whether ownership enforcement lives inside
 
 from __future__ import annotations
 
+import sys
 from typing import Any, Final
 
 from pydantic import BaseModel, ValidationError
@@ -44,6 +45,7 @@ from .repositories.base import EntryRepository
 __all__ = [
     "REF_KEY",
     "TYPE_KEY",
+    "enumerate_allowlisted_model_types",
     "load_model_type",
     "populate_refs",
     "prepare_for_write",
@@ -376,3 +378,43 @@ def validate_delete(namespace: str, id: str, repository: EntryRepository) -> lis
         f"Entry '{r.id}' (kind={r.kind}) in namespace '{namespace}' references '{id}'"
         for r in referrers
     ]
+
+
+def enumerate_allowlisted_model_types() -> list[str]:
+    """Enumerate allowlisted ``BaseModel`` subclasses loaded under ``akgentic.*``.
+
+    Walks a snapshot of ``sys.modules`` to avoid mutation-during-iteration
+    issues. Per-module introspection errors are swallowed — optional
+    dependencies may be absent or partially imported. ``load_model_type``
+    acts as the authoritative allowlist + ``BaseModel`` + reserved-key gate
+    so enumeration never broadens the allowlist.
+
+    Used by both the REST router (``GET /catalog/model_types``) and the
+    ``ak-catalog model-types`` CLI verb.
+    """
+    results: set[str] = set()
+    modules_snapshot = list(sys.modules.items())
+    for module_name, module in modules_snapshot:
+        if not module_name.startswith("akgentic.") or module is None:
+            continue
+        _collect_allowlisted(module, results)
+    return sorted(results)
+
+
+def _collect_allowlisted(module: Any, results: set[str]) -> None:
+    """Add every allowlisted ``BaseModel`` subclass from ``module`` into ``results``."""
+    try:
+        items = list(vars(module).items())
+    except Exception:  # noqa: BLE001 — defensive; partially imported modules
+        return
+    for _name, value in items:
+        if not isinstance(value, type) or not issubclass(value, BaseModel):
+            continue
+        path = f"{value.__module__}.{value.__name__}"
+        if not path.startswith("akgentic.") or path in results:
+            continue
+        try:
+            load_model_type(path)
+        except Exception:  # noqa: BLE001 — swallow reserved-key or import errors
+            continue
+        results.add(path)

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -1,0 +1,423 @@
+"""Tests for the v2 ``ak-catalog`` CLI bundle verbs — Story 17.3.
+
+Exercises ``export``, ``import`` and ``import --dry-run`` through
+:class:`typer.testing.CliRunner` against a YAML-backed tmp-dir ``Catalog``
+seeded with a self-contained namespace (team + agent + tool, agent
+referencing the tool).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.cli import v2 as cli_v2
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+_FIXTURE_MODULE = "akgentic.catalog.tests_fixture_17_3"
+_LEAF_TYPE = f"{_FIXTURE_MODULE}.LeafModel"
+_AGENT_TYPE = f"{_FIXTURE_MODULE}.AgentModel"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "entry",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _register_fixture_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register throwaway Pydantic classes under an ``akgentic.*`` module path."""
+
+    class LeafModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+
+    class AgentModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+        linked: LeafModel | None = None
+
+    module = types.ModuleType(_FIXTURE_MODULE)
+    module.LeafModel = LeafModel  # type: ignore[attr-defined]
+    module.AgentModel = AgentModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _FIXTURE_MODULE, module)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_namespace(root: Path, namespace: str = "ns-a", user_id: str = "alice") -> None:
+    catalog = Catalog(YamlEntryRepository(root))
+    catalog.create(
+        Entry(
+            id="team-a",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            description="primary team",
+            payload=_team_payload(),
+        )
+    )
+    catalog.create(
+        Entry(
+            id="tool-a",
+            kind="tool",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_LEAF_TYPE,
+            description="the tool",
+            payload={"provider": "openai", "temperature": 0.0},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="agent-a",
+            kind="agent",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_AGENT_TYPE,
+            description="agent referencing tool",
+            payload={"provider": "openai", "temperature": 0.0, "linked": {"__ref__": "tool-a"}},
+        )
+    )
+
+
+@pytest.fixture
+def catalog_root(tmp_path: Path) -> Path:
+    root = tmp_path / "catalog"
+    root.mkdir()
+    _seed_namespace(root)
+    return root
+
+
+def _base_args(catalog_root: Path) -> list[str]:
+    return ["--backend", "yaml", "--root", str(catalog_root)]
+
+
+# --------------------------------------------------------------------------- #
+# `export` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestExportVerb:
+    """AC3-AC6 + AC23 — export verb shape, stdout fidelity, error paths."""
+
+    def test_export_stdout_is_parseable_bundle(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert set(payload.keys()) == {"namespace", "user_id", "entries"}
+        assert payload["namespace"] == "ns-a"
+        assert "team-a" in payload["entries"]
+        assert "tool-a" in payload["entries"]
+        assert "agent-a" in payload["entries"]
+
+    def test_export_missing_namespace_is_usage_error(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["export"])
+        assert result.exit_code == 2
+        assert result.stdout == ""
+
+    def test_export_empty_namespace_string_is_usage_error(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", ""])
+        assert result.exit_code == 2
+
+    def test_export_unknown_namespace_is_validation_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        # AC23 — point at an empty catalog dir; exporting any namespace fails.
+        root = tmp_path / "catalog"
+        root.mkdir()
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(root), "export", "--namespace", "nope"],
+        )
+        assert result.exit_code == 1
+        assert "validation error:" in result.stderr
+
+    def test_export_format_flag_ignored(self, runner: CliRunner, catalog_root: Path) -> None:
+        # --format is a no-op on export; bundle is always YAML bytes.
+        result_yaml = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "export", "--namespace", "ns-a"],
+        )
+        assert result_yaml.exit_code == 0
+        # Output must still parse as YAML (the bundle format).
+        payload = yaml.safe_load(result_yaml.stdout)
+        assert payload["namespace"] == "ns-a"
+
+
+# --------------------------------------------------------------------------- #
+# `import` verb — persistence mode
+# --------------------------------------------------------------------------- #
+
+
+class TestImportPersistence:
+    """AC7-AC11 + AC17-AC18 — round-trip + atomicity."""
+
+    def test_round_trip_mutation(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        # AC17 — export → edit → import → re-export → verify.
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert export.exit_code == 0
+        bundle = yaml.safe_load(export.stdout)
+        assert bundle["namespace"] == "ns-a"
+        bundle["entries"]["team-a"]["description"] = "edited description"
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
+
+        imp = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(bundle_path)])
+        assert imp.exit_code == 0, imp.stderr
+        assert imp.stdout == ""
+        assert "imported" in imp.stderr
+        assert "ns-a" in imp.stderr
+
+        re_export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert re_export.exit_code == 0
+        re_bundle = yaml.safe_load(re_export.stdout)
+        assert re_bundle["entries"]["team-a"]["description"] == "edited description"
+        # Other entries untouched — byte-equivalent dumps.
+        for k in ("tool-a", "agent-a"):
+            assert re_bundle["entries"][k] == bundle["entries"][k]
+
+    def test_atomic_failure_leaves_namespace_untouched(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        # AC18 — broken bundle with dangling ref → exit 1 → export byte-equal to pre.
+        before = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert before.exit_code == 0
+        pre_bundle_text = before.stdout
+
+        # Break the bundle: point agent-a.linked.__ref__ at a missing id.
+        bundle = yaml.safe_load(pre_bundle_text)
+        bundle["entries"]["agent-a"]["payload"]["linked"] = {"__ref__": "does-not-exist"}
+        broken_path = tmp_path / "broken.yaml"
+        broken_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
+
+        imp = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(broken_path)])
+        assert imp.exit_code == 1
+        assert "validation error:" in imp.stderr
+
+        after = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert after.exit_code == 0
+        assert after.stdout == pre_bundle_text
+
+
+# --------------------------------------------------------------------------- #
+# `import --dry-run` — success + failure
+# --------------------------------------------------------------------------- #
+
+
+class TestImportDryRun:
+    """AC12-AC13 + AC19-AC21 — dry-run delegation, report rendering, exit-code map."""
+
+    def test_dry_run_happy_json(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        # AC19 — export → dry-run --format json → ok=True, empty errors.
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(export.stdout)
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "import", str(bundle_path), "--dry-run"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True
+        assert payload["global_errors"] == []
+        assert payload["entry_issues"] == []
+        assert result.stderr == ""
+
+    def test_dry_run_failure_json(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        # AC20 — broken bundle → exit 1, stdout valid JSON with ok=false,
+        # stderr carries the AC13 summary line.
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        bundle = yaml.safe_load(export.stdout)
+        bundle["entries"]["agent-a"]["payload"]["linked"] = {"__ref__": "does-not-exist"}
+        broken_path = tmp_path / "broken.yaml"
+        broken_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "import", str(broken_path), "--dry-run"],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        has_error = bool(payload["global_errors"]) or any(
+            i["errors"] for i in payload["entry_issues"]
+        )
+        assert has_error
+        assert re.search(
+            r"validation failed: \d+ global error\(s\), \d+ entry issue\(s\)", result.stderr
+        )
+        # AC20 — no writes performed: re-export equals pre-export.
+        before_re = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert before_re.stdout == export.stdout
+
+    @pytest.mark.parametrize("fmt", ["table", "json", "yaml"])
+    def test_dry_run_happy_format_coverage(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path, fmt: str
+    ) -> None:
+        # AC21 — parametrised over all formats.
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(export.stdout)
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", fmt, "import", str(bundle_path), "--dry-run"],
+        )
+        assert result.exit_code == 0, result.stderr
+        if fmt == "json":
+            payload = json.loads(result.stdout)
+            assert payload["ok"] is True
+            assert payload["namespace"] == "ns-a"
+        elif fmt == "yaml":
+            payload = yaml.safe_load(result.stdout)
+            assert payload["ok"] is True
+            assert payload["namespace"] == "ns-a"
+        else:
+            assert "ok: True" in result.stdout
+            assert "ns-a" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Usage errors
+# --------------------------------------------------------------------------- #
+
+
+class TestImportUsageErrors:
+    """AC9 + AC11 + AC22 — path/parse/encoding failure shapes."""
+
+    def test_missing_file(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist.yaml"
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(missing)])
+        assert result.exit_code == 2
+        assert "file not found" in result.stderr
+
+    def test_directory_not_file(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "a-directory"
+        d.mkdir()
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(d)])
+        assert result.exit_code == 2
+        assert "file not found" in result.stderr
+
+    def test_non_utf8_file(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "garbage.yaml"
+        bad.write_bytes(b"\xff\xfe\x00\x00\xff\xff")
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(bad)])
+        assert result.exit_code == 2
+        assert "not valid UTF-8" in result.stderr
+
+    def test_malformed_yaml(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "malformed.yaml"
+        bad.write_text(":\n-[[[\n")
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(bad)])
+        assert result.exit_code == 2
+        assert "YAML parse error" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Stdout discipline
+# --------------------------------------------------------------------------- #
+
+
+class TestStdoutDiscipline:
+    """AC24 — stream routing pins."""
+
+    def test_persistence_stdout_empty_success_on_stderr(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(export.stdout)
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["import", str(bundle_path)])
+        assert result.exit_code == 0, result.stderr
+        assert result.stdout == ""
+        assert "imported" in result.stderr
+
+    def test_dry_run_json_stderr_empty_stdout_has_report(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(export.stdout)
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "import", str(bundle_path), "--dry-run"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True
+        assert result.stderr == ""

--- a/tests/v2/test_cli_foundation.py
+++ b/tests/v2/test_cli_foundation.py
@@ -1,0 +1,696 @@
+"""Tests for the v2 ``ak-catalog`` CLI — Story 17.1 foundation.
+
+Every verb is exercised through :class:`typer.testing.CliRunner` against a
+YAML-backed tmp-dir ``Catalog`` seeded with a team + model + agent in the same
+namespace. The tests pin exit codes, stdout/stderr discipline, error messages,
+and the format-switching behaviour required by ACs 12–27.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.cli import v2 as cli_v2
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "entry",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """CliRunner with stderr separated from stdout so we can pin both."""
+    return CliRunner()
+
+
+@pytest.fixture
+def catalog_root(tmp_path: Path) -> Path:
+    """Seed a YAML catalog at ``tmp_path/catalog`` with team + model + agent.
+
+    The CLI is then invoked with ``--root`` pointing at the same directory.
+    """
+    root = tmp_path / "catalog"
+    root.mkdir()
+    catalog = Catalog(YamlEntryRepository(root))
+    # Team must land first — it is the bootstrap for the namespace.
+    catalog.create(
+        Entry(
+            id="team-a",
+            kind="team",
+            namespace="ns-a",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            description="primary team",
+            payload=_team_payload(),
+        )
+    )
+    catalog.create(
+        Entry(
+            id="model-a",
+            kind="model",
+            namespace="ns-a",
+            user_id="alice",
+            model_type="akgentic.catalog.tests_fixture_17_1.LeafModel",
+            description="some model",
+            payload={"provider": "openai", "temperature": 0.0},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="agent-a",
+            kind="agent",
+            namespace="ns-a",
+            user_id="alice",
+            model_type="akgentic.catalog.tests_fixture_17_1.AgentModel",
+            description="some agent",
+            payload={"provider": "openai", "temperature": 0.0},
+        )
+    )
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _register_fixture_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register throwaway pydantic model types used by seed entries."""
+    import types
+
+    from pydantic import BaseModel
+
+    class LeafModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+
+    class AgentModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+        linked: LeafModel | None = None
+
+    module = types.ModuleType("akgentic.catalog.tests_fixture_17_1")
+    module.LeafModel = LeafModel  # type: ignore[attr-defined]
+    module.AgentModel = AgentModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "akgentic.catalog.tests_fixture_17_1", module)
+
+
+def _base_args(catalog_root: Path) -> list[str]:
+    return ["--backend", "yaml", "--root", str(catalog_root)]
+
+
+# --------------------------------------------------------------------------- #
+# Entry-point + state regression pins
+# --------------------------------------------------------------------------- #
+
+
+class TestEntryPoint:
+    """AC2 + AC25 — the ``ak-catalog`` console-script resolves to cli.v2:app."""
+
+    def test_entry_point_resolves_to_v2(self) -> None:
+        eps = importlib.metadata.entry_points(group="console_scripts")
+        names = {ep.name: ep.value for ep in eps}
+        assert names.get("ak-catalog") == "akgentic.catalog.cli.v2:app"
+
+
+class TestCliState:
+    """AC26 — CliState survives a model_dump / model_validate round-trip."""
+
+    def test_roundtrip(self) -> None:
+        state = cli_v2.CliState(
+            backend="mongo",
+            root=Path("/tmp/catalog"),
+            uri="mongodb://localhost:27017",
+            db="akgentic",
+            output_format="json",
+        )
+        dumped = state.model_dump()
+        restored = cli_v2.CliState.model_validate(dumped)
+        assert restored == state
+
+
+# --------------------------------------------------------------------------- #
+# `list` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestListVerb:
+    """AC12 + AC13 — list filters and renders per --format."""
+
+    def test_list_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["team", "list", "--namespace", "ns-a"]
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "team-a" in result.stdout
+        assert "ns-a" in result.stdout
+
+    def test_list_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "agent", "list", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert payload[0]["id"] == "agent-a"
+        assert payload[0]["kind"] == "agent"
+
+    def test_list_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "yaml", "model", "list", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert payload[0]["id"] == "model-a"
+
+    def test_list_empty_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["team", "list", "--namespace", "nowhere"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "(no entries)" in result.stdout
+
+    def test_list_empty_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "team", "list", "--namespace", "nowhere"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == []
+
+    def test_list_user_id_set_tri_state(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "agent", "list", "--user-id-set", "true"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert all(e["user_id"] is not None for e in payload)
+
+    def test_list_bad_user_id_set(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "list", "--user-id-set", "maybe"],
+        )
+        assert result.exit_code == 2
+        assert "--user-id-set" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# `get` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestGetVerb:
+    """AC14 + AC15 — get with format switch and error codes."""
+
+    def test_get_happy_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "get", "agent-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "agent-a" in result.stdout
+
+    def test_get_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "agent", "get", "agent-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["id"] == "agent-a"
+        assert payload["kind"] == "agent"
+
+    def test_get_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "yaml", "model", "get", "model-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert payload["id"] == "model-a"
+
+    def test_get_not_found(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "get", "nope", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_get_kind_mismatch(self, runner: CliRunner, catalog_root: Path) -> None:
+        # The team-a entry exists under ns-a but has kind=team; asking the
+        # `agent` sub-app for it must raise the kind-mismatch error.
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "get", "team-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 1
+        assert "has kind=team" in result.stderr
+
+    def test_get_missing_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["agent", "get", "agent-a"])
+        assert result.exit_code == 2
+
+
+# --------------------------------------------------------------------------- #
+# `create` and `update` verbs
+# --------------------------------------------------------------------------- #
+
+
+def _write_entry_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+
+class TestCreateVerb:
+    """AC16 — create from a single-entry YAML file."""
+
+    def test_create_happy(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        entry_file = tmp_path / "new.yaml"
+        _write_entry_yaml(
+            entry_file,
+            {
+                "id": "agent-b",
+                "kind": "agent",
+                "namespace": "ns-a",
+                "user_id": "alice",
+                "model_type": "akgentic.catalog.tests_fixture_17_1.AgentModel",
+                "description": "another agent",
+                "payload": {"provider": "openai", "temperature": 0.1},
+            },
+        )
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "agent", "create", str(entry_file)],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["id"] == "agent-b"
+
+    def test_create_duplicate_id(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        entry_file = tmp_path / "dup.yaml"
+        _write_entry_yaml(
+            entry_file,
+            {
+                "id": "agent-a",  # already exists
+                "kind": "agent",
+                "namespace": "ns-a",
+                "user_id": "alice",
+                "model_type": "akgentic.catalog.tests_fixture_17_1.AgentModel",
+                "description": "dup",
+                "payload": {"provider": "openai", "temperature": 0.0},
+            },
+        )
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "create", str(entry_file)],
+        )
+        assert result.exit_code == 1
+        assert "validation error" in result.stderr
+
+    def test_create_missing_file(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "create", str(tmp_path / "nope.yaml")],
+        )
+        assert result.exit_code == 2
+        assert "file not found" in result.stderr
+
+    def test_create_bad_yaml(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        entry_file = tmp_path / "bad.yaml"
+        entry_file.write_text("this is: not: valid: : yaml::\n  -")
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "create", str(entry_file)],
+        )
+        assert result.exit_code == 2
+
+    def test_create_validation_error(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        entry_file = tmp_path / "invalid.yaml"
+        # Missing required field ``model_type`` → Pydantic ValidationError.
+        _write_entry_yaml(
+            entry_file,
+            {
+                "id": "agent-x",
+                "kind": "agent",
+                "namespace": "ns-a",
+                "payload": {},
+            },
+        )
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "create", str(entry_file)],
+        )
+        assert result.exit_code == 2
+
+
+class TestUpdateVerb:
+    """AC17 — update reuses (namespace, id) from the file body."""
+
+    def test_update_happy(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        entry_file = tmp_path / "upd.yaml"
+        _write_entry_yaml(
+            entry_file,
+            {
+                "id": "agent-a",
+                "kind": "agent",
+                "namespace": "ns-a",
+                "user_id": "alice",
+                "model_type": "akgentic.catalog.tests_fixture_17_1.AgentModel",
+                "description": "updated description",
+                "payload": {"provider": "openai", "temperature": 0.5},
+            },
+        )
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "agent", "update", str(entry_file)],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["description"] == "updated description"
+
+    def test_update_missing(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        entry_file = tmp_path / "missing.yaml"
+        _write_entry_yaml(
+            entry_file,
+            {
+                "id": "agent-missing",
+                "kind": "agent",
+                "namespace": "ns-a",
+                "user_id": "alice",
+                "model_type": "akgentic.catalog.tests_fixture_17_1.AgentModel",
+                "description": "",
+                "payload": {"provider": "openai", "temperature": 0.0},
+            },
+        )
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "update", str(entry_file)],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# `delete` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestDeleteVerb:
+    """AC18 — delete with referrer surfacing on inbound-ref blockers."""
+
+    def test_delete_happy(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["model", "delete", "model-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "deleted model model-a" in result.stderr
+
+    def test_delete_not_found(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["agent", "delete", "nope", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_delete_referrer_surfacing(self, runner: CliRunner, tmp_path: Path) -> None:
+        """A tool referenced by an agent cannot be deleted; referrers listed."""
+        root = tmp_path / "catalog"
+        root.mkdir()
+        catalog = Catalog(YamlEntryRepository(root))
+        # Team + tool + agent referencing tool via __ref__ sentinel.
+        catalog.create(
+            Entry(
+                id="team-r",
+                kind="team",
+                namespace="ns-r",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        catalog.create(
+            Entry(
+                id="tool-r",
+                kind="tool",
+                namespace="ns-r",
+                user_id="alice",
+                model_type="akgentic.catalog.tests_fixture_17_1.LeafModel",
+                description="the tool",
+                payload={"provider": "openai", "temperature": 0.0},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="agent-r",
+                kind="agent",
+                namespace="ns-r",
+                user_id="alice",
+                model_type="akgentic.catalog.tests_fixture_17_1.AgentModel",
+                description="the agent",
+                payload={"linked": {"__ref__": "tool-r"}},
+            )
+        )
+        runner_local = CliRunner()
+        result = runner_local.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(root)]
+            + ["tool", "delete", "tool-r", "--namespace", "ns-r"],
+        )
+        assert result.exit_code == 1
+        # The blocking referrer (agent-r) should appear in stderr or stdout —
+        # the CLI renders referrers per --format to stdout after the error
+        # message on stderr.
+        combined = result.stderr + result.stdout
+        assert "agent-r" in combined
+        # The tool must still be present in the repository.
+        assert catalog.get("ns-r", "tool-r").id == "tool-r"
+
+
+# --------------------------------------------------------------------------- #
+# `search` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestSearchVerb:
+    """AC19 — search covers every EntryQuery filter."""
+
+    def test_search_description_contains(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "json",
+                "agent",
+                "search",
+                "--description-contains",
+                "some",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert any(e["id"] == "agent-a" for e in payload)
+
+    def test_search_by_id(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "model", "search", "--id", "model-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert len(payload) == 1
+        assert payload[0]["id"] == "model-a"
+
+    def test_search_yaml_empty(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "yaml", "model", "search", "--id", "zzz"],
+        )
+        assert result.exit_code == 0
+
+
+# --------------------------------------------------------------------------- #
+# Backend wiring
+# --------------------------------------------------------------------------- #
+
+
+class TestBackendWiring:
+    """AC7 + AC11 + AC24 — backend option validation and extras handling."""
+
+    def test_mongo_missing_uri(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli_v2.app, ["--backend", "mongo", "--db", "akgentic", "team", "list"]
+        )
+        assert result.exit_code == 2
+        assert "--uri is required" in result.stderr
+
+    def test_mongo_missing_db(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "mongo", "--uri", "mongodb://localhost:27017", "team", "list"],
+        )
+        assert result.exit_code == 2
+        assert "--db is required" in result.stderr
+
+    def test_mongo_malformed_uri(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "mongo", "--uri", "http://x", "--db", "x", "team", "list"],
+        )
+        assert result.exit_code == 2
+        assert "mongodb://" in result.stderr
+
+    def test_yaml_accepts_mongo_options_silently(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            [
+                "--backend",
+                "yaml",
+                "--root",
+                str(catalog_root),
+                "--uri",
+                "mongodb://localhost",
+                "--db",
+                "akgentic",
+                "team",
+                "list",
+                "--namespace",
+                "ns-a",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+
+    def test_yaml_creates_missing_root(self, runner: CliRunner, tmp_path: Path) -> None:
+        new_root = tmp_path / "new-root"
+        assert not new_root.exists()
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(new_root), "team", "list"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert new_root.exists()
+
+    def test_invalid_backend(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli_v2.app, ["--backend", "postgres", "team", "list"])
+        assert result.exit_code == 2
+
+    def test_invalid_format(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "csv", "team", "list"],
+        )
+        assert result.exit_code == 2
+
+    def test_mongo_extra_missing(self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Hide pymongo from sys.modules to force an ImportError in _build_catalog.
+
+        The CLI must catch it and surface the 'optional extra' message.
+        """
+        # Block both pymongo and the repositories.mongo._config module that
+        # imports pymongo at attribute access (TYPE_CHECKING guards the top).
+        import builtins as _builtins
+
+        real_import = _builtins.__import__
+
+        def _fake_import(
+            name: str,
+            globals_: Any = None,
+            locals_: Any = None,
+            fromlist: Any = (),
+            level: int = 0,
+        ) -> Any:
+            if name.startswith("pymongo") or name == "pymongo":
+                raise ImportError("pymongo is not installed")
+            if name == "akgentic.catalog.repositories.mongo_entry_repo":
+                raise ImportError("pymongo is not installed")
+            return real_import(name, globals_, locals_, fromlist, level)
+
+        monkeypatch.setattr(_builtins, "__import__", _fake_import)
+        # Drop any cached modules so the fake import hook is actually consulted.
+        for key in list(sys.modules):
+            if key.startswith("akgentic.catalog.repositories.mongo") or key.startswith("pymongo"):
+                monkeypatch.delitem(sys.modules, key, raising=False)
+
+        result = runner.invoke(
+            cli_v2.app,
+            [
+                "--backend",
+                "mongo",
+                "--uri",
+                "mongodb://localhost",
+                "--db",
+                "x",
+                "team",
+                "list",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "optional extra" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Stdout / stderr discipline
+# --------------------------------------------------------------------------- #
+
+
+class TestIoDiscipline:
+    """AC21 — success status messages go to stderr, data to stdout."""
+
+    def test_delete_success_message_on_stderr(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["model", "delete", "model-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0
+        assert "deleted" in result.stderr
+        assert "deleted" not in result.stdout

--- a/tests/v2/test_cli_graph_schema.py
+++ b/tests/v2/test_cli_graph_schema.py
@@ -1,0 +1,741 @@
+"""Tests for the v2 ``ak-catalog`` CLI graph + schema verbs — Story 17.2.
+
+Every verb (``clone``, ``references``, ``resolve``, ``load-team``, ``schema``,
+``model-types``) is exercised through :class:`typer.testing.CliRunner` against
+a YAML-backed tmp-dir ``Catalog`` seeded with a team + model + tool + agent
+where the agent references the tool via ``{"__ref__": ...}``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.cli import v2 as cli_v2
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+_FIXTURE_MODULE = "akgentic.catalog.tests_fixture_17_2"
+_LEAF_TYPE = f"{_FIXTURE_MODULE}.LeafModel"
+_AGENT_TYPE = f"{_FIXTURE_MODULE}.AgentModel"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "entry",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _register_fixture_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register throwaway Pydantic classes under an ``akgentic.*`` module path.
+
+    ``load_model_type`` gates on the ``akgentic.*`` prefix, so the fixture
+    classes MUST live inside a module with that prefix to be loadable by the
+    resolver / schema verb.
+    """
+
+    class LeafModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+
+    class AgentModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+        linked: LeafModel | None = None
+
+    module = types.ModuleType(_FIXTURE_MODULE)
+    module.LeafModel = LeafModel  # type: ignore[attr-defined]
+    module.AgentModel = AgentModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _FIXTURE_MODULE, module)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def catalog_root(tmp_path: Path) -> Path:
+    """Seed a YAML catalog with team + tool + agent-refs-tool + bare model.
+
+    ``agent-a`` references ``tool-a`` via ``{"__ref__": "tool-a"}`` inside its
+    payload's ``linked`` field — exercising ``resolve`` and ``references``.
+    """
+    root = tmp_path / "catalog"
+    root.mkdir()
+    catalog = Catalog(YamlEntryRepository(root))
+    catalog.create(
+        Entry(
+            id="team-a",
+            kind="team",
+            namespace="ns-a",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            description="primary team",
+            payload=_team_payload(),
+        )
+    )
+    catalog.create(
+        Entry(
+            id="tool-a",
+            kind="tool",
+            namespace="ns-a",
+            user_id="alice",
+            model_type=_LEAF_TYPE,
+            description="the tool",
+            payload={"provider": "openai", "temperature": 0.0},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="model-a",
+            kind="model",
+            namespace="ns-a",
+            user_id="alice",
+            model_type=_LEAF_TYPE,
+            description="the model",
+            payload={"provider": "openai", "temperature": 0.1},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="agent-a",
+            kind="agent",
+            namespace="ns-a",
+            user_id="alice",
+            model_type=_AGENT_TYPE,
+            description="agent referencing tool",
+            payload={"provider": "openai", "temperature": 0.0, "linked": {"__ref__": "tool-a"}},
+        )
+    )
+    return root
+
+
+def _base_args(catalog_root: Path) -> list[str]:
+    return ["--backend", "yaml", "--root", str(catalog_root)]
+
+
+# --------------------------------------------------------------------------- #
+# `clone` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestCloneVerb:
+    """AC3-AC6 + AC27-AC28 — clone delegation, error handling, round-trip."""
+
+    def test_clone_cross_namespace_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "team-a",
+                "--dst-namespace",
+                "ns-b",
+                "--dst-user-id",
+                "bob",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "team-a" in result.stdout
+        assert "ns-b" in result.stdout
+
+    def test_clone_cross_namespace_json_roundtrip(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        # AC27 round-trip: top-level carries lineage; sub-entries root-only.
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "json",
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "team-a",
+                "--dst-namespace",
+                "ns-c",
+                "--dst-user-id",
+                "user@example.com",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["kind"] == "team"
+        assert payload["namespace"] == "ns-c"
+        assert payload["user_id"] == "user@example.com"
+        assert payload["parent_namespace"] == "ns-a"
+        assert payload["parent_id"] == "team-a"
+
+    def test_clone_round_trip_dedup(self, runner: CliRunner, tmp_path: Path) -> None:
+        """AC27 deduplication: a shared tool is cloned once, referenced by two parents."""
+        root = tmp_path / "catalog"
+        root.mkdir()
+        catalog = Catalog(YamlEntryRepository(root))
+        catalog.create(
+            Entry(
+                id="team-s",
+                kind="team",
+                namespace="ns-src",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        catalog.create(
+            Entry(
+                id="tool-shared",
+                kind="tool",
+                namespace="ns-src",
+                user_id="alice",
+                model_type=_LEAF_TYPE,
+                payload={"provider": "openai", "temperature": 0.0},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="ns-src",
+                user_id="alice",
+                model_type=_AGENT_TYPE,
+                payload={"linked": {"__ref__": "tool-shared"}},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="agent-2",
+                kind="agent",
+                namespace="ns-src",
+                user_id="alice",
+                model_type=_AGENT_TYPE,
+                payload={"linked": {"__ref__": "tool-shared"}},
+            )
+        )
+        # Clone agent-1 into a fresh namespace — pulls tool-shared transitively.
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(root)]
+            + [
+                "clone",
+                "--src-namespace",
+                "ns-src",
+                "--src-id",
+                "agent-1",
+                "--dst-namespace",
+                "ns-dst",
+                "--dst-user-id",
+                "bob",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        cloned = Catalog(YamlEntryRepository(root)).list_by_namespace("ns-dst")
+        # Exactly two entries — the agent and the single cloned tool.
+        ids = sorted(e.id for e in cloned)
+        assert ids == ["agent-1", "tool-shared"]
+        # Sub-entry (tool) has no lineage; top (agent) carries it.
+        tool = next(e for e in cloned if e.id == "tool-shared")
+        agent = next(e for e in cloned if e.id == "agent-1")
+        assert tool.parent_namespace is None
+        assert tool.parent_id is None
+        assert agent.parent_namespace == "ns-src"
+        assert agent.parent_id == "agent-1"
+
+    def test_clone_empty_string_user_id_is_enterprise(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        """AC28 — empty-string dst-user-id sentinel becomes None in the persisted clone."""
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "json",
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "agent-a",
+                "--dst-namespace",
+                "ns-ent",
+                "--dst-user-id",
+                "",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["user_id"] is None
+
+    def test_clone_src_not_found(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "does-not-exist",
+                "--dst-namespace",
+                "ns-b",
+                "--dst-user-id",
+                "bob",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_clone_missing_src_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "clone",
+                "--src-id",
+                "team-a",
+                "--dst-namespace",
+                "ns-b",
+                "--dst-user-id",
+                "bob",
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_clone_missing_dst_user_id(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "team-a",
+                "--dst-namespace",
+                "ns-b",
+            ],
+        )
+        assert result.exit_code == 2
+
+
+# --------------------------------------------------------------------------- #
+# `references` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestReferencesVerb:
+    """AC7-AC9 + AC29 — inbound-ref listing per format, empty-set rendering."""
+
+    def test_references_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["references", "tool-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "agent-a" in result.stdout
+
+    def test_references_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "references", "tool-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert any(e["id"] == "agent-a" for e in payload)
+
+    def test_references_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "yaml", "references", "tool-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert any(e["id"] == "agent-a" for e in payload)
+
+    def test_references_empty_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        # model-a has zero inbound refs.
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "references", "model-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert json.loads(result.stdout) == []
+
+    def test_references_empty_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["references", "model-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "(no entries)" in result.stdout
+
+    def test_references_missing_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["references", "tool-a"],
+        )
+        assert result.exit_code == 2
+
+
+# --------------------------------------------------------------------------- #
+# `resolve` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestResolveVerb:
+    """AC10-AC12 + AC30 — resolve with kind-guard and ref-populate + error paths."""
+
+    def test_resolve_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["resolve", "agent", "agent-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "AgentModel" in result.stdout
+
+    def test_resolve_json_ref_populated(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "json",
+                "resolve",
+                "agent",
+                "agent-a",
+                "--namespace",
+                "ns-a",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        # The __ref__ marker in linked was populated by the resolver.
+        assert payload["linked"]["provider"] == "openai"
+        assert "__ref__" not in payload.get("linked", {})
+
+    def test_resolve_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "yaml",
+                "resolve",
+                "agent",
+                "agent-a",
+                "--namespace",
+                "ns-a",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert payload["provider"] == "openai"
+
+    def test_resolve_not_found(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["resolve", "agent", "nope", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.stderr
+
+    def test_resolve_kind_mismatch(self, runner: CliRunner, catalog_root: Path) -> None:
+        # team-a is kind=team but caller asks resolve agent.
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["resolve", "agent", "team-a", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 1
+        assert "has kind=team" in result.stderr
+
+    def test_resolve_invalid_kind_is_usage_error(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["resolve", "nonsense", "anything", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 2
+
+    def test_resolve_missing_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["resolve", "agent", "agent-a"],
+        )
+        assert result.exit_code == 2
+
+    def test_resolve_dangling_ref_surfaces_validation_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """AC30 — dangling __ref__ written bypassing ``Catalog.create`` surfaces exit 1."""
+        root = tmp_path / "catalog"
+        root.mkdir()
+        catalog = Catalog(YamlEntryRepository(root))
+        catalog.create(
+            Entry(
+                id="team-d",
+                kind="team",
+                namespace="ns-d",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        # Hand-write an agent file with a dangling __ref__, bypassing
+        # ``Catalog.create`` (which would reject it). Use the YAML repo's raw
+        # layout: root/ns-d/agent/agent-d.yaml.
+        agent_dir = root / "ns-d" / "agent"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        raw = {
+            "id": "agent-d",
+            "kind": "agent",
+            "namespace": "ns-d",
+            "user_id": "alice",
+            "parent_namespace": None,
+            "parent_id": None,
+            "model_type": _AGENT_TYPE,
+            "description": "",
+            "payload": {"linked": {"__ref__": "does-not-exist"}},
+        }
+        (agent_dir / "agent-d.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+        # Force a fresh Catalog wrapper — old instance is unused here.
+        _ = catalog
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(root)]
+            + ["resolve", "agent", "agent-d", "--namespace", "ns-d"],
+        )
+        assert result.exit_code == 1
+        assert "does-not-exist" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# `load-team` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestLoadTeamVerb:
+    """AC13-AC14 — load-team delegates to Catalog.load_team and renders a TeamCard."""
+
+    def test_load_team_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "load-team", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        # TeamCard has name/members; we assert on "name" field presence.
+        assert payload["name"] == "team"
+
+    def test_load_team_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["load-team", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "TeamCard" in result.stdout
+
+    def test_load_team_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "yaml", "load-team", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        payload = yaml.safe_load(result.stdout)
+        assert payload["name"] == "team"
+
+    def test_load_team_no_team_entry(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        root.mkdir()
+        result = runner.invoke(
+            cli_v2.app,
+            ["--backend", "yaml", "--root", str(root)]
+            + ["load-team", "--namespace", "does-not-exist"],
+        )
+        assert result.exit_code == 1
+        assert "no team entry" in result.stderr
+
+    def test_load_team_missing_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["load-team"],
+        )
+        assert result.exit_code == 2
+
+
+# --------------------------------------------------------------------------- #
+# `schema` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestSchemaVerb:
+    """AC17-AC19 + AC31-AC32 — JSON Schema export with allowlist gate."""
+
+    def test_schema_happy_json(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "schema", "akgentic.catalog.models.entry.Entry"],
+        )
+        assert result.exit_code == 0, result.stderr
+        body = json.loads(result.stdout)
+        assert body.get("title") == "Entry"
+        assert body.get("type") == "object"
+
+    def test_schema_table_falls_through_to_json(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        # AC18: table falls through to JSON — same bytes as json.
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["schema", "akgentic.catalog.models.entry.Entry"],
+        )
+        assert result.exit_code == 0, result.stderr
+        body = json.loads(result.stdout)
+        assert body.get("title") == "Entry"
+
+    def test_schema_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root)
+            + ["--format", "yaml", "schema", "akgentic.catalog.models.entry.Entry"],
+        )
+        assert result.exit_code == 0, result.stderr
+        body = yaml.safe_load(result.stdout)
+        assert body.get("title") == "Entry"
+
+    def test_schema_rejects_non_allowlisted(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["schema", "pydantic.BaseModel"],
+        )
+        assert result.exit_code == 1
+        assert "outside allowlist" in result.stderr
+
+    def test_schema_missing_module(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["schema", "akgentic.this.does.not.exist"],
+        )
+        assert result.exit_code == 1
+        # Rich console may wrap long stderr lines; collapse whitespace before asserting.
+        normalized = " ".join(result.stderr.split())
+        assert "could not be imported" in normalized
+
+
+# --------------------------------------------------------------------------- #
+# `model-types` verb
+# --------------------------------------------------------------------------- #
+
+
+class TestModelTypesVerb:
+    """AC20-AC22 + AC33 — reflection verb + helper factoring pin."""
+
+    def test_model_types_json_includes_entry(self, runner: CliRunner, catalog_root: Path) -> None:
+        # The test process has imported akgentic.catalog.models.entry by now
+        # (the test module imports Entry directly at the top).
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "model-types"],
+        )
+        assert result.exit_code == 0, result.stderr
+        paths = json.loads(result.stdout)
+        assert isinstance(paths, list)
+        assert "akgentic.catalog.models.entry.Entry" in paths
+
+    def test_model_types_yaml(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "yaml", "model-types"],
+        )
+        assert result.exit_code == 0, result.stderr
+        paths = yaml.safe_load(result.stdout)
+        assert "akgentic.catalog.models.entry.Entry" in paths
+
+    def test_model_types_table(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["model-types"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "akgentic.catalog.models.entry.Entry" in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# Helper-factoring regression pin (Task 1 / AC34)
+# --------------------------------------------------------------------------- #
+
+
+class TestHelperFactoringPin:
+    """AC21 + AC34 — the shared helper is importable from resolver and returns akgentic.* paths."""
+
+    def test_enumerate_helper_lives_on_resolver(self) -> None:
+        import akgentic.catalog.models.entry  # noqa: F401 — force-import to populate sys.modules
+        from akgentic.catalog.resolver import enumerate_allowlisted_model_types
+
+        paths = enumerate_allowlisted_model_types()
+        assert isinstance(paths, list)
+        assert all(p.startswith("akgentic.") for p in paths)
+        assert "akgentic.catalog.models.entry.Entry" in paths
+
+    def test_rest_endpoint_still_works_post_move(self, tmp_path: Path) -> None:
+        """REST ``GET /catalog/model_types`` still returns allowlisted paths post-move."""
+        pytest.importorskip("fastapi")
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from akgentic.catalog.api._errors import add_exception_handlers
+        from akgentic.catalog.api.router import router, set_catalog
+
+        repo = YamlEntryRepository(tmp_path / "catalog")
+        catalog = Catalog(repo)
+        app = FastAPI()
+        app.include_router(router)
+        set_catalog(catalog)
+        add_exception_handlers(app)
+        client = TestClient(app)
+        import akgentic.catalog.models.entry  # noqa: F401
+
+        response = client.get("/catalog/model_types")
+        assert response.status_code == 200
+        paths = response.json()
+        assert "akgentic.catalog.models.entry.Entry" in paths

--- a/tests/v2/test_cli_validate.py
+++ b/tests/v2/test_cli_validate.py
@@ -1,0 +1,692 @@
+"""Tests for the v2 ``ak-catalog`` CLI validate verb — Story 17.4.
+
+Exercises both flavors of ``ak-catalog validate``:
+
+* Persisted-state flavor: ``ak-catalog validate --namespace <ns>`` delegates
+  to :meth:`Catalog.validate_namespace` against the YAML-backed tmp-dir
+  ``Catalog`` seeded with a self-contained namespace (team + agent + tool).
+* Dry-run bundle flavor: ``ak-catalog validate <bundle-file>`` delegates to
+  :meth:`Catalog.validate_namespace_yaml` against a tmp YAML bundle file.
+
+The error-class parametrisations (AC17 / AC18) construct minimally-broken
+namespaces — one case per check surfaced by
+:func:`akgentic.catalog.validation.validate_entries` plus the resolver's
+ref-cycle and allowlist errors.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import BaseModel
+from typer.testing import CliRunner
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.cli import v2 as cli_v2
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.queries import EntryQuery
+from akgentic.catalog.repositories.yaml_entry_repo import YamlEntryRepository
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+_FIXTURE_MODULE = "akgentic.catalog.tests_fixture_17_4"
+_LEAF_TYPE = f"{_FIXTURE_MODULE}.LeafModel"
+_AGENT_TYPE = f"{_FIXTURE_MODULE}.AgentModel"
+_REQUIRED_TYPE = f"{_FIXTURE_MODULE}.RequiredFieldModel"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "entry",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _register_fixture_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register throwaway Pydantic classes under an ``akgentic.*`` module path."""
+
+    class LeafModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+
+    class AgentModel(BaseModel):
+        provider: str = "openai"
+        temperature: float = 0.0
+        linked: LeafModel | None = None
+
+    class RequiredFieldModel(BaseModel):
+        # No defaults — forces transient validation failure when required fields are absent.
+        must_be_present: str
+
+    module = types.ModuleType(_FIXTURE_MODULE)
+    module.LeafModel = LeafModel  # type: ignore[attr-defined]
+    module.AgentModel = AgentModel  # type: ignore[attr-defined]
+    module.RequiredFieldModel = RequiredFieldModel  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, _FIXTURE_MODULE, module)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _seed_namespace(root: Path, namespace: str = "ns-a", user_id: str = "alice") -> None:
+    catalog = Catalog(YamlEntryRepository(root))
+    catalog.create(
+        Entry(
+            id="team-a",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            description="primary team",
+            payload=_team_payload(),
+        )
+    )
+    catalog.create(
+        Entry(
+            id="tool-a",
+            kind="tool",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_LEAF_TYPE,
+            description="the tool",
+            payload={"provider": "openai", "temperature": 0.0},
+        )
+    )
+    catalog.create(
+        Entry(
+            id="agent-a",
+            kind="agent",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_AGENT_TYPE,
+            description="agent referencing tool",
+            payload={"provider": "openai", "temperature": 0.0, "linked": {"__ref__": "tool-a"}},
+        )
+    )
+
+
+@pytest.fixture
+def catalog_root(tmp_path: Path) -> Path:
+    root = tmp_path / "catalog"
+    root.mkdir()
+    _seed_namespace(root)
+    return root
+
+
+def _base_args(catalog_root: Path) -> list[str]:
+    return ["--backend", "yaml", "--root", str(catalog_root)]
+
+
+# --------------------------------------------------------------------------- #
+# Broken-namespace construction helpers (used by both flavors of AC17 / AC18)
+# --------------------------------------------------------------------------- #
+
+
+def _broken_bundles() -> dict[str, tuple[dict[str, Any], str]]:
+    """Return ``{case_id: (bundle_doc, expected_error_substring)}`` per error class.
+
+    Each bundle is a self-contained document-level dict (``namespace`` /
+    ``user_id`` / ``entries``) that, when written to YAML and fed through
+    ``ak-catalog validate <bundle-file>``, surfaces the named error class.
+    """
+    ns = "ns-a"
+    user = "alice"
+
+    def _entry(
+        kind: str,
+        model_type: str,
+        payload: dict[str, Any],
+        **extra: Any,
+    ) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "kind": kind,
+            "model_type": model_type,
+            "parent_namespace": None,
+            "parent_id": None,
+            "description": "",
+            "payload": payload,
+        }
+        base.update(extra)
+        return base
+
+    cases: dict[str, tuple[dict[str, Any], str]] = {
+        # Zero team entries — only a tool + an agent.
+        "missing_team": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "tool-a": _entry("tool", _LEAF_TYPE, {}),
+                    "agent-a": _entry("agent", _AGENT_TYPE, {"linked": {"__ref__": "tool-a"}}),
+                },
+            },
+            "no team entry",
+        ),
+        # Two team entries under the same namespace.
+        "multiple_teams": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "team-a": _entry("team", _TEAM_TYPE, _team_payload()),
+                    "team-b": _entry("team", _TEAM_TYPE, _team_payload()),
+                },
+            },
+            "multiple team entries",
+        ),
+        # NOTE: user_id mismatch is not reachable through the bundle parser
+        # because ``load_namespace`` stamps the document-level ``user_id`` onto
+        # every parsed entry uniformly. This class is covered in the persisted
+        # flavor only (see ``_persisted_cases`` below). Similarly, ref-cycle
+        # detection requires both targets to be resolvable via the live
+        # repository (``populate_refs`` walks the repo, not the parsed bundle);
+        # in a dry-run bundle flavor a cycle surfaces as a dangling-ref error,
+        # so the cycle class also lives only in the persisted flavor matrix.
+        # Dangling ref: agent-a points at an id absent from bundle + persisted.
+        "dangling_ref": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "team-a": _entry("team", _TEAM_TYPE, _team_payload()),
+                    "agent-a": _entry(
+                        "agent", _AGENT_TYPE, {"linked": {"__ref__": "does-not-exist"}}
+                    ),
+                },
+            },
+            "dangling ref",
+        ),
+        # Allowlist violation: a tool declaring a non-akgentic.* model_type.
+        # load_namespace -> Entry(**data) -> AllowlistedPath rejects it ->
+        # CatalogValidationError, which validate_namespace_yaml captures as a
+        # global error on the ``entry '<id>' is invalid`` wrapper.
+        "allowlist_violation": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "team-a": _entry("team", _TEAM_TYPE, _team_payload()),
+                    "tool-a": _entry("tool", "mypackage.Evil", {}),
+                },
+            },
+            "outside allowlist",
+        ),
+        # Half-set lineage pair: parent_id set, parent_namespace None (the
+        # Entry validator rejects the inverse; this direction is legal to
+        # construct and gets flagged by _check_lineage_pair).
+        "lineage_pair_half_set": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "team-a": _entry("team", _TEAM_TYPE, _team_payload()),
+                    "tool-a": _entry("tool", _LEAF_TYPE, {}, parent_id="orphan-parent"),
+                },
+            },
+            "lineage pair half-set",
+        ),
+        # Transient validation failure: payload missing required field.
+        "transient_validation": (
+            {
+                "namespace": ns,
+                "user_id": user,
+                "entries": {
+                    "team-a": _entry("team", _TEAM_TYPE, _team_payload()),
+                    "tool-a": _entry("tool", _REQUIRED_TYPE, {}),
+                },
+            },
+            "does not validate",
+        ),
+    }
+    return cases
+
+
+def _write_bundle(path: Path, bundle_doc: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(bundle_doc, sort_keys=False))
+
+
+def _seed_raw_entries(root: Path, namespace: str, entries: list[Entry]) -> None:
+    """Write ``entries`` into a YAML-backed repository bypassing Catalog.create."""
+    repo = YamlEntryRepository(root)
+    for entry in entries:
+        repo.put(entry)
+
+
+# --------------------------------------------------------------------------- #
+# Happy paths (AC15 + AC16 + AC22 + AC23)
+# --------------------------------------------------------------------------- #
+
+
+class TestValidateHappy:
+    """AC15 / AC16 / AC22 / AC23 — persisted + bundle happy paths + formats."""
+
+    @pytest.mark.parametrize("fmt", ["table", "json", "yaml"])
+    def test_persisted_happy(self, runner: CliRunner, catalog_root: Path, fmt: str) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", fmt, "validate", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert result.stderr == ""
+        if fmt == "json":
+            payload = json.loads(result.stdout)
+            assert payload["ok"] is True
+            assert payload["namespace"] == "ns-a"
+            assert payload["global_errors"] == []
+            assert payload["entry_issues"] == []
+        elif fmt == "yaml":
+            payload = yaml.safe_load(result.stdout)
+            assert payload["ok"] is True
+            assert payload["namespace"] == "ns-a"
+            assert payload["global_errors"] == []
+            assert payload["entry_issues"] == []
+        else:
+            assert "ok: True" in result.stdout
+            assert "ns-a" in result.stdout
+
+    def test_bundle_happy(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        # Export via the 17.3 export verb -> validate the same bundle.
+        export = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
+        )
+        assert export.exit_code == 0
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text(export.stdout)
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "validate", str(bundle_path)],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert result.stderr == ""
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True
+        assert payload["namespace"] == "ns-a"
+
+    def test_persisted_empty_namespace(self, runner: CliRunner, tmp_path: Path) -> None:
+        # AC15 — empty backend -> ok=False + AC11 stderr line.
+        root = tmp_path / "catalog"
+        root.mkdir()
+        result = runner.invoke(
+            cli_v2.app,
+            [
+                "--backend",
+                "yaml",
+                "--root",
+                str(root),
+                "--format",
+                "json",
+                "validate",
+                "--namespace",
+                "nope",
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        assert payload["namespace"] == "nope"
+        assert payload["global_errors"]
+        assert re.search(
+            r"validation failed: \d+ global error\(s\), \d+ entry issue\(s\)",
+            result.stderr,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Bundle non-destructiveness (AC19)
+# --------------------------------------------------------------------------- #
+
+
+class TestBundleNonDestructive:
+    """AC19 — a failing bundle validate leaves the persisted namespace untouched."""
+
+    def test_broken_bundle_does_not_mutate_repo(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        catalog = Catalog(YamlEntryRepository(catalog_root))
+        before = catalog.list(EntryQuery(namespace="ns-a"))
+        bundle, _ = _broken_bundles()["dangling_ref"]
+        bundle_path = tmp_path / "broken.yaml"
+        _write_bundle(bundle_path, bundle)
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["validate", str(bundle_path)],
+        )
+        assert result.exit_code == 1
+
+        after = Catalog(YamlEntryRepository(catalog_root)).list(EntryQuery(namespace="ns-a"))
+        # Byte-equivalent entries (same ids, same payloads).
+        assert [(e.id, e.payload) for e in before] == [(e.id, e.payload) for e in after]
+
+
+# --------------------------------------------------------------------------- #
+# Error-class coverage — bundle flavor (AC17)
+# --------------------------------------------------------------------------- #
+
+
+class TestBundleErrorClasses:
+    """AC17 — one parametrised case per error class, bundle flavor."""
+
+    @pytest.mark.parametrize("case_id", list(_broken_bundles().keys()))
+    def test_bundle_error_class(
+        self,
+        runner: CliRunner,
+        catalog_root: Path,
+        tmp_path: Path,
+        case_id: str,
+    ) -> None:
+        bundle, substring = _broken_bundles()[case_id]
+        bundle_path = tmp_path / f"{case_id}.yaml"
+        _write_bundle(bundle_path, bundle)
+
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "validate", str(bundle_path)],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        # substring must appear in at least one error surface.
+        haystack = (
+            " ".join(payload["global_errors"])
+            + " "
+            + " ".join(err for issue in payload["entry_issues"] for err in issue["errors"])
+        )
+        assert substring in haystack, f"expected substring {substring!r} in report; got {payload!r}"
+        assert re.search(
+            r"validation failed: \d+ global error\(s\), \d+ entry issue\(s\)",
+            result.stderr,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Error-class coverage — persisted flavor (AC18)
+# --------------------------------------------------------------------------- #
+
+
+def _persisted_cases() -> dict[str, tuple[list[Entry], str]]:
+    """Return ``{case_id: (entries_to_seed, expected_error_substring)}`` for
+    error classes reachable through direct repository seeding (bypassing
+    ``Catalog.create``). Classes that require Entry-construction-level
+    invalid data (``allowlist_violation``) are omitted — their coverage
+    lives in the bundle matrix only.
+    """
+    ns = "ns-a"
+    user = "alice"
+
+    def _e(**kw: Any) -> Entry:
+        base: dict[str, Any] = {
+            "namespace": ns,
+            "user_id": user,
+            "description": "",
+            "payload": {},
+        }
+        base.update(kw)
+        return Entry(**base)
+
+    cases: dict[str, tuple[list[Entry], str]] = {
+        "missing_team": (
+            [
+                _e(id="tool-a", kind="tool", model_type=_LEAF_TYPE),
+                _e(
+                    id="agent-a",
+                    kind="agent",
+                    model_type=_AGENT_TYPE,
+                    payload={"linked": {"__ref__": "tool-a"}},
+                ),
+            ],
+            "no team entry",
+        ),
+        "multiple_teams": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(id="team-b", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+            ],
+            "multiple team entries",
+        ),
+        "mismatched_user_id": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(
+                    id="tool-a",
+                    kind="tool",
+                    model_type=_LEAF_TYPE,
+                    user_id="bob",  # type: ignore[arg-type]
+                ),
+            ],
+            "user_id",
+        ),
+        "ref_cycle": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(
+                    id="agent-a",
+                    kind="agent",
+                    model_type=_AGENT_TYPE,
+                    payload={"linked": {"__ref__": "agent-b"}},
+                ),
+                _e(
+                    id="agent-b",
+                    kind="agent",
+                    model_type=_AGENT_TYPE,
+                    payload={"linked": {"__ref__": "agent-a"}},
+                ),
+            ],
+            "cycle",
+        ),
+        "dangling_ref": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(
+                    id="agent-a",
+                    kind="agent",
+                    model_type=_AGENT_TYPE,
+                    payload={"linked": {"__ref__": "does-not-exist"}},
+                ),
+            ],
+            "dangling ref",
+        ),
+        "lineage_pair_half_set": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(
+                    id="tool-a",
+                    kind="tool",
+                    model_type=_LEAF_TYPE,
+                    parent_id="orphan-parent",
+                ),
+            ],
+            "lineage pair half-set",
+        ),
+        "transient_validation": (
+            [
+                _e(id="team-a", kind="team", model_type=_TEAM_TYPE, payload=_team_payload()),
+                _e(id="tool-a", kind="tool", model_type=_REQUIRED_TYPE),
+            ],
+            "does not validate",
+        ),
+    }
+    return cases
+
+
+class TestPersistedErrorClasses:
+    """AC18 — one parametrised case per error class, persisted flavor."""
+
+    @pytest.mark.parametrize("case_id", list(_persisted_cases().keys()))
+    def test_persisted_error_class(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        case_id: str,
+    ) -> None:
+        entries, substring = _persisted_cases()[case_id]
+        root = tmp_path / "catalog"
+        root.mkdir()
+        _seed_raw_entries(root, "ns-a", entries)
+
+        result = runner.invoke(
+            cli_v2.app,
+            [
+                "--backend",
+                "yaml",
+                "--root",
+                str(root),
+                "--format",
+                "json",
+                "validate",
+                "--namespace",
+                "ns-a",
+            ],
+        )
+        assert result.exit_code == 1, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        haystack = (
+            " ".join(payload["global_errors"])
+            + " "
+            + " ".join(err for issue in payload["entry_issues"] for err in issue["errors"])
+        )
+        assert substring in haystack, f"expected substring {substring!r} in report; got {payload!r}"
+        assert re.search(
+            r"validation failed: \d+ global error\(s\), \d+ entry issue\(s\)",
+            result.stderr,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Argument exclusivity + usage errors (AC20 + AC21)
+# --------------------------------------------------------------------------- #
+
+
+class TestArgumentExclusivity:
+    """AC20 — zero-or-both args + empty-string namespace."""
+
+    def test_zero_args(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["validate"])
+        assert result.exit_code == 2
+        assert "requires either --namespace" in result.stderr
+
+    def test_both_args(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        bundle_path = tmp_path / "bundle.yaml"
+        bundle_path.write_text("dummy: true\n")
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["validate", "--namespace", "ns-a", str(bundle_path)],
+        )
+        assert result.exit_code == 2
+        assert "not both" in result.stderr
+
+    def test_empty_namespace(self, runner: CliRunner, catalog_root: Path) -> None:
+        result = runner.invoke(
+            cli_v2.app, _base_args(catalog_root) + ["validate", "--namespace", ""]
+        )
+        assert result.exit_code == 2
+
+
+class TestBundlePreflightErrors:
+    """AC21 — bundle-file pre-flight errors (missing / directory / utf-8 / yaml)."""
+
+    def test_missing_file(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist.yaml"
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["validate", str(missing)])
+        assert result.exit_code == 2
+        assert "file not found" in result.stderr
+
+    def test_directory_not_file(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "a-directory"
+        d.mkdir()
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["validate", str(d)])
+        assert result.exit_code == 2
+        assert "file not found" in result.stderr
+
+    def test_non_utf8_file(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "garbage.yaml"
+        bad.write_bytes(b"\xff\xfe\x00\x00\xff\xff")
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["validate", str(bad)])
+        assert result.exit_code == 2
+        assert "not valid UTF-8" in result.stderr
+
+    def test_malformed_yaml(self, runner: CliRunner, catalog_root: Path, tmp_path: Path) -> None:
+        bad = tmp_path / "malformed.yaml"
+        bad.write_text(":\n-[[[\n")
+        result = runner.invoke(cli_v2.app, _base_args(catalog_root) + ["validate", str(bad)])
+        assert result.exit_code == 2
+        assert "YAML parse error" in result.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Stdout discipline (AC23)
+# --------------------------------------------------------------------------- #
+
+
+class TestStdoutDiscipline:
+    """AC23 — stdout carries only the report; stderr carries summary on failure."""
+
+    def test_happy_stdout_has_report_stderr_empty(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        result = runner.invoke(
+            cli_v2.app,
+            _base_args(catalog_root) + ["--format", "json", "validate", "--namespace", "ns-a"],
+        )
+        assert result.exit_code == 0
+        assert result.stderr == ""
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True
+
+    def test_failure_stdout_has_report_stderr_has_summary(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "catalog"
+        root.mkdir()
+        result = runner.invoke(
+            cli_v2.app,
+            [
+                "--backend",
+                "yaml",
+                "--root",
+                str(root),
+                "--format",
+                "json",
+                "validate",
+                "--namespace",
+                "nope",
+            ],
+        )
+        assert result.exit_code == 1
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is False
+        assert re.search(
+            r"validation failed: \d+ global error\(s\), \d+ entry issue\(s\)",
+            result.stderr,
+        )


### PR DESCRIPTION
Umbrella PR for Epic 17 — Unified CLI (ak-catalog). STACKED on Epic 16 PR #113. Base branch: feat/112-epic-16-rest-api-and-schema. Must be merged AFTER PRs #107 and #113.

## Stories

- [x] 17-1-cli-foundation-global-options-core-crud-verbs (Relates to #116)
- [x] 17-2-graph-verbs-schema-introspection (Relates to #118)
- [x] 17-3-namespace-bundle-export-import (Relates to #119)
- [x] 17-4-namespace-validation-validate (Relates to #120)

## Review status

- 17-1: PASS. New `cli/v2.py` Typer app with `CliState` Pydantic model, per-kind sub-apps for `team/agent/tool/model/prompt`, and verbs `list/get/create/update/delete/search`. Thin delegation into `Catalog`. Global options validated in a root callback; mongo wiring lazy-imported with a deterministic "optional extra" error. Entry-point repointed from `cli.main:app` to `cli.v2:app` with a regression pin. `CliState` round-trip test present. No cross-submodule changes; no `dict[str, Any]` on boundaries; no ADR-string assertions.
- 17-2 review: PASS. Six graph + schema verbs (`clone`, `references`, `resolve`, `load-team`, `schema`, `model-types`) added as thin delegators to `Catalog` / `resolver.load_model_type`. `_enumerate_allowlisted_model_types` factored into `resolver.py` as the public `enumerate_allowlisted_model_types`; REST router consumes the public helper and its behavior is regression-pinned. `CloneRequest` built from CLI args with empty-string `--dst-user-id` normalized to `None` (ADR-007 enterprise sentinel). Kind-mismatch guard mirrors `get`. New `_render_model` + `_render_schema` helpers, all stderr discipline via `err_console`, all exits via `typer.Exit`. No cross-submodule edits, no `dict[str, Any]` on boundaries, no ADR-string assertions. Local gates: 1188 passed, 92.99% branch coverage, ruff clean, mypy strict clean.
- 17-3 review: PASS. `export` and `import` (with `--dry-run`) verbs added to `cli/v2.py` as thin delegators into `Catalog.export_namespace_yaml` / `import_namespace_yaml` / `validate_namespace_yaml`. `export` writes byte-exact YAML via stdlib `print(..., end="")` preserving round-trip fidelity; `import` pre-flights path / UTF-8 / YAML parse (exit 2), maps `CatalogValidationError` to exit 1 with `"validation error:"`-prefixed stderr, emits the success line to stderr leaving stdout empty. Dry-run derives exit code from `report.ok` alone, renders `NamespaceValidationReport` in `table` / `json` / `yaml` via a sub-50-line `_render_validation_report` helper with sub-helpers. Empty `--namespace` rejected at parse time via callback. 18 new tests cover round-trip + mutation, atomic-failure-leaves-namespace-untouched, dry-run happy / failure parametrised over all formats, and every AC22 usage-error shape. No cross-submodule edits, no `dict[str, Any]` on boundaries, no ADR-string assertions. Local gates: 1206 passed, ruff clean, mypy strict clean.
- 17-4 review: PASS. Root-level `validate` verb added to `cli/v2.py` as a thin delegator into `Catalog.validate_namespace` (persisted flavor) and `Catalog.validate_namespace_yaml` (bundle-file flavor). Argument-exclusivity gate (zero-or-both → exit 2) enforced in the verb body; `--namespace ""` rejected at parse time via a reused `_require_non_empty_namespace_optional` callback. Bundle-file pre-flight delegates to the shared 17.3 `_read_bundle_text`. Exit codes derived from `report.ok` alone (0/1); usage/parse errors exit 2. New `_emit_validation_failure(report)` helper extracts the AC11 summary-line path so 17.3's `_import_dry_run_mode` and 17.4's verb share one code path; the helper was refactored into 17.3 with no behavior drift. `_render_validation_report` is reused verbatim. New tests cover persisted happy path across `table/json/yaml`, bundle happy path, empty-namespace failure, non-destructiveness (AC19: list-before == list-after for a broken bundle), bundle error-class matrix (7 classes: missing_team, multiple_teams, dangling_ref, allowlist_violation, lineage_pair_half_set, transient_validation — with documented rationale for why user-id-mismatch and ref-cycle are persisted-only), persisted error-class matrix (7 classes including mismatched_user_id and ref_cycle), argument-exclusivity, bundle pre-flight (missing/directory/non-UTF-8/malformed-YAML), and stdout/stderr discipline. No cross-submodule edits, no `dict[str, Any]` on boundaries, no ADR-string assertions. Local gates: 1234 passed, ruff clean, ruff format clean, mypy strict clean on 56 source files.

## Scope guard

All changes confined to `packages/akgentic-catalog/`.

## CI policy

Local verification only this run (pytest + ruff + mypy). CI gates are stripped per user override.

- pytest: 1234 passed, `cli/v2.py` well above the 80% gate.
- ruff check: clean.
- ruff format --check: clean.
- mypy (strict): clean (56 source files).

## Stacking

master ← PR #107 (Epic 15) ← PR #113 (Epic 16) ← THIS PR (Epic 17) ← future PR (Epic 19). Epic 18 runs sideways across akgentic-team / akgentic-infra / akgentic-infra-enterprise.

## Epic 17 slice complete

All four stories of Epic 17 have landed on this umbrella PR. Amelia implemented each in sequence, Rex reviewed each against the checklist, and every story closed PASS on first review with zero fixup commits from Rex.

- Issue map:
  - 17-1 → issue #116
  - 17-2 → issue #118
  - 17-3 → issue #119
  - 17-4 → issue #120
- Rex fixup commits per story: 17-1 → 0, 17-2 → 0, 17-3 → 0, 17-4 → 0. Total Rex fixups on Epic 17: 0.
- The v2 `ak-catalog` CLI is now feature-complete for Epics 15 + 16's service + REST surfaces — full CRUD, search, graph (clone/references/resolve/load-team), schema introspection, namespace bundle export/import (with `--dry-run`), and root-level validate (persisted + bundle flavors).
- Next: Epic 19's umbrella PR will stack directly on THIS branch (it retires the v1 CLI modules now that v2 has parity + more). Epic 18 (infra migration) runs sideways across akgentic-team / akgentic-infra / akgentic-infra-enterprise and does not stack on this PR.
