### PR TITLE
feat(akgentic-catalog): 16-4 declare request bodies for namespace import/validate POST

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -33,7 +33,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Body, HTTPException, Query, Response
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
@@ -148,13 +148,18 @@ async def export_namespace(namespace: str) -> Response:
 
 
 @router.post("/namespace/import", response_model=list[Entry], status_code=201)
-async def import_namespace(request: Request) -> list[Entry]:
+async def import_namespace(
+    body: bytes = Body(..., media_type="application/yaml"),
+) -> list[Entry]:
     """Import a bundle YAML document as an atomic namespace replacement.
 
-    The request body is read verbatim (no JSON / form parsing) and decoded as
-    UTF-8. Non-UTF-8 bodies surface as ``HTTPException(400)``. The
-    convention is ``Content-Type: application/yaml`` but the handler does NOT
-    enforce the header — the body shape is authoritative.
+    The request body is declared via ``Body(..., media_type="application/yaml")``
+    so the OpenAPI schema advertises it and Swagger UI renders a textarea.
+    FastAPI passes the raw bytes through untouched — the YAML parser and the
+    custom error mapping continue to own the decode/parse path. Non-UTF-8
+    bodies surface as ``HTTPException(400)``. The convention is
+    ``Content-Type: application/yaml`` but the handler does NOT enforce the
+    header — the body shape is authoritative.
 
     The target namespace is taken from the bundle's document-level
     ``namespace`` key, not the request URL — the bundle body is the single
@@ -162,7 +167,6 @@ async def import_namespace(request: Request) -> list[Entry]:
     :meth:`Catalog.import_namespace_yaml` propagates to the 409 handler.
     """
     logger.debug("POST /catalog/namespace/import")
-    body = await request.body()
     try:
         yaml_text = body.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -189,20 +193,25 @@ async def validate_namespace_get(namespace: str) -> NamespaceValidationReport:
 
 
 @router.post("/namespace/validate", response_model=NamespaceValidationReport)
-async def validate_namespace_post(request: Request) -> NamespaceValidationReport:
+async def validate_namespace_post(
+    body: bytes = Body(..., media_type="application/yaml"),
+) -> NamespaceValidationReport:
     """Dry-run validate a proposed bundle YAML — AC23.
 
-    Body convention: ``application/yaml`` (the body is read verbatim; the
-    handler does not enforce the header). Non-UTF-8 bodies surface as HTTP
-    422; malformed YAML surfaces as HTTP 422 (transport-level structural
-    parse failure, per shard 07's "structural request-body errors (malformed
-    YAML) still surface as 422" contract; promoted from the service's
-    200-with-``ok=false`` internal contract per AC24). Every other
-    validation failure — semantic, structural, per-entry — returns HTTP 200
-    with ``ok=false`` and the report as the payload.
+    The request body is declared via ``Body(..., media_type="application/yaml")``
+    so the OpenAPI schema advertises it and Swagger UI renders a textarea.
+    FastAPI passes the raw bytes through untouched; the handler owns the
+    decode / parse / validate path. Non-UTF-8 bodies surface as HTTP 422;
+    malformed YAML surfaces as HTTP 422 (transport-level structural parse
+    failure, per shard 07's "structural request-body errors (malformed YAML)
+    still surface as 422" contract; promoted from the service's
+    200-with-``ok=false`` internal contract per AC24). Every other validation
+    failure — semantic, structural, per-entry — returns HTTP 200 with
+    ``ok=false`` and the report as the payload. The ``media_type`` argument
+    is documentation only; the handler does not enforce the Content-Type
+    header.
     """
     logger.debug("POST /catalog/namespace/validate")
-    body = await request.body()
     try:
         yaml_text = body.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/tests/v2/test_request_body_declarations.py
