### PR TITLE
feat(akgentic-catalog): epic 16 — ADR-007 AgentCard.role compatibility (16-1 → 16-3)

### DIFF
--- a/src/akgentic/catalog/models/agent.py
+++ b/src/akgentic/catalog/models/agent.py
@@ -197,7 +197,6 @@ class AgentEntry(BaseModel):
                 config.prompt = resolved_prompt  # ADR-003: duck-type gate
 
         return AgentCard(
-            role=card.role,
             description=card.description,
             skills=card.skills,
             agent_class=card.agent_class,

--- a/src/akgentic/catalog/repositories/mongo/agent_repo.py
+++ b/src/akgentic/catalog/repositories/mongo/agent_repo.py
@@ -34,18 +34,24 @@ class MongoAgentCatalogRepository(AgentCatalogRepository):
     def __init__(self, collection: pymongo.collection.Collection) -> None:  # type: ignore[type-arg]
         """Initialize with a pymongo Collection and ensure indexes.
 
-        Creates indexes on ``card.role`` (secondary) and ``card.skills``
+        Creates indexes on ``card.config.role`` (secondary) and ``card.skills``
         (multikey for ``$in`` queries). ``_id`` is inherently unique.
+
+        Per ADR-007, ``AgentCard.role`` is a non-serialized ``@property``
+        derived from ``config.role`` — the stored BSON has no ``card.role``
+        key, so the secondary index targets ``card.config.role`` where the
+        registry key actually lives.
 
         Args:
             collection: The MongoDB collection for agent entries.
         """
         self._collection = collection
         # _id is inherently unique in MongoDB — no explicit index needed.
-        self._collection.create_index("card.role")
+        self._collection.create_index("card.config.role")
         self._collection.create_index("card.skills")
         logger.info(
-            "MongoAgentCatalogRepository initialized with indexes on _id, card.role, card.skills"
+            "MongoAgentCatalogRepository initialized with indexes on "
+            "_id, card.config.role, card.skills"
         )
 
     def create(self, agent_entry: AgentEntry) -> str:
@@ -94,9 +100,10 @@ class MongoAgentCatalogRepository(AgentCatalogRepository):
     def search(self, query: AgentQuery) -> _list[AgentEntry]:
         """Filter agents by AND-ing all non-None query fields.
 
-        Uses server-side exact match for ``id`` and ``card.role``. Uses
-        ``$in`` for ``card.skills`` (ANY overlap semantics). Uses ``$regex``
-        with case-insensitive option for substring matching on ``card.description``.
+        Uses server-side exact match for ``id`` and ``card.config.role``.
+        Uses ``$in`` for ``card.skills`` (ANY overlap semantics). Uses
+        ``$regex`` with case-insensitive option for substring matching on
+        ``card.description``.
 
         Args:
             query: Query with optional filter fields.
@@ -108,7 +115,7 @@ class MongoAgentCatalogRepository(AgentCatalogRepository):
         if query.id is not None:
             mongo_filter["_id"] = query.id
         if query.role is not None:
-            mongo_filter["card.role"] = query.role
+            mongo_filter["card.config.role"] = query.role
         if query.skills is not None:
             mongo_filter["card.skills"] = {"$in": query.skills}
         if query.description is not None:

--- a/src/akgentic/catalog/repositories/postgres/_queries.py
+++ b/src/akgentic/catalog/repositories/postgres/_queries.py
@@ -196,13 +196,14 @@ def agent_id_predicate(value: str) -> tuple[str, list[object]]:
 
 
 def agent_role_predicate(value: str) -> tuple[str, list[object]]:
-    """Build ``data->'card'->>'role' = %s`` predicate for an exact role match.
+    """Build ``data->'card'->'config'->>'role' = %s`` predicate for exact role match.
 
-    ``AgentEntry.card`` is a nested ``AgentCard``, so ``role`` lives under the
-    nested ``card`` object in the JSONB document — matching the Mongo
-    backend's ``card.role`` filter.
+    Per ADR-007, ``AgentCard.role`` is a non-serialized ``@property`` derived
+    from ``config.role`` — the serialized JSONB has no top-level ``card.role``
+    key, so the predicate traverses one level deeper into ``card.config.role``
+    to match the authoritative registry key.
     """
-    return "data->'card'->>'role' = %s", [value]
+    return "data->'card'->'config'->>'role' = %s", [value]
 
 
 def agent_skills_predicate(value: list[str]) -> tuple[str, list[object]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def make_tool(
 def make_agent(
     id: str = "agent-1",
     name: str = "test-agent",
+    role: str = "engineer",
     tool_ids: _list[str] | None = None,
     template_ref: str | None = None,
     params: dict[str, str] | None = None,
@@ -120,14 +121,13 @@ def make_agent(
         prompt["template"] = template_ref
         if params is not None:
             prompt["params"] = params
-    config: dict[str, str | dict[str, str | dict[str, str]]] = {"name": name}
+    config: dict[str, str | dict[str, str | dict[str, str]]] = {"name": name, "role": role}
     if prompt:
         config["prompt"] = prompt
     return AgentEntry(
         id=id,
         tool_ids=tool_ids or [],
         card={
-            "role": "engineer",
             "description": "test agent",
             "skills": ["coding"],
             "agent_class": "akgentic.agent.BaseAgent",

--- a/tests/models/test_agent_entry.py
+++ b/tests/models/test_agent_entry.py
@@ -58,13 +58,22 @@ class MockTemplateCatalog:
 
 
 def _base_agent_card(**overrides: object) -> dict[str, object]:
-    """Build minimal valid card data for BaseAgent."""
+    """Build minimal valid card data for BaseAgent.
+
+    ``config.role`` is the single source of truth for ``AgentCard.role``
+    (ADR-007); this helper injects ``role="engineer"`` into the config
+    dict — including overridden configs that omit it — so every test
+    builds a valid card by default.
+    """
+    role = overrides.pop("role", "engineer")
+    config = overrides.pop("config", {"name": "test-agent"})
+    if isinstance(config, dict) and "role" not in config:
+        config = {**config, "role": role}
     card: dict[str, object] = {
-        "role": "engineer",
         "description": "A test agent",
         "skills": ["coding"],
         "agent_class": "akgentic.agent.BaseAgent",
-        "config": {"name": "test-agent"},
+        "config": config,
     }
     card.update(overrides)
     return card

--- a/tests/models/test_round_trip.py
+++ b/tests/models/test_round_trip.py
@@ -71,12 +71,12 @@ class TestRoundTripAgentEntry:
             id="researcher",
             tool_ids=["search", "planning"],
             card={
-                "role": "research-engineer",
                 "description": "Research engineer specializing in biology",
                 "skills": ["research", "analysis", "citation"],
                 "agent_class": "tests.models.test_round_trip.ResearchAgent",
                 "config": {
                     "name": "researcher",
+                    "role": "research-engineer",
                     "research_domain": "biology",
                     "max_sources": 20,
                     "include_citations": False,
@@ -129,11 +129,10 @@ class TestRoundTripAgentEntry:
             id="researcher",
             tool_ids=["search", "planning", "analysis"],
             card={
-                "role": "engineer",
                 "description": "Test agent",
                 "skills": ["coding"],
                 "agent_class": "tests.models.test_round_trip.ResearchAgent",
-                "config": {"name": "test"},
+                "config": {"name": "test", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -149,12 +148,12 @@ class TestRoundTripAgentEntry:
             id="researcher",
             tool_ids=["search"],
             card={
-                "role": "research-engineer",
                 "description": "Research engineer specializing in biology",
                 "skills": ["research", "analysis", "citation"],
                 "agent_class": "tests.models.test_round_trip.ResearchAgent",
                 "config": {
                     "name": "researcher",
+                    "role": "research-engineer",
                     "research_domain": "biology",
                     "max_sources": 20,
                     "include_citations": False,
@@ -184,7 +183,6 @@ class TestRoundTripBaseConfigAgent:
             id="human-proxy",
             tool_ids=[],
             card={
-                "role": "Human",
                 "description": "User-facing proxy",
                 "skills": [],
                 "agent_class": "tests.models.test_round_trip.BareConfigAgent",
@@ -199,7 +197,7 @@ class TestRoundTripBaseConfigAgent:
         assert restored.card.config.name == "@Human"
         assert restored.card.config.role == "HumanProxy"
         assert restored.tool_ids == []
-        assert restored.card.role == "Human"
+        assert restored.card.role == "HumanProxy"
         assert restored.card.description == "User-facing proxy"
         assert restored.card.routes_to == ["@Manager"]
         assert restored.id == "human-proxy"

--- a/tests/repositories/mongo/test_mongo_agent_repo.py
+++ b/tests/repositories/mongo/test_mongo_agent_repo.py
@@ -96,11 +96,10 @@ class TestSearch:
             id="a3",
             tool_ids=[],
             card={
-                "role": "manager",
                 "description": "team lead",
                 "skills": ["leadership"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "mgr-agent"},
+                "config": {"name": "mgr-agent", "role": "manager"},
                 "routes_to": [],
             },
         )
@@ -116,11 +115,10 @@ class TestSearch:
             id="a1",
             tool_ids=[],
             card={
-                "role": "researcher",
                 "description": "researches topics",
                 "skills": ["research", "coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "researcher"},
+                "config": {"name": "researcher", "role": "researcher"},
                 "routes_to": [],
             },
         )
@@ -128,11 +126,10 @@ class TestSearch:
             id="a2",
             tool_ids=[],
             card={
-                "role": "writer",
                 "description": "writes content",
                 "skills": ["writing"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "writer"},
+                "config": {"name": "writer", "role": "writer"},
                 "routes_to": [],
             },
         )
@@ -140,11 +137,10 @@ class TestSearch:
             id="a3",
             tool_ids=[],
             card={
-                "role": "coder",
                 "description": "writes code",
                 "skills": ["coding", "testing"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "coder"},
+                "config": {"name": "coder", "role": "coder"},
                 "routes_to": [],
             },
         )
@@ -177,11 +173,10 @@ class TestSearch:
             id="a1",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "Builds REST APIs",
                 "skills": ["coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "api-builder"},
+                "config": {"name": "api-builder", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -189,11 +184,10 @@ class TestSearch:
             id="a2",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "Builds CLI tools",
                 "skills": ["coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "cli-builder"},
+                "config": {"name": "cli-builder", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -210,11 +204,10 @@ class TestSearch:
             id="a1",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "builds APIs",
                 "skills": ["coding", "research"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "a1"},
+                "config": {"name": "a1", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -222,11 +215,10 @@ class TestSearch:
             id="a2",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "builds UIs",
                 "skills": ["coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "a2"},
+                "config": {"name": "a2", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -234,11 +226,10 @@ class TestSearch:
             id="a3",
             tool_ids=[],
             card={
-                "role": "manager",
                 "description": "manages APIs team",
                 "skills": ["leadership"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "a3"},
+                "config": {"name": "a3", "role": "manager"},
                 "routes_to": [],
             },
         )
@@ -267,11 +258,10 @@ class TestSearch:
             id="a1",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "builds APIs (v2)",
                 "skills": ["coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "a1"},
+                "config": {"name": "a1", "role": "engineer"},
                 "routes_to": [],
             },
         )
@@ -279,11 +269,10 @@ class TestSearch:
             id="a2",
             tool_ids=[],
             card={
-                "role": "engineer",
                 "description": "builds APIs v2",
                 "skills": ["coding"],
                 "agent_class": "akgentic.agent.BaseAgent",
-                "config": {"name": "a2"},
+                "config": {"name": "a2", "role": "engineer"},
                 "routes_to": [],
             },
         )

--- a/tests/repositories/mongo/test_mongo_agent_repo.py
+++ b/tests/repositories/mongo/test_mongo_agent_repo.py
@@ -84,7 +84,7 @@ class TestSearch:
         assert results[0].id == "a1"
 
     def test_search_by_role_exact_match(self, repo: MongoAgentCatalogRepository) -> None:
-        """Search by role returns exact matches on card.role."""
+        """Search by role returns exact matches on card.config.role (ADR-007)."""
         # make_agent defaults to role="engineer"
         repo.create(make_agent(id="a1"))
         repo.create(
@@ -329,3 +329,25 @@ class TestDelete:
         """Deleting a nonexistent entry raises EntryNotFoundError."""
         with pytest.raises(EntryNotFoundError, match="not found"):
             repo.delete("ghost")
+
+
+class TestIndexes:
+    """ADR-007 guard: verify the role secondary index targets card.config.role."""
+
+    def test_role_index_targets_card_config_role(
+        self,
+        repo: MongoAgentCatalogRepository,  # noqa: ARG002 — repo fixture creates the indexes
+        agent_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        # After __init__ runs the index creation, the collection must
+        # carry an index on ``card.config.role`` (not the legacy
+        # ``card.role`` path, which is no longer serialized).
+        def _keys(spec: object) -> tuple[tuple[str, int], ...]:
+            key = spec["key"] if isinstance(spec, dict) else None  # type: ignore[index]
+            if hasattr(key, "items"):
+                return tuple(key.items())
+            return tuple(key) if key is not None else ()
+
+        indexed_keys = {_keys(spec) for spec in agent_collection.index_information().values()}
+        assert (("card.config.role", 1),) in indexed_keys
+        assert (("card.role", 1),) not in indexed_keys

--- a/tests/repositories/postgres/test_nagra_agent_repo.py
+++ b/tests/repositories/postgres/test_nagra_agent_repo.py
@@ -143,6 +143,20 @@ class TestSearch:
         assert len(results) == 1
         assert results[0].id == "a2"
 
+    def test_search_by_role_nonexistent_returns_empty(
+        self, repo: NagraAgentCatalogRepository
+    ) -> None:
+        # Guard against the ADR-007 regression where the role predicate
+        # traversed a non-existent JSONB path and silently returned zero
+        # rows for every query — including valid ones. If this assertion
+        # starts matching rows, the predicate is pointing at the wrong
+        # path again.
+        repo.create(_agent(id="a1", role="engineer"))
+        repo.create(_agent(id="a2", role="Manager"))
+
+        assert repo.search(AgentQuery(role="engineer")), "expected non-empty hit"
+        assert repo.search(AgentQuery(role="nonexistent-role")) == []
+
     def test_search_by_description_case_insensitive(
         self, repo: NagraAgentCatalogRepository
     ) -> None:

--- a/tests/repositories/postgres/test_nagra_agent_repo.py
+++ b/tests/repositories/postgres/test_nagra_agent_repo.py
@@ -44,11 +44,10 @@ def _agent(
         id=id,
         tool_ids=[],
         card={
-            "role": role,
             "description": description,
             "skills": skills if skills is not None else ["coding"],
             "agent_class": "akgentic.agent.BaseAgent",
-            "config": {"name": name},
+            "config": {"name": name, "role": role},
             "routes_to": [],
         },
     )

--- a/tests/repositories/test_yaml_agent_repo.py
+++ b/tests/repositories/test_yaml_agent_repo.py
@@ -26,7 +26,6 @@ def _agent_dict(
         "id": id,
         "tool_ids": [],
         "card": {
-            "role": role,
             "description": description,
             "skills": skills,
             "agent_class": AGENT_CLASS,

--- a/tests/services/test_agent_catalog.py
+++ b/tests/services/test_agent_catalog.py
@@ -377,11 +377,10 @@ class TestBaseConfigAgentService:
             id=id,
             tool_ids=[],
             card={
-                "role": "Human",
                 "description": "User-facing proxy",
                 "skills": [],
                 "agent_class": "akgentic.agent.HumanProxy",
-                "config": {"name": name},
+                "config": {"name": name, "role": "Human"},
                 "routes_to": [],
             },
         )


### PR DESCRIPTION
## Summary

Epic 16 — carry `akgentic-catalog` through `akgentic-core`'s new `AgentCard.role` contract with the minimum patch needed. Core now exposes `AgentCard.role` as a read-only `@property` derived from `config.role`, rejects cards whose `config.role` is empty, and no longer serializes a top-level `role` on the card. Catalog is scheduled for retirement, so this PR is explicitly compatibility-only — no abstraction layer, no data migration, no redesign.

See [ADR-007](../blob/master/_bmad-output/akgentic-catalog/decisions/adr-07-agentcard-role-compatibility.md) for the full rationale.

## Stories (checklist)

- [x] **16-1** — Fixture compatibility: move `role` into `config` across the test suite (Relates to #144)
- [x] **16-2** — Postgres `agent_role_predicate` traverses `card.config.role` (Relates to #145)
- [x] **16-3** — Mongo role index + filter target `card.config.role` (Relates to #146)

## Review status

- **16-1 PASS** — fixture migration is mechanical; Rex fixup dropped the dead `role=card.role` kwarg in `AgentEntry.to_agent_card` for clarity (extra='ignore' silently ignored it).
- **16-2 PASS** — predicate fix + Rex fixup added an explicit hit/miss regression guard so a future mispath stops silently returning zero rows.
- **16-3 PASS** — index + filter fix + Rex fixup asserting `card.config.role` is indexed and `card.role` is not.

## Scope guard

All changes stay inside `packages/akgentic-catalog/`. Production source touched: `models/agent.py` (one dead-kwarg removal), `repositories/postgres/_queries.py` (one predicate path), `repositories/mongo/agent_repo.py` (two paths + log line). Everything else is test-only.

## Operator notes

- **Mongo deployments** initialized against the old core carry a stale `card.role` secondary index. The new `card.config.role` index is created idempotently alongside it; drop the old one manually (`db.agent_entries.dropIndex("card.role_1")`) to reclaim storage. Per ADR-007, no automated migration.
- **Postgres deployments** have no stale index (only `_id` was ever indexed); pre-existing rows written with top-level-only `role` will fail to deserialize through the new `AgentEntry` validator — an acceptable upgrade signal, not a regression.

## Upstream dependency

Depends on `akgentic-core` PR #58 (branch `feat/58-9-2-agentcard-role-derives-from-config-role`). CI on this catalog PR will only pass once the root repo's core submodule pointer bumps to a SHA that carries the role-derivation change.

## Epic 16 slice complete

Three stories, 779/779 local tests green, catalog functionally aligned with the new core contract and ready to be retired cleanly.
