### PR TITLE
feat(akgentic-catalog): epic 21 — Multi-Format Body Handling (YAML+JSON parity) — 21.1

### DIFF
--- a/src/akgentic/catalog/api/_errors.py
+++ b/src/akgentic/catalog/api/_errors.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 
@@ -46,6 +47,29 @@ async def _handle_catalog_validation_error(
     )
 
 
+async def _handle_pydantic_validation_error(
+    request: Request,
+    exc: ValidationError,
+) -> JSONResponse:
+    """Convert raw ``pydantic.ValidationError`` to a 422 JSON response.
+
+    FastAPI's default 422 handler only fires for ``RequestValidationError``
+    — the exception type it raises when parameter/body validation fails on
+    the typed-argument path. The multi-format body handlers in
+    :mod:`akgentic.catalog.api.router` call ``model.model_validate(...)``
+    directly (after parsing JSON or YAML into a dict), which raises the raw
+    ``pydantic.ValidationError``. This handler mirrors FastAPI's default
+    shape (``{"detail": [...]}``) so clients see the same 422 contract
+    regardless of whether the body path is typed-argument or
+    ``_parse_body_as`` (Epic 21).
+    """
+    logger.debug("pydantic validation error: %s", exc)
+    return JSONResponse(
+        status_code=422,
+        content={"detail": jsonable_encoder(exc.errors())},
+    )
+
+
 def add_exception_handlers(app: FastAPI) -> None:
     """Register catalog exception handlers on a FastAPI application.
 
@@ -54,3 +78,4 @@ def add_exception_handlers(app: FastAPI) -> None:
     """
     app.add_exception_handler(EntryNotFoundError, _handle_entry_not_found)  # type: ignore[arg-type]
     app.add_exception_handler(CatalogValidationError, _handle_catalog_validation_error)  # type: ignore[arg-type]
+    app.add_exception_handler(ValidationError, _handle_pydantic_validation_error)  # type: ignore[arg-type]

--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -38,11 +38,12 @@ after the static ones — preserving dispatch priority.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from fastapi import APIRouter, Body, HTTPException, Query, Response
+from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from akgentic.catalog.api._settings import CatalogRouterSettings
@@ -56,6 +57,11 @@ if TYPE_CHECKING:
     from akgentic.catalog.catalog import Catalog
 
 __all__ = ["NamespaceSummary", "build_router", "router", "set_catalog"]
+
+# Content types accepted on the YAML branch of ``_parse_body_as``. Both
+# variants are in the wild; ``application/x-yaml`` is the historical
+# unregistered spelling and ``application/yaml`` the RFC9512-registered one.
+_YAML_CONTENT_TYPES: frozenset[str] = frozenset({"application/yaml", "application/x-yaml"})
 
 
 class NamespaceSummary(BaseModel):
@@ -101,6 +107,92 @@ def _ensure_kind(entry_kind: EntryKind, path_kind: EntryKind) -> None:
         raise HTTPException(status_code=400, detail="kind mismatch between path and body")
 
 
