### PR TITLE
feat(akgentic-catalog): 16-5 order bundle export entries by kind

### DIFF
--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -34,6 +34,19 @@ __all__ = ["dump_namespace", "load_namespace"]
 
 logger = logging.getLogger(__name__)
 
+# Kind emit order for bundle serialisation: team → agent → prompt → tool → model.
+# Reading a bundle top-down then mirrors the consumption graph: teams consume
+# agents; agents consume prompts, tools, and models. ``EntryKind`` is a closed
+# ``Literal`` of exactly these five values, so indexing by ``e.kind`` is safe
+# without a fallback.
+_KIND_EMIT_ORDER: dict[str, int] = {
+    "team": 0,
+    "agent": 1,
+    "prompt": 2,
+    "tool": 3,
+    "model": 4,
+}
+
 
 # --- dump_namespace ---------------------------------------------------------
 
@@ -60,9 +73,11 @@ def dump_namespace(entries: list[Entry]) -> str:
     re-resolve, re-validate, or re-reconcile; stored payloads are already
     intent-preserving.
 
-    Entries are emitted in a stable order: the single ``kind="team"`` entry
-    first, then the remaining entries sorted by ``id`` (lexicographic,
-    unicode codepoint order).
+    Entries are emitted in a stable order grouped by kind in consumption
+    order — ``team`` → ``agent`` → ``prompt`` → ``tool`` → ``model`` — and
+    within each kind sorted by ``id`` (lexicographic, unicode codepoint
+    order). Reading a bundle top-down then matches the dependency tree:
+    teams consume agents; agents consume prompts, tools, and models.
 
     Args:
         entries: Non-empty list of ``Entry`` instances sharing a single
@@ -127,10 +142,15 @@ def _check_uniform_namespace(entries: list[Entry]) -> list[str]:
 
 
 def _sort_entries_for_emit(entries: list[Entry]) -> list[Entry]:
-    """Return a new list with the team entry (if any) first, others sorted by id."""
-    team = [e for e in entries if e.kind == "team"]
-    non_team = sorted((e for e in entries if e.kind != "team"), key=lambda e: e.id)
-    return team + non_team
+    """Return a new list sorted by (kind emit order, id).
+
+    Kind order follows ``_KIND_EMIT_ORDER`` — ``team`` → ``agent`` →
+    ``prompt`` → ``tool`` → ``model`` — the consumption graph. Within each
+    kind, entries are sorted by ``id`` (lexicographic). ``EntryKind`` is a
+    closed ``Literal`` of exactly these five values, so direct indexing
+    (no ``.get`` fallback) is safe.
+    """
+    return sorted(entries, key=lambda e: (_KIND_EMIT_ORDER[e.kind], e.id))
 
 
 def _entry_to_map(entry: Entry) -> dict[str, Any]:

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -92,6 +92,54 @@ class TestDumpNamespace:
         doc = yaml.safe_load(text)
         assert list(doc["entries"].keys()) == ["team", "a", "b", "c"]
 
+    def test_emit_order_groups_by_kind_then_id(self) -> None:
+        """Entries emit in kind order (team, agent, prompt, tool, model) then id."""
+        prompt_a = Entry(
+            id="prompt_a",
+            kind="prompt",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.llm.prompts.PromptTemplate",
+            payload={},
+        )
+        tool_a = Entry(
+            id="tool_a",
+            kind="tool",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.tool.tool_card.ToolCard",
+            payload={},
+        )
+        model_b = Entry(
+            id="model_b",
+            kind="model",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.llm.model_config.ModelConfig",
+            payload={},
+        )
+        model_a = Entry(
+            id="model_a",
+            kind="model",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.llm.model_config.ModelConfig",
+            payload={},
+        )
+        # Input order scrambled on purpose; two models verify intra-kind id sub-sort.
+        entries = [model_b, tool_a, _agent("zulu"), prompt_a, model_a, _agent("alpha"), _team()]
+        text = dump_namespace(entries)
+        doc = yaml.safe_load(text)
+        assert list(doc["entries"].keys()) == [
+            "team",
+            "alpha",
+            "zulu",
+            "prompt_a",
+            "tool_a",
+            "model_a",
+            "model_b",
+        ]
+
     def test_rejects_empty_list(self) -> None:
         with pytest.raises(CatalogValidationError) as exc_info:
             dump_namespace([])


### PR DESCRIPTION
## Summary

Story 16-5: Bundle export orders entries by kind (team → agent → prompt → tool → model), with ids sorted within each kind. A bundle now reads top-down as a dependency tree — teams consume agents; agents consume prompts, tools, and models.

- Add module-level `_KIND_EMIT_ORDER` mapping in `serialization.py`.
- Rewrite `_sort_entries_for_emit` to sort by `(kind emit order, id)`; rely on the closed `EntryKind` `Literal` for safe direct indexing (no `.get` fallback).
- Update `dump_namespace` docstring to describe the new "kind-then-id" rule.
- Add a test covering all five kinds with intra-kind id sub-sort.

## Stack

This PR is **stacked on #131** (story 16-4).
Base branch: `feat/130-declare-request-bodies-import-validate`. Merge #131 first.

## Review

Rex reviewed commit `9fa6c54`. No fix-worthy issues — diff is minimal, tightly scoped to the AC, docstrings updated, test exercises all five kinds and verifies intra-kind id sub-sort. Full catalog suite passes (598 tests); ruff + mypy strict clean.

Relates to #132
