### PR TITLE
feat(akgentic-catalog): 15.7 YAML writer uses block scalars for multi-line strings

### DIFF
--- a/src/akgentic/catalog/repositories/yaml.py
+++ b/src/akgentic/catalog/repositories/yaml.py
@@ -35,6 +35,32 @@ logger = logging.getLogger(__name__)
 _list = builtins.list  # Alias: the repository's list() method shadows the built-in
 
 
+class _BlockScalarDumper(yaml.SafeDumper):
+    """SafeDumper subclass that emits multi-line ``str`` values as ``|`` block scalars.
+
+    PyYAML's default representer picks single-quoted flow style for strings
+    containing newlines, which renders each ``\\n`` as a visible blank line on
+    disk. Registering a scoped ``str`` representer on this subclass — rather
+    than mutating the global registry via ``yaml.add_representer`` — keeps the
+    change local to callers that opt in via ``Dumper=_BlockScalarDumper``.
+
+    PyYAML automatically picks ``|`` vs ``|-`` based on trailing-newline
+    presence, and falls back to double-quoted for values it cannot faithfully
+    represent in block style (e.g. strings with tabs). No additional predicate
+    is required here.
+    """
+
+
+def _represent_str_block(dumper: yaml.SafeDumper, data: str) -> yaml.ScalarNode:
+    """Represent ``str`` as a ``|`` block scalar when it contains a newline."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_BlockScalarDumper.add_representer(str, _represent_str_block)
+
+
 def _payload_has_ref(node: object, target_id: str) -> bool:
     """Depth-first scan for any ``{"__ref__": target_id}`` marker in ``node``.
 
@@ -130,6 +156,7 @@ class YamlEntryRepository:
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = yaml.dump(
             entry.model_dump(mode="json"),
+            Dumper=_BlockScalarDumper,
             default_flow_style=False,
             sort_keys=False,
             allow_unicode=True,

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -28,6 +28,7 @@ from pydantic import ValidationError
 
 from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.repositories.yaml import _BlockScalarDumper
 
 __all__ = ["dump_namespace", "load_namespace"]
 
@@ -96,7 +97,13 @@ def dump_namespace(entries: list[Entry]) -> str:
         "user_id": entries[0].user_id,
         "entries": {e.id: _entry_to_map(e) for e in sorted_entries},
     }
-    return yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, default_flow_style=False)
+    return yaml.dump(
+        doc,
+        Dumper=_BlockScalarDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
 
 
 def _check_uniform_owner(entries: list[Entry]) -> list[str]:

--- a/tests/repositories/test_yaml_dumper.py
+++ b/tests/repositories/test_yaml_dumper.py
@@ -1,0 +1,71 @@
+"""Tests for the ``_BlockScalarDumper`` subclass defined in ``repositories/yaml.py``.
+
+Story 15.7: YAML writer uses block-scalar style for multi-line strings.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from akgentic.catalog.repositories.yaml import _BlockScalarDumper
+
+
+def test_multiline_string_uses_block_scalar() -> None:
+    """AC1: a multi-line ``str`` value is emitted as a ``|`` block scalar."""
+    data = {
+        "instructions": (
+            "CRITICAL: Always keep the plan updated.\n"
+            "Create tasks when your task involves other team members\n"
+            "or is complex enough to require multiple steps."
+        )
+    }
+    out = yaml.dump(
+        data,
+        Dumper=_BlockScalarDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    # The emitter should use a block-scalar header (`|` or `|-`), not a
+    # single-quoted flow scalar.
+    assert "instructions: |" in out
+    assert "instructions: '" not in out
+    # No blank lines should appear between the non-empty input lines.
+    assert "\n\n" not in out.rstrip("\n")
+
+
+def test_singleline_string_is_not_forced_to_block_scalar() -> None:
+    """AC2: a single-line ``str`` value keeps PyYAML's default (plain) style."""
+    data = {"name": "Planning"}
+    out = yaml.dump(
+        data,
+        Dumper=_BlockScalarDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    # No block-scalar header for one-liners.
+    assert "|" not in out
+    assert out.strip() == "name: Planning"
+
+
+def test_roundtrip_preserves_string_content() -> None:
+    """AC3: mixed single/multi-line payloads survive dump → safe_load byte-faithfully."""
+    data = {
+        "single": "Planning",
+        "multi": "line one\nline two\nline three",
+        "trailing_newline": "ends with newline\n",
+        "nested": {
+            "block": "a\nb\nc",
+            "plain": "short",
+        },
+    }
+    out = yaml.dump(
+        data,
+        Dumper=_BlockScalarDumper,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    reloaded = yaml.safe_load(out)
+    assert reloaded == data


### PR DESCRIPTION
## Summary

Adds a scoped `SafeDumper` subclass (`_BlockScalarDumper`) in `repositories/yaml.py` with a `str` representer that emits multi-line string values as block scalars (`|` / `|-`) rather than PyYAML's default single-quoted flow style. The representer is installed on the subclass only — unrelated PyYAML consumers in the same process keep the library default behaviour.

**Changes (trimmed scope, per rewritten story 15.7):**

- `repositories/yaml.py`: add `_BlockScalarDumper(yaml.SafeDumper)` and `_represent_str_block`; `YamlEntryRepository.put` passes `Dumper=_BlockScalarDumper`.
- `serialization.py`: `dump_namespace` swaps `yaml.safe_dump` → `yaml.dump(..., Dumper=_BlockScalarDumper, ...)`.
- `tests/repositories/test_yaml_dumper.py`: three tests covering AC1 (multi-line → block scalar), AC2 (single-line unchanged), AC3 (byte-faithful round-trip).

PyYAML automatically picks `|` vs `|-` based on trailing-newline presence and falls back to double-quoted for inputs it cannot faithfully represent in block style — no hand-rolled predicate required.

**Out of scope (per story):** CLI printers in `cli/main.py` (terminal output, not a diff surface); tab / leading-space fallback predicate (PyYAML handles it); `dump_yaml` helper module (subclass is ~5 lines, inlined next to caller).

## Stacking

Branched from `feat/126-15-6-ref-splice-typed-instance` because the v2 catalog layout this story edits (single `repositories/yaml.py` + `serialization.py`) has not yet landed on master. PR targets that branch, not master.

## Re-run note

The previous version of story 15.7 was marked `done` with an inflated scope (9 call sites, a `_yaml_dumper.py` helper module, an `_is_block_scalar_safe` predicate, CLI printer migration). That scope was challenged, the story was rewritten to ~5 lines + 3 tests, and the branch was force-reset to the 15.6 base. The commit on this PR (`0e78a6c`) supersedes the prior cancelled implementation. The commit subject/body still reads as the old (pre-rewrite) narrative — see the `Files changed` tab for the actual diff, which matches the trimmed story spec.

Relates to #128
