### PR TITLE
feat(akgentic-catalog): 20-1 ref sibling overrides (ADR-010)

### DIFF
--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -19,8 +19,18 @@ It also exposes the v2 resolver pipeline built on top of those primitives:
   resolve to typed Pydantic instances of the referenced entry's ``model_type``
   (Story 15.6) so polymorphic fields (``list[ToolCard]``, ``list[type]``,
   …) validate against concrete subclasses without authoring workarounds.
+
+  A ref-marker dict may additionally carry non-reserved sibling keys next to
+  ``__ref__`` / ``__type__``. Those siblings are treated as a **shallow
+  override** (top-level ``dict.update`` semantics) merged on top of the
+  resolved target payload before validation (Story 20.1 / ADR-010). This
+  lets a single shared ``BaseModel`` entry (notably ``PromptTemplate``) be
+  reused by many callers, each supplying its own field values without
+  duplicating the full target payload subtree.
 * :func:`reconcile_refs` — walks input + dumped trees in lockstep to preserve
-  author-written ref markers against a Pydantic-dumped payload.
+  author-written ref markers against a Pydantic-dumped payload. Sibling
+  overrides on a ref marker round-trip verbatim: the dict returned for a
+  ref-marker node is the full author-written dict, siblings included.
 * :func:`resolve` — full hydration of an ``Entry`` into a runtime ``BaseModel``.
 * :func:`prepare_for_write` — five-step write pipeline producing the
   intent-preserving, ref-preserving stored payload.