+++ b/tests/v2/test_request_body_declarations.py
@@ -1,0 +1,209 @@
+"""Request-body declaration tests for Story 16.4.
+
+Covers the OpenAPI-visibility swap of ``POST /catalog/namespace/import`` and
+``POST /catalog/namespace/validate`` from a raw ``Request`` read to a
+``Body(..., media_type="application/yaml")`` declaration. Happy-path and
+error-path behaviour for these endpoints is covered in
+``test_api_router.py``; this file focuses on:
+
+* OpenAPI schema advertises both request bodies (AC #1, #2).
+* Missing body produces a consistent HTTP 422 (AC #8).
+* Mismatched / missing ``Content-Type`` header still processes the body
+  (AC #9 — ``media_type`` is documentation, not enforcement).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from akgentic.catalog.catalog import Catalog  # noqa: E402
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+_AGENT_TYPE = "akgentic.core.agent_card.AgentCard"
+
+
+def _team_payload() -> dict[str, Any]:
+    """Return a minimal valid ``TeamCard`` payload."""
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+def _agent_payload(name: str = "a") -> dict[str, Any]:
+    """Return a minimal valid ``AgentCard`` payload."""
+    return {
+        "role": "r",
+        "description": "",
+        "skills": [],
+        "agent_class": "akgentic.core.agent.Akgent",
+        "config": {"name": name, "role": "r"},
+        "routes_to": [],
+        "metadata": {},
+    }
+
+
+def _build_bundle(namespace: str = "ns-body") -> str:
+    """Return a minimal, structurally valid bundle YAML string."""
+    import yaml as _yaml
+
+    doc = {
+        "namespace": namespace,
+        "user_id": "alice",
+        "entries": {
+            "team": {
+                "kind": "team",
+                "model_type": _TEAM_TYPE,
+                "parent_namespace": None,
+                "parent_id": None,
+                "description": "",
+                "payload": _team_payload(),
+            },
+            "a": {
+                "kind": "agent",
+                "model_type": _AGENT_TYPE,
+                "parent_namespace": None,
+                "parent_id": None,
+                "description": "",
+                "payload": _agent_payload("a"),
+            },
+        },
+    }
+    return _yaml.safe_dump(doc, sort_keys=False)
+
+
+# --- AC #1, #2: OpenAPI schema declares both request bodies ----------------
+
+
+class TestOpenAPISchema:
+    """``/openapi.json`` advertises ``requestBody`` for both POST endpoints."""
+
+    def _openapi(self, api_client: tuple[TestClient, Catalog]) -> dict[str, Any]:
+        client, _ = api_client
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema: dict[str, Any] = response.json()
+        return schema
+
+    def _request_body(
+        self, schema: dict[str, Any], path: str
+    ) -> dict[str, Any]:
+        """Extract the ``requestBody`` dict for ``POST {path}``."""
+        op = schema["paths"][path]["post"]
+        request_body = op.get("requestBody")
+        assert request_body is not None, f"POST {path} has no requestBody"
+        assert isinstance(request_body, dict)
+        return request_body
+
+    def test_import_declares_request_body(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        schema = self._openapi(api_client)
+        body = self._request_body(schema, "/catalog/namespace/import")
+        assert body.get("required") is True
+        assert "application/yaml" in body["content"]
+
+    def test_validate_declares_request_body(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        schema = self._openapi(api_client)
+        body = self._request_body(schema, "/catalog/namespace/validate")
+        assert body.get("required") is True
+        assert "application/yaml" in body["content"]
+
+
+# --- AC #8: missing body produces a consistent 422 --------------------------
+
+
+class TestMissingBody:
+    """Empty-body POSTs surface as HTTP 422 for both routes."""
+
+    def test_import_missing_body_422(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client
+        response = client.post("/catalog/namespace/import")
+        assert response.status_code == 422
+
+    def test_validate_missing_body_422(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client
+        response = client.post("/catalog/namespace/validate")
+        assert response.status_code == 422
+
+
+# --- AC #9: Content-Type header is documentation, not enforcement -----------
+
+
+class TestContentTypeNotEnforced:
+    """A valid bundle is processed under any non-JSON Content-Type.
+
+    FastAPI's ``Body(bytes, media_type=...)`` reads the raw body when the
+    request's ``Content-Type`` is anything other than ``application/json``;
+    for ``application/json`` FastAPI interposes JSON parsing regardless of
+    the ``media_type`` declaration. The ``application/json`` clash is a
+    FastAPI invariant — not a handler-level contract — and is not exercised
+    here. The tests below verify the remaining "header is not enforced"
+    surface: ``application/yaml`` (declared default), ``text/plain``
+    (mismatched but tolerated), and the httpx default (no explicit header).
+    """
+
+    def test_import_accepts_text_plain_content_type(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client
+        yaml_text = _build_bundle(namespace="ns-body-imp-ct")
+        response = client.post(
+            "/catalog/namespace/import",
+            content=yaml_text.encode("utf-8"),
+            headers={"Content-Type": "text/plain"},
+        )
+        assert response.status_code == 201
+        assert {e["id"] for e in response.json()} == {"team", "a"}
+
+    def test_validate_accepts_text_plain_content_type(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client
+        yaml_text = _build_bundle(namespace="ns-body-val-ct")
+        response = client.post(
+            "/catalog/namespace/validate",
+            content=yaml_text.encode("utf-8"),
+            headers={"Content-Type": "text/plain"},
+        )
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    def test_import_accepts_default_content_type(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """httpx's default Content-Type for ``content=bytes`` is not JSON — the
+        handler must still accept the body verbatim.
+        """
+        client, _ = api_client
+        yaml_text = _build_bundle(namespace="ns-body-imp-noct")
+        response = client.post(
+            "/catalog/namespace/import",
+            content=yaml_text.encode("utf-8"),
+        )
+        assert response.status_code == 201


### PR DESCRIPTION
## Summary

Swap both `POST /catalog/namespace/import` and `POST /catalog/namespace/validate` from a raw `Request.body()` read to the declarative `body: bytes = Body(..., media_type="application/yaml")` form. The OpenAPI schema now advertises the request body, Swagger UI renders a textarea, and missing bodies surface as a consistent HTTP 422 instead of the prior semantic `ok=false` surprise.

Behaviour-preserving rewrite:
- Non-UTF-8 bodies: HTTP 400 on `/import`, HTTP 422 on `/validate` (asymmetry preserved verbatim — out of scope to unify).
- Malformed YAML: HTTP 422 on both.
- Content-Type: handler does not enforce (declared `application/yaml` is documentation).

## Accepted deviation — AC #9

Testing confirmed `Body(bytes, media_type="application/yaml")` cannot accept `Content-Type: application/json` — FastAPI interposes JSON parsing for that header regardless of `media_type`. This is a FastAPI invariant, not a handler contract. The deviation is documented in the story's Dev Agent Record and the new test module's docstring; tests exercise the supported surface (`application/yaml`, `text/plain`, httpx default). Reviewer (Rex) accepted this as a reasonable pragmatic reading of AC #9 — YAML is the canonical input format.

## Tests

- `tests/v2/test_request_body_declarations.py` — 7 new tests (2 OpenAPI schema, 2 missing body, 3 content-type tolerance).
- All existing router tests continue to pass verbatim (`Body(bytes, ...)` is a drop-in for raw `Request.body()` when the client sends bytes).
- `ruff check` clean, `mypy --strict` clean (22 source files), `pytest packages/akgentic-catalog/tests/` — 597 passed.

## Stacked PR base

Base branch is `feat/128-yaml-block-scalars` (Story 15.7) rather than `master` — master lacks the Epic 15/16 v2 router code this story builds on. The PR stack will collapse to master via `/ak-epic-merge` at epic close.

Relates to #130
