### PR TITLE
Story 17.1: Lineage-field hardening — Entry docstring + Catalog.update guard

### DIFF
--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -178,13 +178,17 @@ class Catalog:
 
         1. Existence check: ``repository.get`` MUST return non-``None``.
         2. Run ``prepare_for_write`` (may raise ``CatalogValidationError``).
-        3. For non-team entries, re-run ``_check_ownership`` on the prepared
+        3. Reject lineage mutations from one non-``None`` pair to a different
+           non-``None`` pair (resets to ``(None, None)`` are allowed;
+           idempotent re-writes are allowed). See
+           ``_check_lineage_unchanged_or_reset``.
+        4. For non-team entries, re-run ``_check_ownership`` on the prepared
            shape so validator normalisations are honoured. Team entries are
            authoritative for their own ``user_id`` and skip this check —
            changing a team's ``user_id`` is a deliberate ownership transfer
            that leaves sub-entries inconsistent until a caller-side migration
            follows up (not this service's concern).
-        4. ``repository.put`` + return.
+        5. ``repository.put`` + return.
 
         ``update`` NEVER mints a namespace; the empty-string / sentinel path
         is exclusive to :meth:`create`.
@@ -198,12 +202,14 @@ class Catalog:
 
         Raises:
             EntryNotFoundError: If no entry exists at ``(entry.namespace, entry.id)``.
-            CatalogValidationError: From ``prepare_for_write`` or
-                ``_check_ownership``.
+            CatalogValidationError: From ``prepare_for_write``, the lineage
+                mutation guard, or ``_check_ownership``.
         """
-        if self._repository.get(entry.namespace, entry.id) is None:
+        existing = self._repository.get(entry.namespace, entry.id)
+        if existing is None:
             raise EntryNotFoundError(f"Entry ({entry.namespace}, {entry.id}) not found")
         prepared = prepare_for_write(entry, self._repository)
+        self._check_lineage_unchanged_or_reset(existing, prepared)
         if prepared.kind != "team":
             self._check_ownership(prepared)
         self._repository.put(prepared)
@@ -568,6 +574,61 @@ class Catalog:
                     f"entry first (bootstrap invariant)"
                 ]
             )
+
+    def _check_lineage_unchanged_or_reset(self, existing: Entry, prepared: Entry) -> None:
+        """Reject lineage mutations from one non-``None`` pair to a different pair.
+
+        The four allowed transitions (per ADR-008 §D3) are:
+
+        * stored ``(None, None)`` → prepared ``(None, None)`` — no-op.
+        * stored ``(None, None)`` → prepared ``(set, set)`` — first stamp.
+        * stored ``(set, set)`` → prepared ``(None, None)`` — operator detach.
+        * stored ``(set, set)`` → prepared same ``(set, set)`` — idempotent.
+
+        Anything else — i.e. both prepared lineage fields are non-``None`` and
+        at least one differs from the stored value — is rejected with a
+        single-element ``CatalogValidationError`` carrying the message pinned
+        by the AC: ``"Lineage fields cannot be mutated ..."``.
+
+        The check fires on every ``Catalog.update`` call regardless of
+        ``kind``. ``Catalog.create``, ``Catalog.clone``, and ``Catalog.delete``
+        do not call this helper.
+
+        Args:
+            existing: The stored entry returned by the existence check in
+                ``Catalog.update``.
+            prepared: The candidate entry returned by ``prepare_for_write``.
+
+        Raises:
+            CatalogValidationError: When the prepared lineage values are both
+                non-``None`` and at least one differs from the stored value.
+        """
+        # A reset to (None, None) is always allowed — it is the documented
+        # operator-side escape hatch for detaching a clone from its source.
+        if prepared.parent_namespace is None and prepared.parent_id is None:
+            return
+        # An idempotent re-write (stored == prepared) is allowed.
+        if (
+            existing.parent_namespace == prepared.parent_namespace
+            and existing.parent_id == prepared.parent_id
+        ):
+            return
+        # The "first stamp" path — stored (None, None) → prepared (set, set) —
+        # is allowed. The validator does not police where lineage is set,
+        # only that an existing non-None pair is not silently overwritten.
+        if existing.parent_namespace is None and existing.parent_id is None:
+            return
+        # Otherwise: a non-None stored pair differs from the prepared pair.
+        # Reject with the message pinned by the AC.
+        raise CatalogValidationError(
+            [
+                "Lineage fields cannot be mutated from one non-None value to "
+                "a different non-None value (parent_namespace: "
+                f"{existing.parent_namespace!r} → {prepared.parent_namespace!r}, "
+                f"parent_id: {existing.parent_id!r} → {prepared.parent_id!r}). "
+                "Reset to None to detach a clone from its source."
+            ]
+        )
 
     def _check_ownership(self, entry: Entry) -> None:
         """Ensure ``entry.user_id == team_entry.user_id`` within ``entry.namespace``."""

--- a/src/akgentic/catalog/models/entry.py
+++ b/src/akgentic/catalog/models/entry.py
@@ -95,6 +95,13 @@ class Entry(BaseModel):
     The validator ``_check_parent_pair`` rejects the fourth combination
     (``parent_namespace`` set, ``parent_id is None``) because a namespace
     without an id does not identify a parent entry.
+
+    Lineage fields (``parent_namespace``, ``parent_id``) are pass-through
+    audit metadata. No service-level logic branches on them; the only writer
+    is ``Catalog.clone`` (root-only stamp). They are persisted, indexed
+    (Postgres ``(namespace, parent_id)``), and queryable via ``EntryQuery``
+    so operators can answer "list every entry cloned from
+    ``(src-ns, src-id)``".
     """
 
     id: NonEmptyStr = Field(description="Entry id, unique within (namespace, kind).")

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -572,3 +572,196 @@ class TestDeleteClean:
         # The team entry has no inbound refs (no other entries exist).
         catalog.delete("ns-clean", team.id)
         assert repo.get("ns-clean", team.id) is None
+
+
+# --- AC18 — update lineage-mutation guard ---------------------------------------
+
+
+def _seed_agent_with_lineage(
+    catalog: Catalog,
+    repo: EntryRepository,
+    namespace: str,
+    user_id: str | None,
+    agent_type: str,
+    parent_namespace: str | None,
+    parent_id: str | None,
+) -> Entry:
+    """Seed a non-team agent entry with arbitrary lineage values into ``repo``.
+
+    ``Catalog.create`` does not police lineage — but to make the seeded entry's
+    lineage value deterministic we go around the service and call
+    ``repo.put`` directly for the lineage stamp. The team entry is bootstrapped
+    via the normal path so the namespace passes the bootstrap invariant for
+    the subsequent ``catalog.update`` call.
+    """
+    _seed_team(catalog, namespace=namespace, user_id=user_id)
+    entry = Entry(
+        id="lineage-target",
+        kind="agent",
+        namespace=namespace,
+        user_id=user_id,
+        parent_namespace=parent_namespace,
+        parent_id=parent_id,
+        model_type=agent_type,
+        payload={"provider": "openai"},
+    )
+    repo.put(entry)
+    return entry
+
+
+class TestUpdateLineageGuard:
+    """AC18 — Catalog.update rejects lineage mutations between non-None pairs."""
+
+    def test_update_lineage_unchanged_no_op(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stored (None, None) -> candidate (None, None) — no-op transition.
+        catalog, repo = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        stored = _seed_agent_with_lineage(
+            catalog,
+            repo,
+            namespace="ns-lin-noop",
+            user_id="alice",
+            agent_type=agent_type,
+            parent_namespace=None,
+            parent_id=None,
+        )
+        candidate = stored.model_copy(update={"parent_namespace": None, "parent_id": None})
+        result = catalog.update(candidate)
+        assert result.parent_namespace is None
+        assert result.parent_id is None
+        roundtrip = repo.get("ns-lin-noop", stored.id)
+        assert roundtrip is not None
+        assert roundtrip.parent_namespace == candidate.parent_namespace
+        assert roundtrip.parent_id == candidate.parent_id
+
+    def test_update_lineage_first_stamp_allowed(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stored (None, None) -> candidate (set, set) — first stamp.
+        catalog, repo = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        stored = _seed_agent_with_lineage(
+            catalog,
+            repo,
+            namespace="ns-lin-first",
+            user_id="alice",
+            agent_type=agent_type,
+            parent_namespace=None,
+            parent_id=None,
+        )
+        candidate = stored.model_copy(update={"parent_namespace": "src-ns", "parent_id": "src-id"})
+        result = catalog.update(candidate)
+        assert result.parent_namespace == "src-ns"
+        assert result.parent_id == "src-id"
+        roundtrip = repo.get("ns-lin-first", stored.id)
+        assert roundtrip is not None
+        assert roundtrip.parent_namespace == candidate.parent_namespace
+        assert roundtrip.parent_id == candidate.parent_id
+
+    def test_update_lineage_reset_to_none_allowed(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stored (set, set) -> candidate (None, None) — operator detach.
+        catalog, repo = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        stored = _seed_agent_with_lineage(
+            catalog,
+            repo,
+            namespace="ns-lin-reset",
+            user_id="alice",
+            agent_type=agent_type,
+            parent_namespace="src-ns",
+            parent_id="src-id",
+        )
+        candidate = stored.model_copy(update={"parent_namespace": None, "parent_id": None})
+        result = catalog.update(candidate)
+        assert result.parent_namespace is None
+        assert result.parent_id is None
+        roundtrip = repo.get("ns-lin-reset", stored.id)
+        assert roundtrip is not None
+        assert roundtrip.parent_namespace == candidate.parent_namespace
+        assert roundtrip.parent_id == candidate.parent_id
+
+    def test_update_lineage_idempotent_rewrite_allowed(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stored (set, set) -> candidate same (set, set) — idempotent re-write.
+        catalog, repo = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        stored = _seed_agent_with_lineage(
+            catalog,
+            repo,
+            namespace="ns-lin-idem",
+            user_id="alice",
+            agent_type=agent_type,
+            parent_namespace="src-ns",
+            parent_id="src-id",
+        )
+        candidate = stored.model_copy(update={"parent_namespace": "src-ns", "parent_id": "src-id"})
+        result = catalog.update(candidate)
+        assert result.parent_namespace == "src-ns"
+        assert result.parent_id == "src-id"
+        roundtrip = repo.get("ns-lin-idem", stored.id)
+        assert roundtrip is not None
+        assert roundtrip.parent_namespace == candidate.parent_namespace
+        assert roundtrip.parent_id == candidate.parent_id
+
+    def test_update_lineage_mutation_rejected(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stored ("src", "x") -> candidate ("other", "y") — rejected.
+        catalog, repo = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        stored = _seed_agent_with_lineage(
+            catalog,
+            repo,
+            namespace="ns-lin-reject",
+            user_id="alice",
+            agent_type=agent_type,
+            parent_namespace="src",
+            parent_id="x",
+        )
+        candidate = stored.model_copy(update={"parent_namespace": "other", "parent_id": "y"})
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.update(candidate)
+        # AC5: single-element errors list.
+        assert len(exc.value.errors) == 1
+        # AC2 / AC6: grep-stable substring on the rejection message.
+        assert "Lineage fields cannot be mutated" in exc.value.errors[0]
+        # Repository was not mutated — re-`get` returns the stored lineage.
+        roundtrip = repo.get("ns-lin-reject", stored.id)
+        assert roundtrip is not None
+        assert roundtrip.parent_namespace == "src"
+        assert roundtrip.parent_id == "x"
+
+    def test_update_lineage_mutation_skips_repository_put(
+        self,
+        counting_catalog: tuple[Catalog, CountingEntryRepository],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # AC4 — the failure aborts before repository.put runs.
+        catalog, counting = counting_catalog
+        agent_type = _register_agent_model(monkeypatch)
+        # Seed via the counting repo's inner store (use catalog.create for the
+        # team and a direct put for the lineage-stamped agent).
+        _seed_team(catalog, namespace="ns-lin-noput", user_id="alice")
+        stored = Entry(
+            id="lineage-target",
+            kind="agent",
+            namespace="ns-lin-noput",
+            user_id="alice",
+            parent_namespace="src",
+            parent_id="x",
+            model_type=agent_type,
+            payload={"provider": "openai"},
+        )
+        counting.put(stored)
+        counting.reset()
+        candidate = stored.model_copy(update={"parent_namespace": "other", "parent_id": "y"})
+        with pytest.raises(CatalogValidationError):
+            catalog.update(candidate)
+        # The rejection path performed zero put calls — the existing entry
+        # is still the seeded shape.
+        assert counting.count("put") == 0


### PR DESCRIPTION
## Summary

Pin the lineage-field contract in the `Entry` docstring and add a service-level validator on `Catalog.update` that rejects mutations from one non-`None` lineage pair to a different non-`None` pair. Resets to `(None, None)` and idempotent re-writes remain allowed; first-stamp transitions from `(None, None)` to `(set, set)` are also allowed.

Implements story 17.1 — closes #158.

## Changes

- `src/akgentic/catalog/models/entry.py` — `Entry` class docstring extended with a lineage-disposition paragraph (existing three-case lineage table preserved).
- `src/akgentic/catalog/catalog.py` — `Catalog.update` retains the `repository.get` result as `existing` and calls a new private helper `_check_lineage_unchanged_or_reset(existing, prepared)` between `prepare_for_write` and `_check_ownership`. The helper raises `CatalogValidationError` carrying the grep-stable substring `"Lineage fields cannot be mutated"` (single-element `errors` list). The `update` docstring pipeline is renumbered to five steps.
- `tests/v2/test_catalog_crud.py` — new `# --- AC18 — update lineage-mutation guard ---` banner with 11 tests: four allowed transitions plus a rejection case parametrised across yaml + mongo backends, plus a counting-repo test verifying zero `put` calls on the rejection path.

## Quality gates

- ruff lint: clean.
- mypy strict: clean.
- pytest (full submodule): 774 passed, 23 skipped.
- coverage on `catalog.py`: 92 % (above the 80 % gate).
- CI: green on push.

Closes #158