@@ -143,6 +153,18 @@ def populate_refs(
     widening is compatible with every existing caller (``resolve``,
     ``prepare_for_write``, ``validation._check_transient_validation``).
 
+    Sibling overrides (Story 20.1 / ADR-010): a ref-marker dict may carry
+    non-reserved sibling keys alongside ``__ref__`` / ``__type__``. Those
+    siblings are read as a **shallow override** (top-level ``dict.update``
+    semantics) and merged on top of the resolved target payload before the
+    target's ``model_type`` validates the result. The merge is shallow — a
+    sibling ``params: {role: "Manager"}`` **replaces** the target's
+    ``params`` entirely rather than recursing into it. Override values may
+    themselves be ref markers; they are resolved recursively with the same
+    cycle-detection set as any other nested ref. If the ref marker has no
+    non-reserved siblings, the resolver's behaviour is observationally
+    identical to the pre-20.1 baseline.
+
     Args:
         node: Arbitrary payload subtree (dict, list, or leaf value).
         repository: Entry repository used to resolve refs in ``namespace``.
@@ -161,11 +183,11 @@ def populate_refs(
         CatalogValidationError: If a ref cycle is detected, the target id is
             absent from ``repository``, a ``TYPE_KEY`` hint does not match
             the target entry's ``model_type``, or the target entry's payload
-            fails validation against its own ``model_type`` class. The error
-            carries a single-element ``errors`` list with substring-stable
-            messages (``"cycle"``, ``"not found"``, ``"expected X"`` +
-            ``"got Y"``, or ``"Payload of '<id>' does not validate against
-            <model_type>"``).
+            fails validation against its own ``model_type`` class (after any
+            sibling override merge). The error carries a single-element
+            ``errors`` list with substring-stable messages (``"cycle"``,
+            ``"not found"``, ``"expected X"`` + ``"got Y"``, or ``"Payload of
+            '<id>' does not validate against <model_type>"``).
     """
     visiting: set[tuple[str, str]] = set() if _visiting is None else _visiting
 
@@ -190,8 +212,10 @@ def _populate_ref_marker(
 
     Checks run in order — cycle, missing target, ``__type__`` mismatch, then
     (Story 15.6) recursive population of nested refs inside the target's
-    payload, ``load_model_type`` on the target's declared ``model_type``, and
-    ``cls.model_validate`` to build a typed instance.
+    payload, optional shallow merge of non-reserved siblings on top of that
+    payload (Story 20.1 / ADR-010), ``load_model_type`` on the target's
+    declared ``model_type``, and ``cls.model_validate`` to build a typed
+    instance.
 
     Cycle comes first to avoid a redundant repository lookup when we already
     know we are looping; missing-target comes second because the ``__type__``
@@ -201,7 +225,18 @@ def _populate_ref_marker(
     A validation failure at instantiation time raises
     ``CatalogValidationError`` naming the referenced entry's id and
     ``model_type`` so authoring errors point at the offending entry, not at
-    the parent that happens to reference it (AC #5).
+    the parent that happens to reference it.
+
+    Sibling-override semantics (ADR-010): any keys on ``node`` other than
+    ``__ref__`` / ``__type__`` are collected as overrides. When non-empty,
+    the override dict is itself run through :func:`populate_refs` (sharing
+    the same ``visiting | {key}`` cycle-detection set as the target-payload
+    recursion), then shallow-merged on top of the populated target payload
+    via ``{**target, **overrides}``. The merge is top-level — no recursive
+    descent into shared subkeys — and runs before ``cls.model_validate``.
+    When the ref marker has no non-reserved siblings, this branch is
+    skipped entirely and behaviour is observationally identical to the
+    pre-20.1 baseline.
     """
     target_id = node[REF_KEY]
     expected = node.get(TYPE_KEY)
@@ -224,9 +259,33 @@ def _populate_ref_marker(
     # becomes a typed instance — Pydantic accepts a subclass instance where
     # the parent field is annotated with its base class.
     populated_payload = populate_refs(target.payload, repository, namespace, visiting | {key})
+
+    # Story 20.1 / ADR-010: merge non-reserved siblings on top of the target
+    # payload as a shallow override. When no siblings exist, skip this branch
+    # entirely so the no-override code path stays byte-identical to baseline.
+    overrides = {k: v for k, v in node.items() if k not in _RESERVED_KEYS}
+    if overrides:
+        resolved_overrides = populate_refs(overrides, repository, namespace, visiting | {key})
+        # resolved_overrides is always a dict here: populate_refs preserves
+        # the dict shape of any non-ref-marker dict input (the outer override
+        # dict has no __ref__ at its top level — only its values may).
+        if not isinstance(populated_payload, dict):  # pragma: no cover — defensive
+            # Target payloads are always dicts for v2 catalog entries; this
+            # guard pins the invariant for readers rather than handling a
+            # real failure mode.
+            raise CatalogValidationError(
+                [
+                    f"Cannot merge sibling overrides onto '{target.id}': "
+                    "resolved target payload is not a dict"
+                ]
+            )
+        merged = {**populated_payload, **resolved_overrides}
+    else:
+        merged = populated_payload
+
     cls = load_model_type(target.model_type)
     try:
-        return cls.model_validate(populated_payload)
+        return cls.model_validate(merged)
     except ValidationError as e:
         raise CatalogValidationError(
             [f"Payload of '{target.id}' does not validate against {target.model_type}: {e}"]
@@ -284,9 +343,16 @@ def reconcile_refs(input_node: Any, dumped_node: Any) -> Any:
     values. Author-written ref markers in ``input_node`` must win verbatim so
     that the stored payload round-trips back to itself when re-resolved.
 
+    A ref-marker dict is returned verbatim as a whole — any non-reserved
+    sibling keys the author wrote next to ``__ref__`` (Story 20.1 /
+    ADR-010, shallow overrides) survive the write path unchanged, because
+    this function never recurses into a ref-marker dict's values. The
+    stored payload therefore resolves to the same in-memory shape when
+    re-read, including its override values.
+
     Args:
         input_node: The original payload subtree the author wrote (may carry
-            ``REF_KEY`` markers).
+            ``REF_KEY`` markers, optionally with sibling overrides).
         dumped_node: The corresponding subtree from ``model_dump``.
 
     Returns:

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/assistant.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/assistant.yaml
@@ -1,0 +1,22 @@
+id: assistant
+kind: agent
+namespace: sibling-overrides-v1
+user_id: null
+parent_namespace: null
+parent_id: null
+model_type: akgentic.core.AgentCard
+description: Assistant sharing the team prompt with its own params.
+payload:
+  role: Assistant
+  description: Assistant sharing the team prompt with its own params.
+  agent_class: akgentic.agent.BaseAgent
+  skills:
+    - research
+  config:
+    name: "@Assistant"
+    role: Assistant
+    prompt:
+      __ref__: id_team_prompt
+      params:
+        role: Assistant
+        instructions: Provide clear answers.

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/manager.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/manager.yaml
@@ -1,0 +1,22 @@
+id: manager
+kind: agent
+namespace: sibling-overrides-v1
+user_id: null
+parent_namespace: null
+parent_id: null
+model_type: akgentic.core.AgentCard
+description: Manager sharing the team prompt with its own params.
+payload:
+  role: Manager
+  description: Manager sharing the team prompt with its own params.
+  agent_class: akgentic.agent.BaseAgent
+  skills:
+    - coordination
+  config:
+    name: "@Manager"
+    role: Manager
+    prompt:
+      __ref__: id_team_prompt
+      params:
+        role: Manager
+        instructions: Coordinate the team.

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/prompt/id_team_prompt.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/prompt/id_team_prompt.yaml
@@ -1,0 +1,13 @@
+id: id_team_prompt
+kind: prompt
+namespace: sibling-overrides-v1
+user_id: null
+parent_namespace: null
+parent_id: null
+model_type: akgentic.llm.prompts.PromptTemplate
+description: Shared team prompt template — each referring agent supplies its own `params`.
+payload:
+  template: "You are a helpful {role}. {instructions}"
+  params:
+    role: assistant
+    instructions: Be helpful.

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/team/team.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/team/team.yaml
@@ -1,0 +1,21 @@
+id: team
+kind: team
+namespace: sibling-overrides-v1
+user_id: null
+parent_namespace: null
+parent_id: null
+model_type: akgentic.team.TeamCard
+description: Minimal team exercising the shared prompt + sibling overrides capability.
+payload:
+  name: Sibling Overrides Team
+  description: Minimal team exercising the shared prompt + sibling overrides capability.
+  entry_point:
+    card: { __ref__: manager }
+  members:
+    - card: { __ref__: manager }
+    - card: { __ref__: assistant }
+  message_types:
+    - __type__: akgentic.agent.AgentMessage
+  agent_profiles:
+    - __ref__: manager
+    - __ref__: assistant

--- a/tests/v2/test_resolver_sibling_overrides.py
+++ b/tests/v2/test_resolver_sibling_overrides.py
@@ -1,0 +1,599 @@
+"""Tests for Story 20.1 / ADR-010 — ``__ref__`` sibling overrides.
+
+A ref-marker dict may carry non-reserved sibling keys alongside ``__ref__``
+and ``__type__``. The resolver treats them as a **shallow override**: the
+siblings are merged on top of the resolved target payload (top-level
+``dict.update`` semantics) before the target's ``model_type`` validates the
+result.
+
+These tests exercise every acceptance criterion from
+``_bmad-output/akgentic-catalog/stories/20-1-ref-sibling-overrides.md``:
+
+* AC #1 — shallow override merges onto the target payload.
+* AC #2 — no-override backwards compatibility (covered by
+  :mod:`.test_populate_refs` baseline plus an explicit assertion here).
+* AC #3 — overrides are shallow (top-level replacement, not deep merge).
+* AC #4 — override values may themselves contain ``__ref__``.
+* AC #5 — reserved keys (``__ref__`` / ``__type__``) retain their ADR-008
+  roles.
+* AC #6 — missing-field survival via base.
+* AC #7 — invalid override names the target's ``model_type``.
+* AC #8 — cycle detection unchanged across override resolution.
+* AC #9 — ``reconcile_refs`` / ``prepare_for_write`` preserves ref +
+  sibling overrides verbatim.
+* AC #10 — ``find_references`` (delete guard) unchanged.
+* AC #11 — one shared prompt entry works across multiple agents via
+  per-agent ``params`` overrides.
+"""
+
+from __future__ import annotations
+
+import copy
+import shutil
+from pathlib import Path
+from typing import Any
+
+import akgentic.tool  # noqa: F401 — load real ToolCard subclasses for the fixture bundle
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from akgentic.catalog.models.errors import CatalogValidationError
+from akgentic.catalog.repositories.yaml import YamlEntryRepository
+from akgentic.catalog.resolver import populate_refs, prepare_for_write
+
+from .conftest import FakeEntryRepository, make_entry, register_akgentic_test_module
+
+
+class Anything(BaseModel):
+    """Permissive test model — ``extra='allow'`` so any payload validates.
+
+    Mirrors the helper class in ``test_populate_refs`` so sibling-override
+    tests that do not need a realistic model shape can build throw-away
+    entries quickly. ``model_dump()`` round-trips the input dict, keeping
+    the dict-equality assertions below tight.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def anything_model_type(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register ``Anything`` under an ``akgentic.*`` module and return its FQCN."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_20_1_sibling_overrides_anything",
+        Anything=Anything,
+    )
+    return f"{module_name}.Anything"
+
+
+@pytest.fixture
+def prompt_template_module() -> str:
+    """Return the FQCN of the real ``akgentic.llm.PromptTemplate`` class.
+
+    The resolver's allowlist requires ``akgentic.*`` prefixes, so the tests
+    below use the production ``PromptTemplate`` directly rather than a stand-in.
+    """
+    # Imported lazily inside the fixture so module-import fails are surfaced
+    # in the actual test, not at collection time.
+    from akgentic.llm.prompts import PromptTemplate  # noqa: F401 — import-only check
+
+    return "akgentic.llm.prompts.PromptTemplate"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1 — AC #1: motivating PromptTemplate case
+# ---------------------------------------------------------------------------
+
+
+class TestShallowOverrideMergesMotivating:
+    """AC #1 — the concrete ``PromptTemplate`` reuse case."""
+
+    def test_ref_with_params_override_shallow_merges(
+        self, prompt_template_module: str
+    ) -> None:
+        from akgentic.llm.prompts import PromptTemplate
+
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_team_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={
+                    "template": "You are a helpful {role}. {instructions}",
+                    "params": {"role": "assistant", "instructions": "Be helpful."},
+                },
+            )
+        )
+        marker = {
+            "__ref__": "id_team_prompt",
+            "params": {
+                "role": "Manager",
+                "instructions": "Coordinate the team effectively.",
+            },
+        }
+        result = populate_refs(marker, repo, "ns-1")
+
+        assert isinstance(result, PromptTemplate)
+        assert result.template == "You are a helpful {role}. {instructions}"
+        assert result.params == {
+            "role": "Manager",
+            "instructions": "Coordinate the team effectively.",
+        }
+
+    def test_target_payload_not_mutated(self, prompt_template_module: str) -> None:
+        """The target entry's payload must not be mutated by the override merge."""
+        repo = FakeEntryRepository()
+        target_payload: dict[str, Any] = {
+            "template": "T",
+            "params": {"role": "assistant"},
+        }
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload=target_payload,
+            )
+        )
+        snapshot = copy.deepcopy(target_payload)
+        populate_refs(
+            {"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1"
+        )
+        assert target_payload == snapshot
+
+    def test_fresh_instance_on_each_call(self, prompt_template_module: str) -> None:
+        """Re-resolving the same ref with a different override yields a fresh instance."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={"template": "T", "params": {"role": "assistant"}},
+            )
+        )
+        a = populate_refs(
+            {"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1"
+        )
+        b = populate_refs(
+            {"__ref__": "id_prompt", "params": {"role": "Expert"}}, repo, "ns-1"
+        )
+        assert a is not b
+        assert a.params == {"role": "Manager"}  # type: ignore[attr-defined]
+        assert b.params == {"role": "Expert"}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2 — AC #2: no-override backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestNoOverrideBackwardsCompatible:
+    """AC #2 — ref-marker without siblings behaves exactly as before."""
+
+    def test_pure_ref_only(self, anything_model_type: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"k": 1, "v": "literal"},
+            )
+        )
+        result = populate_refs({"__ref__": "target"}, repo, "ns-1")
+        assert isinstance(result, Anything)
+        assert result.model_dump() == {"k": 1, "v": "literal"}
+
+    def test_ref_with_only_type_hint(self, anything_model_type: str) -> None:
+        """`__type__` is reserved and is NOT treated as an override."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="target",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"k": 1},
+            )
+        )
+        marker = {"__ref__": "target", "__type__": anything_model_type}
+        result = populate_refs(marker, repo, "ns-1")
+        assert isinstance(result, Anything)
+        assert result.model_dump() == {"k": 1}
+
+
+# ---------------------------------------------------------------------------
+# Task 4.3 — AC #3: shallow merge, not deep
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideIsShallow:
+    """AC #3 — the override replaces the base's top-level value wholesale."""
+
+    def test_override_replaces_nested_dict_wholesale(
+        self, prompt_template_module: str
+    ) -> None:
+        from akgentic.llm.prompts import PromptTemplate
+
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                # PromptTemplate.params is ``dict[str, str]``, so both keys are
+                # strings — this exercises the shallow-merge rule directly.
+                payload={"template": "T", "params": {"role": "assistant", "tone": "neutral"}},
+            )
+        )
+        marker = {"__ref__": "id_prompt", "params": {"role": "Manager"}}
+        result = populate_refs(marker, repo, "ns-1")
+
+        assert isinstance(result, PromptTemplate)
+        # Shallow merge: the override's ``params`` replaces the base's ``params``
+        # entirely. ``tone`` is GONE because the override does not re-declare it.
+        assert result.params == {"role": "Manager"}
+
+
+# ---------------------------------------------------------------------------
+# Task 4.4 — AC #4: override values may themselves be ref markers
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideValueIsRef:
+    """AC #4 — a ref-marker inside an override resolves recursively."""
+
+    def test_override_value_is_a_ref(self, anything_model_type: str) -> None:
+        repo = FakeEntryRepository()
+        # Target for the outer ref — has some default fields.
+        repo.put(
+            make_entry(
+                id="id_parent",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"name": "base-parent", "nested": {"default": True}},
+            )
+        )
+        # Target for the override ref — the override key wants this value.
+        repo.put(
+            make_entry(
+                id="id_child",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"leaf": 42},
+            )
+        )
+        marker = {"__ref__": "id_parent", "nested": {"__ref__": "id_child"}}
+        result = populate_refs(marker, repo, "ns-1")
+
+        assert isinstance(result, Anything)
+        assert result.name == "base-parent"  # type: ignore[attr-defined]
+        # The override value became a typed Anything instance via populate_refs
+        # recursion BEFORE the merge ran.
+        child = result.nested  # type: ignore[attr-defined]
+        assert isinstance(child, Anything)
+        assert child.model_dump() == {"leaf": 42}
+
+
+# ---------------------------------------------------------------------------
+# Task 4.5 — AC #8: cycle detection threads through override resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCycleViaOverride:
+    """AC #8 — A → B.override → A triggers the existing ``cycle`` error."""
+
+    def test_override_cycle_raises_cycle_error(self, anything_model_type: str) -> None:
+        repo = FakeEntryRepository()
+        # A's payload is trivial — the cycle is established via B's OVERRIDE
+        # value pointing back at A, not via A's payload.
+        repo.put(
+            make_entry(
+                id="A",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"via_b": {"__ref__": "B", "extra": {"__ref__": "A"}}},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="B",
+                namespace="ns-1",
+                model_type=anything_model_type,
+                payload={"k": 1},
+            )
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs({"__ref__": "A"}, repo, "ns-1")
+        msg = exc_info.value.errors[0].lower()
+        assert "cycle" in msg
+        # The closing id is A (the outer ref), which is detected when the
+        # override value tries to re-enter it via B.
+        assert "a" in msg
+
+
+# ---------------------------------------------------------------------------
+# Task 4.6 — AC #6: override may omit a required field (base supplies it)
+# ---------------------------------------------------------------------------
+
+
+class TestBaseSuppliesOmittedField:
+    """AC #6 — missing-field survival via base."""
+
+    def test_override_omitting_required_field_succeeds_via_base(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class StrictModel(BaseModel):
+            required_field: str
+            other: str = "default"
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_20_1_base_supplies_missing",
+            StrictModel=StrictModel,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_strict",
+                namespace="ns-1",
+                model_type=f"{module_name}.StrictModel",
+                payload={"required_field": "from-base", "other": "base-other"},
+            )
+        )
+        # Override omits ``required_field`` entirely — base's value survives
+        # the shallow merge.
+        marker = {"__ref__": "id_strict", "other": "overridden"}
+        result = populate_refs(marker, repo, "ns-1")
+
+        assert isinstance(result, StrictModel)
+        assert result.required_field == "from-base"
+        assert result.other == "overridden"
+
+
+# ---------------------------------------------------------------------------
+# Task 4.7 — AC #7: invalid override value names target's model_type
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidOverrideError:
+    """AC #7 — the error substring must name the target entry and model_type."""
+
+    def test_invalid_override_value_names_target_model_type(
+        self, prompt_template_module: str
+    ) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={"template": "T", "params": {"role": "assistant"}},
+            )
+        )
+        # ``params`` must be a dict[str, str]; passing a string is a type error.
+        marker: dict[str, Any] = {"__ref__": "id_prompt", "params": "not a dict"}
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(marker, repo, "ns-1")
+        msg = exc_info.value.errors[0]
+        assert "Payload of 'id_prompt' does not validate against" in msg
+        assert prompt_template_module in msg
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — AC #9: reconcile_refs / prepare_for_write preserves ref + siblings
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathRoundTrip:
+    """AC #9 — stored payload preserves the full ref-marker dict verbatim."""
+
+    def test_prepare_for_write_preserves_ref_and_siblings(
+        self, prompt_template_module: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from akgentic.llm.prompts import PromptTemplate
+
+        class Parent(BaseModel):
+            name: str
+            prompt: PromptTemplate
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_20_1_write_path_parent",
+            Parent=Parent,
+            PromptTemplate=PromptTemplate,
+        )
+
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={"template": "T", "params": {"role": "assistant"}},
+            )
+        )
+        input_payload: dict[str, Any] = {
+            "name": "parent",
+            "prompt": {"__ref__": "id_prompt", "params": {"role": "Manager"}},
+        }
+        entry = make_entry(
+            id="id_parent",
+            namespace="ns-1",
+            model_type=f"{module_name}.Parent",
+            payload=input_payload,
+        )
+        prepared = prepare_for_write(entry, repo)
+
+        # The whole ref-marker dict (including siblings) must survive verbatim.
+        assert prepared.payload["prompt"] == {
+            "__ref__": "id_prompt",
+            "params": {"role": "Manager"},
+        }
+
+    def test_round_trip_resolves_to_same_typed_instance(
+        self, prompt_template_module: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-resolving the stored payload matches the author's intent."""
+        from akgentic.llm.prompts import PromptTemplate
+
+        class Parent(BaseModel):
+            name: str
+            prompt: PromptTemplate
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_20_1_write_path_round_trip",
+            Parent=Parent,
+            PromptTemplate=PromptTemplate,
+        )
+
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={"template": "T", "params": {"role": "assistant"}},
+            )
+        )
+        entry = make_entry(
+            id="id_parent",
+            namespace="ns-1",
+            model_type=f"{module_name}.Parent",
+            payload={
+                "name": "p",
+                "prompt": {"__ref__": "id_prompt", "params": {"role": "Manager"}},
+            },
+        )
+        prepared = prepare_for_write(entry, repo)
+
+        # Re-resolve the stored payload end-to-end; it should produce the same
+        # in-memory shape as the author's original intent.
+        rehydrated = Parent.model_validate(
+            populate_refs(prepared.payload, repo, prepared.namespace)
+        )
+        original = Parent.model_validate(
+            populate_refs(entry.payload, repo, entry.namespace)
+        )
+        assert rehydrated.model_dump(mode="python", exclude_unset=True) == original.model_dump(
+            mode="python", exclude_unset=True
+        )
+        assert rehydrated.prompt.params == {"role": "Manager"}
+
+
+# ---------------------------------------------------------------------------
+# Task 6 — AC #10: find_references returns the entry even with overrides
+# ---------------------------------------------------------------------------
+
+
+class TestFindReferencesWithOverrides:
+    """AC #10 — sibling overrides do not hide the inbound ref edge."""
+
+    def test_find_references_sees_ref_with_overrides(
+        self, prompt_template_module: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from akgentic.llm.prompts import PromptTemplate
+
+        class Parent(BaseModel):
+            name: str
+            prompt: PromptTemplate
+
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_20_1_find_refs",
+            Parent=Parent,
+            PromptTemplate=PromptTemplate,
+        )
+
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="id_prompt",
+                namespace="ns-1",
+                model_type=prompt_template_module,
+                payload={"template": "T", "params": {}},
+            )
+        )
+        parent = make_entry(
+            id="id_parent",
+            namespace="ns-1",
+            model_type=f"{module_name}.Parent",
+            payload={
+                "name": "p",
+                "prompt": {"__ref__": "id_prompt", "params": {"role": "Manager"}},
+            },
+        )
+        repo.put(parent)
+
+        referrers = repo.find_references("ns-1", "id_prompt")
+        assert len(referrers) == 1
+        assert referrers[0].id == "id_parent"
+
+
+# ---------------------------------------------------------------------------
+# Task 7 — AC #11: shared prompt entry across multiple agents via fixture
+# ---------------------------------------------------------------------------
+
+
+FIXTURE_ROOT = Path(__file__).parent.parent / "fixtures" / "sibling_overrides"
+
+
+@pytest.fixture
+def sibling_overrides_repo(tmp_path: Path) -> YamlEntryRepository:
+    """Copy the sibling-overrides fixture bundle into ``tmp_path`` and return a repo.
+
+    The bundle lives under ``tests/fixtures/sibling_overrides/`` and models the
+    AC #11 end-to-end shape: one shared ``prompt`` entry plus two agents that
+    reference it with different ``params:`` overrides.
+    """
+    dest = tmp_path / "catalog"
+    shutil.copytree(FIXTURE_ROOT, dest)
+    return YamlEntryRepository(dest)
+
+
+class TestSharedPromptAcrossAgents:
+    """AC #11 — one shared prompt, two agents, different ``params`` each."""
+
+    def test_validate_namespace_ok(self, sibling_overrides_repo: YamlEntryRepository) -> None:
+        from akgentic.catalog.catalog import Catalog
+
+        catalog = Catalog(sibling_overrides_repo)
+        report = catalog.validate_namespace("sibling-overrides-v1")
+        assert report.ok, f"Namespace report was not ok: {report}"
+        assert report.global_errors == []
+        assert report.entry_issues == []
+
+    @pytest.mark.parametrize(
+        ("agent_id", "expected_params"),
+        [
+            ("manager", {"role": "Manager", "instructions": "Coordinate the team."}),
+            ("assistant", {"role": "Assistant", "instructions": "Provide clear answers."}),
+        ],
+    )
+    def test_agent_prompts_share_template_with_own_params(
+        self,
+        sibling_overrides_repo: YamlEntryRepository,
+        agent_id: str,
+        expected_params: dict[str, str],
+    ) -> None:
+        agent_entry = sibling_overrides_repo.get("sibling-overrides-v1", agent_id)
+        assert agent_entry is not None
+        populated = populate_refs(
+            agent_entry.payload, sibling_overrides_repo, agent_entry.namespace
+        )
+        from akgentic.llm.prompts import PromptTemplate
+
+        prompt = populated["config"]["prompt"]
+        assert isinstance(prompt, PromptTemplate)
+        # Shared template — identical across both agents.
+        assert prompt.template == "You are a helpful {role}. {instructions}"
+        # Per-agent overrides.
+        assert prompt.params == expected_params


