### PR TITLE
feat(akgentic-catalog): 16.6 list namespaces endpoint

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 from fastapi import APIRouter, Body, HTTPException, Query, Response
+from pydantic import BaseModel
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
@@ -44,7 +45,22 @@ from akgentic.catalog.validation import NamespaceValidationReport
 if TYPE_CHECKING:
     from akgentic.catalog.catalog import Catalog
 
-__all__ = ["router", "set_catalog"]
+__all__ = ["NamespaceSummary", "router", "set_catalog"]
+
+
+class NamespaceSummary(BaseModel):
+    """Flat DTO for ``GET /catalog/namespaces`` — one row per namespace.
+
+    Every catalog namespace contains exactly one ``kind="team"`` entry
+    (enforced by the catalog service), so "list namespaces" is equivalent to
+    "list team entries, project to this DTO". The shape intentionally omits
+    ``user_id``, ``parent_namespace``, and other entry-model fields to keep
+    the payload minimal and to avoid leaking tenancy design to the picker.
+    """
+
+    namespace: str
+    name: str
+    description: str
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +93,30 @@ def _ensure_kind(entry_kind: EntryKind, path_kind: EntryKind) -> None:
 
 
 # --- Static-path routes (must precede /{kind} routes) -----------------------
+
+
+@router.get("/namespaces", response_model=list[NamespaceSummary])
+async def list_namespaces() -> list[NamespaceSummary]:
+    """List every catalog namespace with its team name and description.
+
+    Equivalent to listing ``kind="team"`` entries and projecting each to
+    ``NamespaceSummary``. The list is sorted alphabetically by ``namespace``.
+    No ``user_id`` filter is applied — callers (or tier-specific middleware)
+    are responsible for tenancy filtering. Namespaces that somehow lack a
+    team entry are skipped silently (defensive guard for a state the catalog
+    invariants should prevent).
+    """
+    logger.debug("GET /catalog/namespaces")
+    teams = _get_catalog().list(EntryQuery(kind="team"))
+    summaries = [
+        NamespaceSummary(
+            namespace=t.namespace,
+            name=str(t.payload.get("name", "")),
+            description=t.description,
+        )
+        for t in teams
+    ]
+    return sorted(summaries, key=lambda s: s.namespace)
 
 
 @router.post("/clone", response_model=Entry, status_code=201)

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -1088,6 +1088,149 @@ def test_router_namespace_validate_malformed_yaml_returns_422(
     assert "failed to parse bundle YAML" in response.json()["detail"]
 
 
+# --- List namespaces (Story 16.6) ------------------------------------------
+
+
+class TestListNamespaces:
+    """``GET /catalog/namespaces`` — Story 16.6 ACs 1-5."""
+
+    def test_empty_catalog_returns_empty_list(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #2 — empty catalog → HTTP 200, ``[]``."""
+        client, _ = api_client
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_returns_summaries_sorted_by_namespace(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #1 — two namespaces with team entries project to sorted summaries."""
+        client, catalog = api_client
+        # Seed namespaces out of alphabetical order and with distinct team
+        # names + descriptions to verify the projection.
+        team_b = _team_payload()
+        team_b["name"] = "Team B"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-b",
+                model_type=_TEAM_TYPE,
+                description="beta team",
+                payload=team_b,
+            )
+        )
+        team_a = _team_payload()
+        team_a["name"] = "Team A"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-a",
+                model_type=_TEAM_TYPE,
+                description="alpha team",
+                payload=team_a,
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == [
+            {"namespace": "ns-a", "name": "Team A", "description": "alpha team"},
+            {"namespace": "ns-b", "name": "Team B", "description": "beta team"},
+        ]
+
+    def test_missing_name_in_payload_falls_back_to_empty_string(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #3 spirit — pre-validation/defensive: missing ``name`` → ``""``.
+
+        Bypasses the service to seed a team entry whose payload lacks the
+        ``name`` key (a state ``create`` would reject). The handler must not
+        crash — it returns ``name=""`` so clients can filter/render.
+        """
+        client, catalog = api_client
+        payload_without_name = _team_payload()
+        payload_without_name.pop("name")
+        catalog._repository.put(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-no-name",
+                model_type=_TEAM_TYPE,
+                description="",
+                payload=payload_without_name,
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == [{"namespace": "ns-no-name", "name": "", "description": ""}]
+
+    def test_namespace_without_team_entry_is_skipped(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #3 — namespace with sub-entries but no team entry is omitted.
+
+        The service's ``create`` invariants forbid seeding an agent without a
+        team (tested via 409 in :class:`TestCreate`), so we bypass via the
+        repository to synthesize the corrupted state, then verify the
+        endpoint skips it silently (no error, no partial row).
+        """
+        client, catalog = api_client
+        catalog._repository.put(
+            Entry(
+                id="orphan-agent",
+                kind="agent",
+                namespace="ns-no-team",
+                model_type=_AGENT_TYPE,
+                payload=_agent_payload("orphan"),
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        namespaces = [row["namespace"] for row in response.json()]
+        assert "ns-no-team" not in namespaces
+
+    def test_includes_entries_across_user_ids(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #4 — the endpoint does not filter by ``user_id``.
+
+        Community-tier (``user_id=None``) and multi-tenant
+        (``user_id="alice"``, ``user_id="bob"``) namespaces must all appear.
+        Tenancy filtering is a caller concern.
+        """
+        client, catalog = api_client
+        _seed_team(catalog, "ns-public", user_id=None)
+        _seed_team(catalog, "ns-alice", user_id="alice")
+        _seed_team(catalog, "ns-bob", user_id="bob")
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        namespaces = [row["namespace"] for row in response.json()]
+        assert namespaces == ["ns-alice", "ns-bob", "ns-public"]
+
+    def test_openapi_declares_response_model(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC #5 — ``/openapi.json`` exposes the operation with the right shape."""
+        client, _ = api_client
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        spec = response.json()
+        op = spec["paths"]["/catalog/namespaces"]["get"]
+        # Response schema is declared as ``list[NamespaceSummary]``.
+        content = op["responses"]["200"]["content"]["application/json"]["schema"]
+        assert content["type"] == "array"
+        # Resolve the referenced component name.
+        ref = content["items"]["$ref"]
+        assert ref.endswith("/NamespaceSummary")
+        component = spec["components"]["schemas"]["NamespaceSummary"]
+        assert set(component["properties"].keys()) == {"namespace", "name", "description"}
+
+
 def test_router_namespace_import_malformed_yaml_returns_422(
     api_client: tuple[TestClient, Catalog],
 ) -> None:


### PR DESCRIPTION
## Summary

Implements Story 16.6 — `GET /catalog/namespaces` returning a flat `list[NamespaceSummary]` with `{namespace, name, description}` sorted alphabetically by namespace.

- New `NamespaceSummary` DTO in `api/router.py` — minimal shape, intentionally omits `user_id`, `parent_namespace`, etc. to avoid leaking tenancy design to the namespace picker.
- Handler queries `Catalog.list(EntryQuery(kind="team"))` and projects to the DTO. No `user_id` filter — tenancy filtering is left to caller middleware (forward-compat with multi-tenant deployments).
- Route declared before the `/{kind}` family so FastAPI does not treat `namespaces` as a path param.
- Defensive `str(payload.get("name", ""))` guard handles bundle-shape edge cases (missing `name` key).
- Six tests in `TestListNamespaces`: empty, sorted happy path, missing `name` fallback, orphan-agent skip, cross-`user_id` visibility, OpenAPI schema declaration.

## Review

Stacked on `feat/132-16-5-bundle-export-kind-order`. Reviewed by Rex — no fix-worthy issues, no fixup commit needed.

- Ruff: clean on `src/`
- mypy strict: clean
- pytest: 604 passed
- Scope: confined to `packages/akgentic-catalog/`

Relates to #134