+async def _parse_body_as[T: BaseModel](request: Request, model_type: type[T]) -> T:
+    """Parse a raw request body as ``model_type`` from JSON or YAML.
+
+    Dispatches on the request's ``Content-Type`` header (normalized: split on
+    ``;``, strip, lower-case). ``application/json`` (or missing header) uses
+    ``json.loads``; ``application/yaml`` and ``application/x-yaml`` use
+    ``yaml.safe_load``. Any other non-empty content type is rejected with a
+    415. Malformed JSON/YAML payloads surface as 422 with a descriptive
+    detail string.
+
+    An empty body on either JSON or YAML path is treated as ``{}`` so that
+    downstream Pydantic validation produces the familiar ``field required``
+    422 contract — matching the v1 ``_parse_yaml_or_json`` shape ported from
+    ``akgentic-infra`` (see ``akgentic-infra`` ADR-023 §D4).
+
+    Pydantic ``ValidationError`` raised by ``model_type.model_validate`` is
+    NOT wrapped here — FastAPI's registered exception handlers surface it as
+    the default 422 envelope. Wrapping would double-encode the error and
+    drift from the typed-body contract used elsewhere in the router.
+
+    Args:
+        request: The inbound Starlette ``Request`` (body already buffered).
+        model_type: The Pydantic ``BaseModel`` subclass to validate into.
+
+    Returns:
+        A validated ``model_type`` instance.
+
+    Raises:
+        HTTPException: 415 for unknown content types; 422 for malformed
+            JSON or YAML payloads.
+        pydantic.ValidationError: Propagates unwrapped for FastAPI's default
+            422 handler.
+    """
+    raw = await request.body()
+    raw_ct = request.headers.get("content-type", "application/json")
+    ct = raw_ct.split(";")[0].strip().lower()
+    payload: Any
+    if ct == "application/json" or ct == "":
+        try:
+            payload = json.loads(raw) if raw else {}
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=422, detail=f"invalid JSON body: {exc}") from exc
+    elif ct in _YAML_CONTENT_TYPES:
+        try:
+            payload = yaml.safe_load(raw) if raw else {}
+        except yaml.YAMLError as exc:
+            raise HTTPException(status_code=422, detail=f"invalid YAML body: {exc}") from exc
+    else:
+        raise HTTPException(
+            status_code=415,
+            detail=(
+                f"unsupported Content-Type: {ct!r}; expected application/json or application/yaml"
+            ),
+        )
+    return model_type.model_validate(payload)
+
+
+def _multi_format_body_openapi(model_name: str) -> dict[str, Any]:
+    """Return an ``openapi_extra`` dict advertising JSON + YAML request bodies.
+
+    The schema entry points at the already-registered Pydantic component
+    (``#/components/schemas/{model_name}``) so no additional schema objects
+    are emitted — FastAPI collects the schema once when the model is used
+    as a ``response_model`` or body argument elsewhere in the app.
+
+    Args:
+        model_name: The Pydantic class name FastAPI emits in
+            ``components.schemas`` (e.g. ``"Entry"``).
+
+    Returns:
+        A dict merged into the operation's OpenAPI object by FastAPI.
+    """
+    schema_ref = {"$ref": f"#/components/schemas/{model_name}"}
+    content_entry = {"schema": schema_ref}
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": content_entry,
+                "application/yaml": content_entry,
+                "application/x-yaml": content_entry,
+            },
+        }
+    }
+
+
 # --- Handler implementations ------------------------------------------------
 
 
@@ -127,8 +219,12 @@ async def list_namespaces() -> list[NamespaceSummary]:
     return sorted(summaries, key=lambda s: s.namespace)
 
 