### PR DESCRIPTION
## Summary

- Extend `_populate_ref_marker` in `akgentic.catalog.resolver` so a ref-marker dict may carry non-reserved sibling keys next to `__ref__` / `__type__`. Siblings are collected, recursively resolved via `populate_refs` (sharing the same cycle-detection set), and shallow-merged on top of the resolved target payload via `{**target, **overrides}` before `cls.model_validate` — enabling a single shared `BaseModel` entry (notably `PromptTemplate`) to be reused by many callers with per-caller field overrides.
- The no-override code path is observationally identical to the pre-20.1 baseline (guarded behind `if overrides:`). `reconcile_refs` and `_payload_has_ref` required no code change — existing logic already preserves/ignores siblings as needed.
- Adds `tests/v2/test_resolver_sibling_overrides.py` (16 tests covering AC 1–10), the trimmed `tests/fixtures/sibling_overrides/sibling-overrides-v1/` YAML bundle exercising the end-to-end shared-prompt capability (AC 11), plus docstring updates to the module, `populate_refs`, `_populate_ref_marker`, and `reconcile_refs`.

### References

- Epic 20: `_bmad-output/akgentic-catalog/epics/epic-20-ref-sibling-overrides.md`
- ADR-010: `_bmad-output/akgentic-catalog/decisions/adr-10-ref-sibling-overrides.md`
- Story 20.1: `_bmad-output/akgentic-catalog/stories/20-1-ref-sibling-overrides.md`

Relates to #138

## Review status

**Verdict: PASS** — no fixup commit required.

- Every AC #1 through #13 maps to a specific test or is covered by the full suite (661 passed, 0 skip/xfail). Local ruff and mypy strict on `src/` are clean.
- Resolver change is tight (≤ 50 LOC on `_populate_ref_marker`), docstrings updated on all four surfaces (module, `populate_refs`, `_populate_ref_marker`, `reconcile_refs`), cycle set correctly threaded through override resolution.
- No ADR-reference string assertions in tests; no `dict[str, Any]` leakage into public APIs.

## Scope guard

All changes in commit `64e2552` are strictly under `packages/akgentic-catalog/` (resolver source, new tests, new fixture bundle). No cross-submodule edits. The parent-repo `agent-team-v1` bundle rewrite is deliberately out of scope per the story, with AC #11 exercised via an equivalent fixture inside this submodule.