-async def clone_entry(req: CloneRequest) -> Entry:
-    """Deep-copy an entry tree into ``dst_namespace`` — AC13."""
+async def clone_entry(request: Request) -> Entry:
+    """Deep-copy an entry tree into ``dst_namespace`` — AC13.
+
+    Accepts a ``CloneRequest`` body in either JSON or YAML (see Epic 21).
+    """
+    req = await _parse_body_as(request, CloneRequest)
     logger.debug(
         "POST /catalog/clone (%s,%s) -> (%s,%s)",
         req.src_namespace,
@@ -242,8 +338,12 @@ async def list_references(
     return catalog.find_references(namespace, id)
 
 
-async def search_entries(kind: EntryKind, query: EntryQuery) -> list[Entry]:
-    """Search entries of ``kind`` via an ``EntryQuery`` body — AC12."""
+async def search_entries(kind: EntryKind, request: Request) -> list[Entry]:
+    """Search entries of ``kind`` via an ``EntryQuery`` body — AC12.
+
+    Accepts the ``EntryQuery`` body in either JSON or YAML (see Epic 21).
+    """
+    query = await _parse_body_as(request, EntryQuery)
     logger.debug("POST /catalog/%s/search", kind)
     if query.kind is not None and query.kind != kind:
         raise HTTPException(status_code=400, detail="kind mismatch between path and body")
@@ -251,8 +351,12 @@ async def search_entries(kind: EntryKind, query: EntryQuery) -> list[Entry]:
     return _get_catalog().list(effective)
 
 
-async def create_entry(kind: EntryKind, entry: Entry) -> Entry:
-    """Create a new entry — AC7."""
+async def create_entry(kind: EntryKind, request: Request) -> Entry:
+    """Create a new entry — AC7.
+
+    Accepts the ``Entry`` body in either JSON or YAML (see Epic 21).
+    """
+    entry = await _parse_body_as(request, Entry)
     logger.debug("POST /catalog/%s — creating (%s, %s)", kind, entry.namespace, entry.id)
     _ensure_kind(entry.kind, kind)
     return _get_catalog().create(entry)
@@ -295,10 +399,14 @@ async def get_entry(
 async def update_entry(
     kind: EntryKind,
     id: str,
-    entry: Entry,
+    request: Request,
     namespace: str = Query(...),
 ) -> Entry:
-    """Update an entry; URL is authoritative over body. AC9."""
+    """Update an entry; URL is authoritative over body. AC9.
+
+    Accepts the ``Entry`` body in either JSON or YAML (see Epic 21).
+    """
+    entry = await _parse_body_as(request, Entry)
     logger.debug("PUT /catalog/%s/%s?namespace=%s", kind, id, namespace)
     _ensure_kind(entry.kind, kind)
     if entry.namespace != namespace or entry.id != id:
@@ -332,7 +440,12 @@ def _register_static_routes(target: APIRouter) -> None:
     also registered (Story 16.7 — FastAPI dispatches in declaration order).
     """
     target.get("/namespaces", response_model=list[NamespaceSummary])(list_namespaces)
-    target.post("/clone", response_model=Entry, status_code=201)(clone_entry)
+    target.post(
+        "/clone",
+        response_model=Entry,
+        status_code=201,
+        openapi_extra=_multi_format_body_openapi("CloneRequest"),
+    )(clone_entry)
     target.get("/schema")(get_schema)
     target.get("/model_types", response_model=list[str])(list_model_types)
     target.get("/team/{namespace}/resolve")(resolve_team)
@@ -360,12 +473,25 @@ def _register_generic_kind_routes(target: APIRouter) -> None:
     target.get("/{kind}/{id}/resolve")(resolve_entry)
     target.get("/{kind}/{id}/references", response_model=list[Entry])(list_references)
     # Search (must precede /{kind}/{id}).
-    target.post("/{kind}/search", response_model=list[Entry])(search_entries)
+    target.post(
+        "/{kind}/search",
+        response_model=list[Entry],
+        openapi_extra=_multi_format_body_openapi("EntryQuery"),
+    )(search_entries)
     # CRUD routes.
-    target.post("/{kind}", response_model=Entry, status_code=201)(create_entry)
+    target.post(
+        "/{kind}",
+        response_model=Entry,
+        status_code=201,
+        openapi_extra=_multi_format_body_openapi("Entry"),
+    )(create_entry)
     target.get("/{kind}", response_model=list[Entry])(list_entries)
     target.get("/{kind}/{id}", response_model=Entry)(get_entry)
-    target.put("/{kind}/{id}", response_model=Entry)(update_entry)
+    target.put(
+        "/{kind}/{id}",
+        response_model=Entry,
+        openapi_extra=_multi_format_body_openapi("Entry"),
+    )(update_entry)
     target.delete("/{kind}/{id}", status_code=204)(delete_entry)
 
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for ``tests/api/`` (Epic 21).
+
+Mirrors the ``api_client`` fixture from ``tests/v2/conftest.py``. Defined here
+(rather than promoted to the package-level ``tests/conftest.py``) to keep the
+v2 test layout unchanged; Epic 21 only needs the fixture inside ``tests/api/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.repositories.yaml import YamlEntryRepository
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def api_client(tmp_path: Path) -> tuple[Any, Catalog]:
+    """Yield a ``(TestClient, Catalog)`` pair wired to a YAML-backed v2 router.
+
+    Function-scoped — ``set_catalog`` is called fresh per test so the module-
+    level ``_catalog`` in ``api/router.py`` cannot leak between tests.
+    ``fastapi`` is guarded via ``importorskip`` inside the fixture body so
+    this conftest module stays importable when the ``api`` extra is absent.
+    Opts **in** to the kind-generic CRUD surface (Story 16.7).
+    """
+    pytest.importorskip("fastapi")
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from akgentic.catalog.api._errors import add_exception_handlers
+    from akgentic.catalog.api._settings import CatalogRouterSettings
+    from akgentic.catalog.api.router import build_router, set_catalog
+
+    repo = YamlEntryRepository(tmp_path)
+    catalog = Catalog(repo)
+
+    app = FastAPI(title="Akgentic Catalog")
+    app.include_router(build_router(CatalogRouterSettings(expose_generic_kind_crud=True)))
+    set_catalog(catalog)
+    add_exception_handlers(app)
+
+    return TestClient(app), catalog

--- a/tests/api/test_router_body_formats.py
+++ b/tests/api/test_router_body_formats.py
@@ -1,0 +1,452 @@
+"""Round-trip and unit tests for Epic 21 — multi-format body handling.
+
+Covers:
+
+* Story 21.1 ACs — every per-kind CRUD handler (``create_entry``,
+  ``update_entry``, ``search_entries``, ``clone_entry``) accepts JSON and
+  YAML request bodies with identical semantics, and ``openapi.json``
+  advertises all three content types (``application/json``,
+  ``application/yaml``, ``application/x-yaml``) on the four endpoints.
+* Unit tests for ``_parse_body_as`` covering every content-type branch,
+  empty-body handling, malformed JSON/YAML error responses, and case /
+  parameter-stripping normalization.
+
+All integration tests use the ``api_client`` fixture from
+``tests/api/conftest.py`` — a real ``TestClient`` around a YAML-backed
+``Catalog``. No ``MagicMock``; no shortcut past the handler signature.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pydantic
+import pytest
+import yaml
+
+pytest.importorskip("fastapi")
+
+from fastapi import HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+from akgentic.catalog.api.router import _parse_body_as  # noqa: E402
+from akgentic.catalog.catalog import Catalog  # noqa: E402
+from akgentic.catalog.models.entry import Entry  # noqa: E402
+from akgentic.catalog.models.queries import CloneRequest, EntryQuery  # noqa: E402
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+_PROMPT_TYPE = "akgentic.llm.models.PromptTemplate"
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _team_payload() -> dict[str, Any]:
+    """Return a minimal valid ``TeamCard`` payload."""
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+def _prompt_payload() -> dict[str, Any]:
+    """Return a minimal dict payload for a ``prompt`` entry (free-form)."""
+    return {"text": "hello"}
+
+
+def _team_entry(
+    namespace: str = "ns-body",
+    entry_id: str = "team",
+    user_id: str | None = None,
+) -> Entry:
+    """Build an ``Entry`` of kind ``team`` with a valid payload."""
+    return Entry(
+        id=entry_id,
+        kind="team",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_TEAM_TYPE,
+        payload=_team_payload(),
+    )
+
+
+def _prompt_entry(
+    namespace: str = "ns-body",
+    entry_id: str = "prompt-1",
+    user_id: str | None = None,
+) -> Entry:
+    """Build an ``Entry`` of kind ``prompt`` with a valid payload."""
+    return Entry(
+        id=entry_id,
+        kind="prompt",
+        namespace=namespace,
+        user_id=user_id,
+        model_type="akgentic.core.agent_card.AgentCard",  # allowlisted placeholder
+        payload={
+            # AgentCard-shaped payload so model_type validates at resolve time;
+            # structural validity at the Entry layer is all we need here.
+            "role": "r",
+            "description": "",
+            "skills": [],
+            "agent_class": "akgentic.core.agent.Akgent",
+            "config": {"name": entry_id, "role": "r"},
+            "routes_to": [],
+            "metadata": {},
+        },
+    )
+
+
+def _json_body(entry: Entry) -> str:
+    """Serialize ``entry`` as a JSON request body."""
+    return entry.model_dump_json()
+
+
+def _yaml_body(model: pydantic.BaseModel) -> str:
+    """Serialize ``model`` as a YAML request body."""
+    return yaml.safe_dump(model.model_dump(mode="json"), sort_keys=False)
+
+
+# --- Task 7: round-trip handler tests --------------------------------------
+
+
+class TestCreateEntryBodyFormats:
+    """POST /catalog/{kind} under JSON and YAML bodies."""
+
+    def test_json_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, _ = api_client
+        entry = _team_entry(namespace="ns-create-json")
+        response = client.post(
+            "/catalog/team",
+            content=_json_body(entry).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] == "team"
+        assert body["namespace"] == "ns-create-json"
+        assert body["kind"] == "team"
+
+    def test_yaml_body_team(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, _ = api_client
+        entry = _team_entry(namespace="ns-create-yaml-team")
+        response = client.post(
+            "/catalog/team",
+            content=_yaml_body(entry).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] == "team"
+        assert body["namespace"] == "ns-create-yaml-team"
+        assert body["kind"] == "team"
+
+    def test_yaml_body_prompt(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """Second kind covered — AC requires at least two kinds exercised."""
+        client, catalog = api_client
+        # Seed a team first so the prompt has a namespace to live in.
+        catalog.create(_team_entry(namespace="ns-create-yaml-prompt"))
+        entry = _prompt_entry(namespace="ns-create-yaml-prompt", entry_id="p1")
+        response = client.post(
+            "/catalog/prompt",
+            content=_yaml_body(entry).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] == "p1"
+        assert body["kind"] == "prompt"
+
+
+class TestUpdateEntryBodyFormats:
+    """PUT /catalog/{kind}/{id} under JSON and YAML bodies."""
+
+    def test_json_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        namespace = "ns-update-json"
+        catalog.create(_team_entry(namespace=namespace))
+        updated = _team_entry(namespace=namespace)
+        updated = updated.model_copy(update={"description": "updated-json"})
+        response = client.put(
+            f"/catalog/team/team?namespace={namespace}",
+            content=_json_body(updated).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+        assert response.json()["description"] == "updated-json"
+
+    def test_yaml_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        namespace = "ns-update-yaml"
+        catalog.create(_team_entry(namespace=namespace))
+        updated = _team_entry(namespace=namespace)
+        updated = updated.model_copy(update={"description": "updated-yaml"})
+        response = client.put(
+            f"/catalog/team/team?namespace={namespace}",
+            content=_yaml_body(updated).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 200
+        assert response.json()["description"] == "updated-yaml"
+
+    def test_url_mismatch_400_under_yaml(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """URL authoritative check fires regardless of body format."""
+        client, catalog = api_client
+        right = "ns-update-mismatch-right"
+        catalog.create(_team_entry(namespace=right))
+        # Body namespace deliberately differs from URL namespace.
+        body_entry = _team_entry(namespace="ns-update-mismatch-wrong")
+        response = client.put(
+            f"/catalog/team/team?namespace={right}",
+            content=_yaml_body(body_entry).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 400
+
+
+class TestSearchEntriesBodyFormats:
+    """POST /catalog/{kind}/search under JSON and YAML bodies."""
+
+    def test_json_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        namespace = "ns-search-json"
+        catalog.create(_team_entry(namespace=namespace))
+        query = EntryQuery(namespace=namespace)
+        response = client.post(
+            "/catalog/team/search",
+            content=query.model_dump_json().encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+        rows = response.json()
+        assert len(rows) == 1
+        assert rows[0]["namespace"] == namespace
+
+    def test_yaml_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        namespace = "ns-search-yaml"
+        catalog.create(_team_entry(namespace=namespace))
+        query = EntryQuery(namespace=namespace)
+        response = client.post(
+            "/catalog/team/search",
+            content=_yaml_body(query).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 200
+        rows = response.json()
+        assert len(rows) == 1
+        assert rows[0]["namespace"] == namespace
+
+    def test_kind_mismatch_400_under_yaml(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """Cross-kind mismatch check fires under YAML too."""
+        client, _ = api_client
+        query = EntryQuery(kind="agent")
+        response = client.post(
+            "/catalog/team/search",
+            content=_yaml_body(query).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 400
+
+
+class TestCloneEntryBodyFormats:
+    """POST /catalog/clone under JSON and YAML bodies."""
+
+    def test_json_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        src_ns = "ns-clone-src-json"
+        dst_ns = "ns-clone-dst-json"
+        catalog.create(_team_entry(namespace=src_ns))
+        req = CloneRequest(
+            src_namespace=src_ns,
+            src_id="team",
+            dst_namespace=dst_ns,
+        )
+        response = client.post(
+            "/catalog/clone",
+            content=req.model_dump_json().encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 201
+        assert response.json()["namespace"] == dst_ns
+
+    def test_yaml_body(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        src_ns = "ns-clone-src-yaml"
+        dst_ns = "ns-clone-dst-yaml"
+        catalog.create(_team_entry(namespace=src_ns))
+        req = CloneRequest(
+            src_namespace=src_ns,
+            src_id="team",
+            dst_namespace=dst_ns,
+        )
+        response = client.post(
+            "/catalog/clone",
+            content=_yaml_body(req).encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 201
+        assert response.json()["namespace"] == dst_ns
+
+
+# --- OpenAPI advertisement --------------------------------------------------
+
+
+class TestOpenAPIAdvertisement:
+    """``openapi.json`` advertises all three content types on the four endpoints."""
+
+    _EXPECTED = {"application/json", "application/yaml", "application/x-yaml"}
+
+    def _schema(self, api_client: tuple[TestClient, Catalog]) -> dict[str, Any]:
+        client, _ = api_client
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema: dict[str, Any] = response.json()
+        return schema
+
+    def _assert_three_formats(self, schema: dict[str, Any], path: str, method: str) -> None:
+        op = schema["paths"][path][method]
+        content = op["requestBody"]["content"]
+        assert self._EXPECTED.issubset(content.keys()), (
+            f"{method.upper()} {path} missing content types: {self._EXPECTED - content.keys()}"
+        )
+
+    def test_openapi_declares_three_content_types_on_four_endpoints(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        schema = self._schema(api_client)
+        self._assert_three_formats(schema, "/catalog/{kind}", "post")
+        self._assert_three_formats(schema, "/catalog/{kind}/{id}", "put")
+        self._assert_three_formats(schema, "/catalog/{kind}/search", "post")
+        self._assert_three_formats(schema, "/catalog/clone", "post")
+
+
+# --- Task 8: _parse_body_as unit tests -------------------------------------
+
+
+def _build_request(body: bytes, content_type: str | None) -> Request:
+    """Build a minimal Starlette ``Request`` around raw bytes.
+
+    Uses an in-memory ``receive`` coroutine to feed the body in a single
+    ``http.request`` message. Headers are encoded to bytes per the ASGI
+    contract. A missing ``content_type`` means no header is attached (tests
+    the "default to application/json" fallback).
+    """
+    headers: list[tuple[bytes, bytes]] = []
+    if content_type is not None:
+        headers.append((b"content-type", content_type.encode("latin-1")))
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "headers": headers,
+    }
+    sent = {"done": False}
+
+    async def receive() -> dict[str, Any]:
+        if sent["done"]:
+            return {"type": "http.disconnect"}
+        sent["done"] = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)  # type: ignore[arg-type]
+
+
+def _valid_entry_json_bytes() -> bytes:
+    """Canonical JSON bytes for a minimal valid ``Entry``."""
+    return _json_body(_team_entry(namespace="ns-unit")).encode("utf-8")
+
+
+def _valid_entry_yaml_bytes() -> bytes:
+    """Canonical YAML bytes for a minimal valid ``Entry``."""
+    return _yaml_body(_team_entry(namespace="ns-unit")).encode("utf-8")
+
+
+class TestParseBodyAs:
+    """Unit tests for every branch of ``_parse_body_as``."""
+
+    async def test_json_happy_path(self) -> None:
+        request = _build_request(_valid_entry_json_bytes(), "application/json")
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"
+
+    async def test_yaml_happy_path_application_yaml(self) -> None:
+        request = _build_request(_valid_entry_yaml_bytes(), "application/yaml")
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"
+
+    async def test_yaml_happy_path_application_x_yaml(self) -> None:
+        request = _build_request(_valid_entry_yaml_bytes(), "application/x-yaml")
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"
+
+    async def test_empty_body_json_propagates_validation_error(self) -> None:
+        """Empty JSON body -> ``model_validate({})`` -> Pydantic ValidationError."""
+        request = _build_request(b"", "application/json")
+        with pytest.raises(pydantic.ValidationError):
+            await _parse_body_as(request, Entry)
+
+    async def test_empty_body_yaml_propagates_validation_error(self) -> None:
+        """Empty YAML body -> ``model_validate({})`` -> Pydantic ValidationError."""
+        request = _build_request(b"", "application/yaml")
+        with pytest.raises(pydantic.ValidationError):
+            await _parse_body_as(request, Entry)
+
+    async def test_unknown_content_type_raises_415(self) -> None:
+        request = _build_request(b"<xml/>", "application/xml")
+        with pytest.raises(HTTPException) as exc_info:
+            await _parse_body_as(request, Entry)
+        assert exc_info.value.status_code == 415
+        assert "unsupported Content-Type" in str(exc_info.value.detail)
+        assert "application/xml" in str(exc_info.value.detail)
+
+    async def test_malformed_yaml_raises_422(self) -> None:
+        request = _build_request(b":: not yaml ::", "application/yaml")
+        with pytest.raises(HTTPException) as exc_info:
+            await _parse_body_as(request, Entry)
+        assert exc_info.value.status_code == 422
+        assert "invalid YAML body" in str(exc_info.value.detail)
+
+    async def test_malformed_json_raises_422(self) -> None:
+        request = _build_request(b"{not json", "application/json")
+        with pytest.raises(HTTPException) as exc_info:
+            await _parse_body_as(request, Entry)
+        assert exc_info.value.status_code == 422
+        assert "invalid JSON body" in str(exc_info.value.detail)
+
+    async def test_content_type_parameter_stripping(self) -> None:
+        """``application/yaml; charset=utf-8`` is treated as YAML."""
+        request = _build_request(_valid_entry_yaml_bytes(), "application/yaml; charset=utf-8")
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"
+
+    async def test_case_insensitive_content_type(self) -> None:
+        """``Application/YAML`` normalizes to ``application/yaml``."""
+        request = _build_request(_valid_entry_yaml_bytes(), "Application/YAML")
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"
+
+    async def test_missing_content_type_defaults_to_json(self) -> None:
+        """No ``Content-Type`` header -> JSON branch (Starlette default)."""
+        request = _build_request(_valid_entry_json_bytes(), content_type=None)
+        entry = await _parse_body_as(request, Entry)
+        assert isinstance(entry, Entry)
+        assert entry.kind == "team"


### PR DESCRIPTION
## Summary

- Adds `_parse_body_as(request, model_type)` helper in `akgentic.catalog.api.router` that dispatches `application/json`, `application/yaml`, and `application/x-yaml` request bodies into typed Pydantic instances, with 415 for unknown content types and 422 for malformed JSON/YAML.
- Rewrites the four per-kind CRUD handlers (`create_entry`, `update_entry`, `search_entries`, `clone_entry`) to take `request: Request` and route body parsing through the helper. URL-authoritative checks (`_ensure_kind`, namespace/id mismatch, kind mismatch on search) are preserved verbatim.
- Declares three-content-type `requestBody` entries on all four endpoints via `openapi_extra=_multi_format_body_openapi(...)` so `openapi.json` advertises JSON + YAML parity.
- Registers a `pydantic.ValidationError` handler in `api/_errors.py` so the multi-format body path returns the same 422 envelope shape the typed-argument path produced.
- Adds 23 tests: 11 round-trip handler tests (4 handlers × 2 formats + mismatch-under-YAML variants + second-kind `prompt` coverage + OpenAPI schema assertion) and 11 unit tests for `_parse_body_as` (every branch, empty-body handling, content-type normalization, malformed payload errors). All use real `TestClient` and a YAML-backed `Catalog` — zero `MagicMock`.
- Delivers `akgentic-infra` ADR-023 §D4's commitment to preserve the v1 "CLI ships the bytes; server validates" contract on the v2 unified router.

## Story

Relates to #140

- Epic: `_bmad-output/akgentic-catalog/epics/epic-21-multi-format-body-handling.md`
- Governing architectural commitment: `_bmad-output/akgentic-infra/decisions/adr-023-admin-catalog-is-v2-router-with-authstrategy.md` §D4

## Acceptance criteria

- [x] 21-1-per-kind-crud-accepts-yaml-bodies (Relates to #140)

## Review status

21-1 review: PASS. No HIGH or MEDIUM issues. One LOW cosmetic nit (two unused helpers `_PROMPT_TYPE` / `_prompt_payload` in the new test file) was deliberately NOT auto-fixed — does not justify a second commit and doesn't affect correctness or coverage.

No fixup commit required.

## Epic 21 slice complete

This PR delivers the entire Epic 21 scope (1/1 stories). After merge, Epic 21 transitions to `done` in sprint-status.

## CI status

CI on `feat/140-epic-21-multi-format-body-handling` is green on Amelia's commit 9f1f3dd — see `gh run list --branch feat/140-epic-21-multi-format-body-handling -R b12consulting/akgentic-catalog`. Latest pre-PR push: `completed / success` in 59s. PR-level checks will be reported post-creation.

## Scope guard

All changes stayed inside `packages/akgentic-catalog/src/akgentic/catalog/api/` (2 files) and `packages/akgentic-catalog/tests/api/` (3 files). No files modified outside `packages/akgentic-catalog/`. Module-boundary rule (CLAUDE.md §4) upheld.
