### PR TITLE
Story 17.2: Namespace metadata entry — EntryKind="meta", NamespaceMeta model, and namespace-route fallback

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -17,6 +17,7 @@ from akgentic.catalog.catalog import UNSET_NAMESPACE, Catalog
 from akgentic.catalog.env import resolve_env_vars
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.namespace_meta import NamespaceMeta
 from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.repositories.yaml import YamlEntryRepository
@@ -42,6 +43,7 @@ __all__ = [
     "EntryNotFoundError",
     "EntryQuery",
     "EntryRepository",
+    "NamespaceMeta",
     "UNSET_NAMESPACE",
     "YamlEntryRepository",
     "load_model_type",

--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -49,6 +49,7 @@ from pydantic import BaseModel
 from akgentic.catalog.api._settings import CatalogRouterSettings
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.namespace_meta import NamespaceMeta
 from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 from akgentic.catalog.resolver import enumerate_allowlisted_model_types, load_model_type
 from akgentic.catalog.validation import NamespaceValidationReport
@@ -197,26 +198,117 @@ def _multi_format_body_openapi(model_name: str) -> dict[str, Any]:
 
 
 async def list_namespaces() -> list[NamespaceSummary]:
-    """List every catalog namespace with its team name and description.
+    """List every catalog namespace with name and description (meta-then-team fallback).
 
-    Equivalent to listing ``kind="team"`` entries and projecting each to
-    ``NamespaceSummary``. The list is sorted alphabetically by ``namespace``.
-    No ``user_id`` filter is applied — callers (or tier-specific middleware)
-    are responsible for tenancy filtering. Namespaces that somehow lack a
-    team entry are skipped silently (defensive guard for a state the catalog
-    invariants should prevent).
+    Issues one ``EntryQuery(kind="team")`` to discover every namespace. For
+    each team entry, the handler attempts ``Catalog.get(team.namespace,
+    "_meta")``; when a meta entry exists, ``name`` and ``description`` are
+    drawn from the meta payload (ADR-008 §D1). Otherwise the values fall
+    back to the team entry — preserving behaviour for deployments that
+    pre-date the meta entry.
+
+    The list is sorted alphabetically by ``namespace``. No ``user_id``
+    filter is applied — callers (or tier-specific middleware) are
+    responsible for tenancy filtering.
     """
     logger.debug("GET /catalog/namespaces")
-    teams = _get_catalog().list(EntryQuery(kind="team"))
-    summaries = [
-        NamespaceSummary(
-            namespace=t.namespace,
-            name=str(t.payload.get("name", "")),
-            description=t.description,
-        )
-        for t in teams
-    ]
+    catalog = _get_catalog()
+    teams = catalog.list(EntryQuery(kind="team"))
+    summaries = [_build_namespace_summary(catalog, t) for t in teams]
     return sorted(summaries, key=lambda s: s.namespace)
+
+
+def _build_namespace_summary(catalog: Catalog, team: Entry) -> NamespaceSummary:
+    """Project ``team`` to a ``NamespaceSummary`` with the meta-then-team fallback.
+
+    Reads the namespace's ``_meta`` entry when present and uses its
+    ``payload["name"]`` / ``description``. Falls back to the team entry's
+    values when no meta entry exists OR when the meta payload's ``name`` is
+    missing / empty (graceful degradation per AC6).
+    """
+    team_name = str(team.payload.get("name", ""))
+    name = team_name
+    description = team.description
+    try:
+        meta = catalog.get(team.namespace, "_meta")
+    except EntryNotFoundError:
+        meta = None
+    if meta is not None and meta.kind == "meta":
+        meta_name = meta.payload.get("name") if isinstance(meta.payload, dict) else None
+        if isinstance(meta_name, str) and meta_name != "":
+            name = meta_name
+        description = meta.description
+    return NamespaceSummary(namespace=team.namespace, name=name, description=description)
+
+
+async def get_namespace_meta(namespace: str) -> Entry:
+    """Return the ``(namespace, "_meta")`` entry; 404 when absent.
+
+    Delegates to ``Catalog.get(namespace, "_meta")``. ``EntryNotFoundError``
+    propagates unchanged (mapped to HTTP 404 by ``api/_errors.py``). A stored
+    entry whose ``kind`` is not ``"meta"`` (defensive — the catalog
+    invariants should prevent this) is treated as absent and the handler
+    re-raises ``EntryNotFoundError`` so the response shape stays consistent.
+    """
+    logger.debug("GET /catalog/namespace/%s/meta", namespace)
+    entry = _get_catalog().get(namespace, "_meta")
+    if entry.kind != "meta":
+        raise EntryNotFoundError(f"Entry ({namespace}, _meta, kind=meta) not found")
+    return entry
+
+
+async def put_namespace_meta(namespace: str, request: Request) -> Response:
+    """Upsert the ``(namespace, "_meta")`` entry from a ``NamespaceMeta`` body.
+
+    Accepts the body in JSON or YAML via ``_parse_body_as``. The handler
+    substitutes ``id="_meta"``, ``kind="meta"``, ``namespace=<URL>``, and
+    ``model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta"``;
+    the body's ``NamespaceMeta`` shape does NOT declare those fields, so a
+    JSON/YAML payload that accidentally carries them is simply not parsed.
+    The team's ``user_id`` is propagated from the namespace's team entry
+    (ownership invariant).
+
+    Dispatches to ``Catalog.create`` when no ``_meta`` entry exists (HTTP
+    201) or to ``Catalog.update`` otherwise (HTTP 200). Returns the stored
+    entry serialised as JSON.
+    """
+    meta = await _parse_body_as(request, NamespaceMeta)
+    logger.debug("PUT /catalog/namespace/%s/meta", namespace)
+    catalog = _get_catalog()
+    teams = catalog.list(EntryQuery(kind="team", namespace=namespace))
+    if not teams:
+        # Lift the bootstrap message up so the 409 surface matches Catalog.create.
+        raise CatalogValidationError(
+            [
+                f"Namespace '{namespace}' has no team entry — create the team "
+                f"entry first (bootstrap invariant)"
+            ]
+        )
+    team = teams[0]
+    entry = Entry(
+        id="_meta",
+        kind="meta",
+        namespace=namespace,
+        user_id=team.user_id,
+        model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+        description=meta.description,
+        payload=meta.model_dump(mode="json"),
+    )
+    try:
+        catalog.get(namespace, "_meta")
+    except EntryNotFoundError:
+        created = catalog.create(entry)
+        return Response(
+            content=created.model_dump_json(),
+            media_type="application/json",
+            status_code=201,
+        )
+    updated = catalog.update(entry)
+    return Response(
+        content=updated.model_dump_json(),
+        media_type="application/json",
+        status_code=200,
+    )
 
 
 async def clone_entry(request: Request) -> Entry:
@@ -457,6 +549,12 @@ def _register_static_routes(target: APIRouter) -> None:
     target.post("/namespace/validate", response_model=NamespaceValidationReport)(
         validate_namespace_post
     )
+    target.get("/namespace/{namespace}/meta", response_model=Entry)(get_namespace_meta)
+    target.put(
+        "/namespace/{namespace}/meta",
+        response_model=Entry,
+        openapi_extra=_multi_format_body_openapi("NamespaceMeta"),
+    )(put_namespace_meta)
 
 
 def _register_generic_kind_routes(target: APIRouter) -> None:

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -137,13 +137,15 @@ class Catalog:
            mint a fresh ``uuid.uuid4()`` and substitute it.
         2. Reject duplicates via ``_check_duplicate`` — raises
            ``CatalogValidationError`` if ``(namespace, id)`` already exists.
-        3. Non-team entries: run ``_check_bootstrap`` then ``_check_ownership``.
+        3. Reject a second ``kind="meta"`` entry in the same namespace via
+           ``_check_meta_singleton`` (ADR-008 §D1). Skipped for ``kind!="meta"``.
+        4. Non-team entries: run ``_check_bootstrap`` then ``_check_ownership``.
            Team entries skip both (a team entry IS the bootstrap; it is the
            ``user_id`` authority for its own namespace).
-        4. Run ``prepare_for_write`` — ref resolution, class load, Pydantic
+        5. Run ``prepare_for_write`` — ref resolution, class load, Pydantic
            validation, dump, reconcile. ``CatalogValidationError`` propagates
            unchanged.
-        5. Call ``repository.put`` with the prepared entry; return it.
+        6. Call ``repository.put`` with the prepared entry; return it.
 
         Args:
             entry: Candidate entry to create. For team entries with a sentinel
@@ -162,6 +164,7 @@ class Catalog:
             entry = self._mint_team_namespace(entry)
 
         self._check_duplicate(entry.namespace, entry.id)
+        self._check_meta_singleton(entry)
 
         if entry.kind != "team":
             self._check_bootstrap(entry.namespace)
@@ -493,6 +496,18 @@ class Catalog:
                 f"is required"
             )
 
+        meta_entries = [e for e in prepared if e.kind == "meta"]
+        if len(meta_entries) > 1:
+            meta_ids = sorted(e.id for e in meta_entries)
+            # ADR-008 §D1 — at most one kind=meta entry per namespace.
+            # Use the same shape as ``validation._check_meta_singleton`` so test
+            # assertions stay grep-stable across the bundle and persisted paths.
+            namespace_for_msg = prepared[0].namespace if prepared else ""
+            errors.append(
+                f"namespace '{namespace_for_msg}' has multiple meta entries: {meta_ids} — "
+                f"exactly one kind=meta entry is allowed per namespace"
+            )
+
         if team_entries:
             expected_user = team_entries[0].user_id
             expected_ns = team_entries[0].namespace
@@ -564,6 +579,41 @@ class Catalog:
         """Raise ``CatalogValidationError`` if ``(namespace, id)`` already exists."""
         if self._repository.get(namespace, id) is not None:
             raise CatalogValidationError([f"Entry ({namespace}, {id}) already exists"])
+
+    def _check_meta_singleton(self, entry: Entry) -> None:
+        """Reject a second ``kind="meta"`` entry in ``entry.namespace`` (ADR-008 §D1).
+
+        Short-circuits when ``entry.kind != "meta"`` — every existing pipeline
+        for ``team`` / ``agent`` / ``tool`` / ``model`` / ``prompt`` is byte-
+        identical. For ``kind="meta"``, queries the repository for any existing
+        meta entry in the same namespace and raises if one is found.
+
+        The helper is called from ``Catalog.create`` only. ``update`` cannot
+        introduce a duplicate (it requires the entry to already exist by
+        ``(namespace, id)``); ``clone`` of a meta entry is structurally guarded
+        by the duplicate-id check (a same-namespace clone produces a different
+        id, so the meta-singleton check is unreachable on the clone path —
+        cross-namespace clones land in a fresh namespace where the singleton
+        invariant is satisfied by construction); ``delete`` is unrelated.
+
+        Args:
+            entry: Candidate entry. Inspected for ``kind`` and ``namespace``;
+                no other fields read.
+
+        Raises:
+            CatalogValidationError: When ``entry.kind == "meta"`` and another
+                meta entry already exists in ``entry.namespace``.
+        """
+        if entry.kind != "meta":
+            return
+        existing_metas = self._repository.list(EntryQuery(namespace=entry.namespace, kind="meta"))
+        if existing_metas:
+            raise CatalogValidationError(
+                [
+                    f"Namespace '{entry.namespace}' already has a meta entry — "
+                    f"exactly one kind=meta entry is allowed per namespace"
+                ]
+            )
 
     def _check_bootstrap(self, namespace: str) -> None:
         """Ensure a team entry exists in ``namespace``; raise otherwise."""

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -566,7 +566,7 @@ def _make_kind_app(kind: EntryKind) -> typer.Typer:
     return sub
 
 
-_ENTRY_KINDS: tuple[EntryKind, ...] = ("team", "agent", "tool", "model", "prompt")
+_ENTRY_KINDS: tuple[EntryKind, ...] = ("team", "agent", "tool", "model", "prompt", "meta")
 # Register one sub-app per EntryKind. The literal order matches EntryKind.
 for _kind in _ENTRY_KINDS:
     app.add_typer(_make_kind_app(_kind), name=_kind)

--- a/src/akgentic/catalog/models/__init__.py
+++ b/src/akgentic/catalog/models/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from akgentic.catalog.models.entry import AllowlistedPath, Entry, EntryKind, NonEmptyStr
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.namespace_meta import NamespaceMeta
 from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 
 __all__ = [
@@ -20,5 +21,6 @@ __all__ = [
     "EntryKind",
     "EntryNotFoundError",
     "EntryQuery",
+    "NamespaceMeta",
     "NonEmptyStr",
 ]

--- a/src/akgentic/catalog/models/entry.py
+++ b/src/akgentic/catalog/models/entry.py
@@ -31,13 +31,16 @@ from ._types import NonEmptyStr
 __all__ = ["AllowlistedPath", "Entry", "EntryKind", "NonEmptyStr"]
 
 
-EntryKind = Literal["team", "agent", "tool", "model", "prompt"]
-"""The five entry kinds a v2 catalog stores.
+EntryKind = Literal["team", "agent", "tool", "model", "prompt", "meta"]
+"""The six entry kinds a v2 catalog stores.
 
 ``team``/``agent``/``tool`` mirror v1 semantics. ``model`` and ``prompt`` are
-new v2 kinds — model-type configs and reusable prompt templates promoted to
+v2 kinds — model-type configs and reusable prompt templates promoted to
 first-class entries so they can be referenced via the ref-sentinel mechanism
-(see ``akgentic.catalog.resolver``).
+(see ``akgentic.catalog.resolver``). ``meta`` is the per-namespace metadata
+kind introduced by ADR-008 §D1: a namespace-scoped, free-form metadata
+payload addressed by the convention id ``"_meta"`` and constrained to a
+singleton (zero or one ``kind=meta`` entry per namespace).
 """
 
 

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -1,0 +1,72 @@
+"""Namespace-metadata payload model — backs ``EntryKind="meta"`` entries.
+
+This module exposes a single Pydantic ``BaseModel`` (:class:`NamespaceMeta`)
+used as the payload-validation class for the ``kind="meta"`` catalog entry
+introduced by ADR-008 §D1. The model intentionally carries only three pinned
+fields — ``name``, ``description``, and a free-form ``properties`` map — so
+the namespace picker reads tenant-level metadata from a stable, purpose-built
+shape instead of leaking ``TeamCard``'s schema.
+
+Key exports:
+
+* :class:`NamespaceMeta` — the payload model. Plain ``BaseModel`` (not
+  ``SerializableBaseModel``) — catalog payload models are not actor messages.
+
+The model is reachable via the ``model_type=
+"akgentic.catalog.models.namespace_meta.NamespaceMeta"`` allowlist used by
+:func:`akgentic.catalog.resolver.load_model_type`. No resolver / allowlist
+change is required by this story; the existing ``akgentic.*`` prefix already
+covers it.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from ._types import NonEmptyStr
+
+__all__ = ["NamespaceMeta"]
+
+
+class NamespaceMeta(BaseModel):
+    """Payload model for the per-namespace metadata entry (``kind="meta"``).
+
+    Three pinned fields:
+
+    * ``name`` — required non-empty display name for the namespace; surfaced
+      by ``GET /catalog/namespaces`` to feed the picker.
+    * ``description`` — optional human-readable description; defaults to
+      empty string.
+    * ``properties`` — free-form ``str -> str`` annotations carrying
+      tenant-level metadata (display tier, owner team, custom labels) that
+      should NOT pollute :class:`~akgentic.team.models.TeamCard`.
+
+    Convention id is ``"_meta"``; the route fallback in
+    ``GET /catalog/namespaces`` reads ``payload["name"]`` /
+    ``description`` from the meta entry and falls back to the team entry
+    otherwise (so existing deployments continue to work without explicit
+    backfill — see ADR-008 §D1).
+
+    The model is plain ``BaseModel`` per architecture §D6 — catalog payload
+    models are validated configuration, not actor messages, so the
+    ``SerializableBaseModel`` machinery is intentionally NOT inherited.
+    """
+
+    name: NonEmptyStr = Field(
+        description=(
+            "Display name for the namespace; surfaced by the namespace picker "
+            "(GET /catalog/namespaces)."
+        ),
+    )
+    description: str = Field(
+        default="",
+        description=("Human-readable description; surfaced by the namespace picker; may be empty."),
+    )
+    properties: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Free-form string-to-string annotations carrying tenant-level "
+            "metadata (display tier, owner team, custom labels). Both keys "
+            "and values are strings."
+        ),
+    )

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -35,17 +35,19 @@ __all__ = ["dump_namespace", "load_namespace"]
 
 logger = logging.getLogger(__name__)
 
-# Kind emit order for bundle serialisation: team → agent → prompt → tool → model.
+# Kind emit order for bundle serialisation: team → meta → agent → prompt → tool → model.
 # Reading a bundle top-down then mirrors the consumption graph: teams consume
-# agents; agents consume prompts, tools, and models. ``EntryKind`` is a closed
-# ``Literal`` of exactly these five values, so indexing by ``e.kind`` is safe
-# without a fallback.
+# agents; agents consume prompts, tools, and models. ``meta`` follows ``team``
+# because both describe the namespace as a whole (ADR-008 §D1). ``EntryKind``
+# is a closed ``Literal`` of exactly these six values, so indexing by ``e.kind``
+# is safe without a fallback.
 _KIND_EMIT_ORDER: dict[str, int] = {
     "team": 0,
-    "agent": 1,
-    "prompt": 2,
-    "tool": 3,
-    "model": 4,
+    "meta": 1,
+    "agent": 2,
+    "prompt": 3,
+    "tool": 4,
+    "model": 5,
 }
 
 # Section-header comment strings for each kind, aligned to an 80-character visual
@@ -58,6 +60,7 @@ _KIND_EMIT_ORDER: dict[str, int] = {
 # `` ####`` trailer → 80 columns total.
 _KIND_HEADERS: dict[str, str] = {
     "team": "  #### ─── Teams ".ljust(75, "─") + " ####",
+    "meta": "  #### ─── Meta ".ljust(75, "─") + " ####",
     "agent": "  #### ─── Agents ".ljust(75, "─") + " ####",
     "prompt": "  #### ─── Prompts ".ljust(75, "─") + " ####",
     "tool": "  #### ─── Tools ".ljust(75, "─") + " ####",
@@ -97,10 +100,11 @@ def dump_namespace(entries: list[Entry]) -> str:
     intent-preserving.
 
     Entries are emitted in a stable order grouped by kind in consumption
-    order — ``team`` → ``agent`` → ``prompt`` → ``tool`` → ``model`` — and
-    within each kind sorted by ``id`` (lexicographic, unicode codepoint
-    order). Reading a bundle top-down then matches the dependency tree:
-    teams consume agents; agents consume prompts, tools, and models.
+    order — ``team`` → ``meta`` → ``agent`` → ``prompt`` → ``tool`` →
+    ``model`` — and within each kind sorted by ``id`` (lexicographic,
+    unicode codepoint order). Reading a bundle top-down then matches the
+    dependency tree: teams describe the namespace, meta annotates it; then
+    agents consume prompts, tools, and models.
 
     The rendered document includes a comment-header line per non-empty kind
     group and blank-line separation between entries; both are stripped by
@@ -211,11 +215,12 @@ def _check_uniform_namespace(entries: list[Entry]) -> list[str]:
 def _sort_entries_for_emit(entries: list[Entry]) -> list[Entry]:
     """Return a new list sorted by (kind emit order, id).
 
-    Kind order follows ``_KIND_EMIT_ORDER`` — ``team`` → ``agent`` →
-    ``prompt`` → ``tool`` → ``model`` — the consumption graph. Within each
-    kind, entries are sorted by ``id`` (lexicographic). ``EntryKind`` is a
-    closed ``Literal`` of exactly these five values, so direct indexing
-    (no ``.get`` fallback) is safe.
+    Kind order follows ``_KIND_EMIT_ORDER`` — ``team`` → ``meta`` →
+    ``agent`` → ``prompt`` → ``tool`` → ``model`` — the consumption graph
+    with the namespace-meta entry sandwiched between team and agents.
+    Within each kind, entries are sorted by ``id`` (lexicographic).
+    ``EntryKind`` is a closed ``Literal`` of exactly these six values, so
+    direct indexing (no ``.get`` fallback) is safe.
     """
     return sorted(entries, key=lambda e: (_KIND_EMIT_ORDER[e.kind], e.id))
 

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -117,6 +117,7 @@ def _global_checks(entries: list[Entry], namespace: str) -> list[str]:
     """Return every bundle-wide error for ``entries`` as a flat list."""
     errors: list[str] = []
     errors.extend(_check_team_count(entries, namespace))
+    errors.extend(_check_meta_singleton(entries, namespace))
     errors.extend(_check_uniform_namespace(entries, namespace))
     errors.extend(_check_uniform_user_id(entries))
     errors.extend(_check_no_duplicate_ids(entries, namespace))
@@ -133,6 +134,25 @@ def _check_team_count(entries: list[Entry], namespace: str) -> list[str]:
         ids = sorted(t.id for t in teams)
         return [f"namespace '{namespace}' has multiple team entries: {ids}"]
     return []
+
+
+def _check_meta_singleton(entries: list[Entry], namespace: str) -> list[str]:
+    """Allow zero or one ``kind=meta`` entry; flag two or more (ADR-008 §D1).
+
+    A namespace MAY have a single ``kind=meta`` entry (convention id
+    ``"_meta"``) carrying namespace-scoped metadata. Zero is valid (the route
+    fallback in ``GET /catalog/namespaces`` covers the missing-meta case). Two
+    or more produce a single error message naming every offending id so the
+    UI can render every duplicate at once.
+    """
+    metas = [e for e in entries if e.kind == "meta"]
+    if len(metas) <= 1:
+        return []
+    ids = sorted(m.id for m in metas)
+    return [
+        f"namespace '{namespace}' has multiple meta entries: {ids} — "
+        f"exactly one kind=meta entry is allowed per namespace"
+    ]
 
 
 def _check_uniform_namespace(entries: list[Entry], namespace: str) -> list[str]:

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -1094,9 +1094,7 @@ def test_router_namespace_validate_malformed_yaml_returns_422(
 class TestListNamespaces:
     """``GET /catalog/namespaces`` — Story 16.6 ACs 1-5."""
 
-    def test_empty_catalog_returns_empty_list(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_empty_catalog_returns_empty_list(self, api_client: tuple[TestClient, Catalog]) -> None:
         """AC #2 — empty catalog → HTTP 200, ``[]``."""
         client, _ = api_client
         response = client.get("/catalog/namespaces")
@@ -1194,9 +1192,7 @@ class TestListNamespaces:
         namespaces = [row["namespace"] for row in response.json()]
         assert "ns-no-team" not in namespaces
 
-    def test_includes_entries_across_user_ids(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_includes_entries_across_user_ids(self, api_client: tuple[TestClient, Catalog]) -> None:
         """AC #4 — the endpoint does not filter by ``user_id``.
 
         Community-tier (``user_id=None``) and multi-tenant
@@ -1212,9 +1208,7 @@ class TestListNamespaces:
         namespaces = [row["namespace"] for row in response.json()]
         assert namespaces == ["ns-alice", "ns-bob", "ns-public"]
 
-    def test_openapi_declares_response_model(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_openapi_declares_response_model(self, api_client: tuple[TestClient, Catalog]) -> None:
         """AC #5 — ``/openapi.json`` exposes the operation with the right shape."""
         client, _ = api_client
         response = client.get("/openapi.json")
@@ -1249,3 +1243,236 @@ def test_router_namespace_import_malformed_yaml_returns_422(
     )
     assert response.status_code == 422
     assert "failed to parse bundle YAML" in response.json()["detail"]
+
+
+# --- Story 17.2 — namespace-meta routes -----------------------------------
+
+
+_NAMESPACE_META_TYPE_ROUTER = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _seed_meta_entry(
+    catalog: Catalog,
+    namespace: str,
+    user_id: str | None = None,
+    name: str = "Tenant 42",
+    description: str = "primary tenant",
+) -> Entry:
+    """Seed a kind=meta entry directly through the catalog (Story 17.2)."""
+    return catalog.create(
+        Entry(
+            id="_meta",
+            kind="meta",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_NAMESPACE_META_TYPE_ROUTER,
+            description=description,
+            payload={"name": name, "description": description, "properties": {}},
+        )
+    )
+
+
+class TestListNamespacesMetaFallback:
+    """Story 17.2 AC6 — meta-then-team fallback for ``GET /catalog/namespaces``."""
+
+    def test_meta_entry_takes_precedence_over_team(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, catalog = api_client
+        team_payload = _team_payload()
+        team_payload["name"] = "Team Display Name"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-42",
+                model_type=_TEAM_TYPE,
+                description="team description",
+                payload=team_payload,
+            )
+        )
+        _seed_meta_entry(
+            catalog,
+            namespace="tenant-42",
+            user_id=None,
+            name="Friendly Display",
+            description="meta description",
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+        assert rows == [
+            {
+                "namespace": "tenant-42",
+                "name": "Friendly Display",
+                "description": "meta description",
+            }
+        ]
+
+    def test_team_fallback_when_no_meta_entry(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        team_payload = _team_payload()
+        team_payload["name"] = "Team Display Name"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-42",
+                model_type=_TEAM_TYPE,
+                description="team description",
+                payload=team_payload,
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+        assert rows == [
+            {
+                "namespace": "tenant-42",
+                "name": "Team Display Name",
+                "description": "team description",
+            }
+        ]
+
+    def test_meta_with_empty_name_falls_back_to_team_name(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """AC6 graceful-degradation path — meta exists but ``name`` is missing."""
+        client, catalog = api_client
+        team_payload = _team_payload()
+        team_payload["name"] = "Team Display"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-42",
+                model_type=_TEAM_TYPE,
+                description="team description",
+                payload=team_payload,
+            )
+        )
+        # Bypass NamespaceMeta validation — directly seed a meta entry whose
+        # payload lacks ``name`` (a state put cannot reject because the entry
+        # is structurally valid; only ``NamespaceMeta`` validation enforces
+        # name presence at the route layer).
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="tenant-42",
+                model_type=_NAMESPACE_META_TYPE_ROUTER,
+                description="meta description",
+                payload={"description": "meta description", "properties": {}},
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+        # name falls back to team's, description comes from meta.
+        assert rows == [
+            {
+                "namespace": "tenant-42",
+                "name": "Team Display",
+                "description": "meta description",
+            }
+        ]
+
+
+class TestGetNamespaceMeta:
+    """Story 17.2 AC7 — ``GET /catalog/namespace/{ns}/meta``."""
+
+    def test_returns_meta_entry_when_present(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        _seed_meta_entry(catalog, "tenant-42", name="Tenant 42")
+        response = client.get("/catalog/namespace/tenant-42/meta")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["id"] == "_meta"
+        assert body["kind"] == "meta"
+        assert body["namespace"] == "tenant-42"
+        assert body["payload"]["name"] == "Tenant 42"
+
+    def test_returns_404_when_absent(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        response = client.get("/catalog/namespace/tenant-42/meta")
+        assert response.status_code == 404
+        assert "errors" in response.json()
+
+
+class TestPutNamespaceMeta:
+    """Story 17.2 AC8 — ``PUT /catalog/namespace/{ns}/meta`` upsert."""
+
+    def test_create_branch_returns_201(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "primary", "properties": {"tier": "gold"}}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["kind"] == "meta"
+        assert entry["id"] == "_meta"
+        assert entry["namespace"] == "tenant-42"
+        assert entry["payload"]["name"] == "Tenant 42"
+        assert entry["payload"]["properties"] == {"tier": "gold"}
+        assert entry["model_type"] == _NAMESPACE_META_TYPE_ROUTER
+
+    def test_update_branch_returns_200(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        _seed_meta_entry(catalog, "tenant-42", name="Old Name")
+        body = {"name": "New Name", "description": "updated", "properties": {}}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 200
+        entry = response.json()
+        assert entry["payload"]["name"] == "New Name"
+        assert entry["description"] == "updated"
+
+    def test_body_kind_id_namespace_model_type_silently_ignored(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """The handler substitutes ``kind`` / ``id`` / ``namespace`` / ``model_type``
+        regardless of body content. ``NamespaceMeta`` does not declare those
+        fields, so a JSON payload that carries them is simply not parsed.
+        """
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {
+            "name": "Tenant 42",
+            "description": "",
+            "properties": {},
+            # These should be ignored by the handler:
+            "kind": "team",
+            "id": "evil-id",
+            "namespace": "evil-namespace",
+            "model_type": "akgentic.evil",
+        }
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["kind"] == "meta"
+        assert entry["id"] == "_meta"
+        assert entry["namespace"] == "tenant-42"
+        assert entry["model_type"] == _NAMESPACE_META_TYPE_ROUTER
+
+    def test_malformed_body_missing_name_returns_422(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """Malformed body (missing required ``name``) surfaces as 422 from
+        Pydantic ``ValidationError`` raised inside ``NamespaceMeta.model_validate``.
+        """
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"description": "missing name", "properties": {}}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 422
+
+    def test_no_team_entry_returns_409(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """When the namespace has no team entry, the handler surfaces 409
+        with the bootstrap-error message.
+        """
+        client, _ = api_client
+        body = {"name": "ghost", "description": "", "properties": {}}
+        response = client.put("/catalog/namespace/ghost-ns/meta", json=body)
+        assert response.status_code == 409

--- a/tests/v2/test_api_router_kind_crud_gating.py
+++ b/tests/v2/test_api_router_kind_crud_gating.py
@@ -464,3 +464,32 @@ class TestStaticRoutesWinDispatchOrder:
         response = client.get("/catalog/namespaces")
         assert response.status_code == 200
         assert isinstance(response.json(), list)
+
+
+class TestNamespaceMetaRoutesAlwaysOn:
+    """Story 17.2 — the two ``/namespace/{ns}/meta`` routes are always-on.
+
+    They MUST be registered when ``expose_generic_kind_crud=False`` (the
+    community-tier default), like every other static / namespace-scoped route.
+    """
+
+    def test_get_namespace_meta_route_registered_when_kind_crud_hidden(
+        self, api_client_kind_crud_hidden: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client_kind_crud_hidden
+        # Without seeding, the route returns 404 (entry not found), NOT
+        # 404 from "route not registered" — and certainly NOT 405. Assert
+        # that the OpenAPI schema declares the path.
+        response = client.get("/openapi.json")
+        spec = response.json()
+        assert "/catalog/namespace/{namespace}/meta" in spec["paths"]
+        assert "get" in spec["paths"]["/catalog/namespace/{namespace}/meta"]
+
+    def test_put_namespace_meta_route_registered_when_kind_crud_hidden(
+        self, api_client_kind_crud_hidden: tuple[TestClient, Catalog]
+    ) -> None:
+        client, _ = api_client_kind_crud_hidden
+        response = client.get("/openapi.json")
+        spec = response.json()
+        assert "/catalog/namespace/{namespace}/meta" in spec["paths"]
+        assert "put" in spec["paths"]["/catalog/namespace/{namespace}/meta"]

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -765,3 +765,85 @@ class TestUpdateLineageGuard:
         # The rejection path performed zero put calls — the existing entry
         # is still the seeded shape.
         assert counting.count("put") == 0
+
+
+# --- AC5 / Story 17.2 — meta singleton on create ---------------------------
+
+
+_NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _meta_entry(namespace: str, user_id: str | None, entry_id: str = "_meta") -> Entry:
+    """Build a valid ``kind="meta"`` ``Entry`` for the singleton tests."""
+    return Entry(
+        id=entry_id,
+        kind="meta",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_NAMESPACE_META_TYPE,
+        description="namespace metadata",
+        payload={"name": namespace, "description": "", "properties": {}},
+    )
+
+
+class TestMetaSingletonOnCreate:
+    """Story 17.2 AC5 — at most one ``kind="meta"`` entry per namespace."""
+
+    def test_first_meta_create_succeeds(self, catalog_factory: CatalogFactory) -> None:
+        """First meta entry in a namespace persists like any other entry."""
+        catalog, _ = catalog_factory()
+        team = _seed_team(catalog, namespace="tenant-42", user_id="alice")
+        meta = _meta_entry(team.namespace, user_id="alice")
+        stored = catalog.create(meta)
+        assert stored.kind == "meta"
+        assert stored.id == "_meta"
+        assert stored.namespace == "tenant-42"
+        # Round-trip: list_by_namespace returns it.
+        rows = catalog.list_by_namespace("tenant-42")
+        assert any(e.kind == "meta" and e.id == "_meta" for e in rows)
+
+    def test_second_meta_create_rejected(self, catalog_factory: CatalogFactory) -> None:
+        """Second meta entry (different id, same namespace) raises with pinned msg."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="tenant-42", user_id="alice")
+        catalog.create(_meta_entry("tenant-42", user_id="alice"))
+        # A second meta entry with a different id must still be rejected.
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.create(_meta_entry("tenant-42", user_id="alice", entry_id="meta-extra"))
+        assert "already has a meta entry" in exc_info.value.errors[0]
+        # Namespace is interpolated in the message.
+        assert "'tenant-42'" in exc_info.value.errors[0]
+
+    def test_duplicate_id_check_wins_over_meta_singleton(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """When the second meta create collides on (namespace, id), duplicate-id wins."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="tenant-42", user_id="alice")
+        catalog.create(_meta_entry("tenant-42", user_id="alice"))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.create(_meta_entry("tenant-42", user_id="alice"))  # same id
+        # The duplicate-id check is more specific and runs first.
+        msg = exc_info.value.errors[0]
+        assert "already exists" in msg
+
+    def test_meta_singleton_does_not_block_other_namespaces(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """A meta entry in namespace A does not prevent meta in namespace B."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, namespace="tenant-a", user_id="alice")
+        _seed_team(catalog, namespace="tenant-b", user_id="bob")
+        catalog.create(_meta_entry("tenant-a", user_id="alice"))
+        # Different namespace — should succeed.
+        stored = catalog.create(_meta_entry("tenant-b", user_id="bob"))
+        assert stored.namespace == "tenant-b"
+
+    def test_meta_singleton_does_not_block_other_kinds(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """The singleton check is skipped for kind != meta — non-meta paths unaffected."""
+        catalog, _ = catalog_factory()
+        team = _seed_team(catalog, namespace="tenant-42", user_id="alice")
+        # Should succeed — kind=team is not the meta path.
+        assert team.kind == "team"

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -419,3 +419,88 @@ class TestImportNamespaceYaml:
             "__ref__": "leaf",
             "__type__": leaf_type,
         }
+
+
+# --- Story 17.2 — bundle import meta singleton ----------------------------
+
+
+_NAMESPACE_META_TYPE_BUNDLE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _meta_entry_for_bundle(
+    namespace: str,
+    user_id: str | None,
+    entry_id: str = "_meta",
+    name: str = "primary",
+) -> Entry:
+    return Entry(
+        id=entry_id,
+        kind="meta",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_NAMESPACE_META_TYPE_BUNDLE,
+        description=f"meta {entry_id}",
+        payload={"name": name, "description": "", "properties": {}},
+    )
+
+
+class TestBundleImportMetaSingleton:
+    """Story 17.2 AC4 — bundle import rejects two ``kind="meta"`` entries."""
+
+    def test_bundle_with_two_meta_entries_rejected_no_writes(
+        self,
+        catalog_factory: CatalogFactory,
+    ) -> None:
+        catalog, repo = catalog_factory()
+        # Pre-seed the namespace so we can verify state is unchanged on rollback.
+        team = _seed_team(catalog, namespace="tenant-42", user_id="alice")
+        before = sorted(e.id for e in repo.list_by_namespace("tenant-42"))
+
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-42",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            _meta_entry_for_bundle("tenant-42", user_id="alice", entry_id="_meta", name="A"),
+            _meta_entry_for_bundle(
+                "tenant-42",
+                user_id="alice",
+                entry_id="meta-extra",
+                name="B",
+            ),
+        ]
+        yaml_text = dump_namespace(bundle)
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.import_namespace_yaml(yaml_text)
+        assert any("has multiple meta entries" in m for m in exc_info.value.errors)
+        # Atomic-failure contract: the namespace state is byte-identical to
+        # the pre-import state.
+        after = sorted(e.id for e in repo.list_by_namespace("tenant-42"))
+        assert after == before
+        assert team.id == "team"
+
+    def test_bundle_with_one_meta_entry_imports_cleanly(
+        self,
+        catalog_factory: CatalogFactory,
+    ) -> None:
+        catalog, repo = catalog_factory()
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-42",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            _meta_entry_for_bundle("tenant-42", user_id="alice", name="primary"),
+        ]
+        yaml_text = dump_namespace(bundle)
+        catalog.import_namespace_yaml(yaml_text)
+        ids = {e.id for e in repo.list_by_namespace("tenant-42")}
+        assert ids == {"team", "_meta"}

--- a/tests/v2/test_cli_foundation.py
+++ b/tests/v2/test_cli_foundation.py
@@ -696,3 +696,94 @@ class TestIoDiscipline:
         assert result.exit_code == 0
         assert "deleted" in result.stderr
         assert "deleted" not in result.stdout
+
+
+# --------------------------------------------------------------------------- #
+# `meta` sub-app — Story 17.2
+# --------------------------------------------------------------------------- #
+
+
+_NAMESPACE_META_TYPE_CLI = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _meta_yaml_file(tmp_path: Path, namespace: str, name: str = "Tenant 42") -> Path:
+    """Write a single-entry YAML file describing a kind=meta entry."""
+    file = tmp_path / f"{namespace}-meta.yaml"
+    file.write_text(
+        yaml.safe_dump(
+            {
+                "id": "_meta",
+                "kind": "meta",
+                "namespace": namespace,
+                "user_id": "alice",
+                "model_type": _NAMESPACE_META_TYPE_CLI,
+                "description": "namespace metadata",
+                "payload": {"name": name, "description": "", "properties": {}},
+            }
+        )
+    )
+    return file
+
+
+class TestMetaSubApp:
+    """Story 17.2 AC11 — the ``meta`` sub-app is registered with standard verbs."""
+
+    def test_meta_subapp_registered(self, runner: CliRunner, catalog_root: Path) -> None:
+        """Top-level ``--help`` lists ``meta`` as one of the registered sub-apps."""
+        result = runner.invoke(cli_main.app, _base_args(catalog_root) + ["--help"])
+        assert result.exit_code == 0
+        # The sub-apps are listed in the help text. ``meta`` must be among them.
+        assert "meta" in result.stdout
+
+    def test_meta_create_then_get(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        """``meta create`` succeeds and ``meta get`` returns it."""
+        meta_file = _meta_yaml_file(tmp_path, "ns-a", name="Display A")
+        result = runner.invoke(
+            cli_main.app,
+            _base_args(catalog_root) + ["meta", "create", str(meta_file)],
+        )
+        assert result.exit_code == 0
+        # Verify get returns the stored entry.
+        result_get = runner.invoke(
+            cli_main.app,
+            _base_args(catalog_root)
+            + ["--format", "json", "meta", "get", "_meta", "--namespace", "ns-a"],
+        )
+        assert result_get.exit_code == 0
+        data = json.loads(result_get.stdout)
+        assert data["id"] == "_meta"
+        assert data["kind"] == "meta"
+
+    def test_meta_create_twice_rejected(
+        self, runner: CliRunner, catalog_root: Path, tmp_path: Path
+    ) -> None:
+        """A second ``meta create`` for the same namespace exits 1 with pinned msg."""
+        first_file = _meta_yaml_file(tmp_path, "ns-a", name="First")
+        first_result = runner.invoke(
+            cli_main.app,
+            _base_args(catalog_root) + ["meta", "create", str(first_file)],
+        )
+        assert first_result.exit_code == 0
+        # Second meta entry with a different id but same namespace should fail.
+        second_file = tmp_path / "ns-a-meta-extra.yaml"
+        second_file.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "meta-extra",
+                    "kind": "meta",
+                    "namespace": "ns-a",
+                    "user_id": "alice",
+                    "model_type": _NAMESPACE_META_TYPE_CLI,
+                    "description": "second meta",
+                    "payload": {"name": "Second", "description": "", "properties": {}},
+                }
+            )
+        )
+        second_result = runner.invoke(
+            cli_main.app,
+            _base_args(catalog_root) + ["meta", "create", str(second_file)],
+        )
+        assert second_result.exit_code == 1
+        assert "already has a meta entry" in second_result.stderr

--- a/tests/v2/test_entry.py
+++ b/tests/v2/test_entry.py
@@ -31,7 +31,28 @@ class TestEntryImport:
         # ``Literal`` aliases expose their members via typing.get_args
         from typing import get_args
 
-        assert set(get_args(EntryKind)) == {"team", "agent", "tool", "model", "prompt"}
+        assert set(get_args(EntryKind)) == {
+            "team",
+            "agent",
+            "tool",
+            "model",
+            "prompt",
+            "meta",
+        }
+
+    def test_entry_kind_accepts_meta_literal(self) -> None:
+        """AC2 — Story 17.2: Entry construction accepts ``kind="meta"``."""
+        entry = Entry.model_validate(
+            {
+                "id": "_meta",
+                "kind": "meta",
+                "namespace": "tenant-42",
+                "model_type": "akgentic.catalog.models.namespace_meta.NamespaceMeta",
+                "payload": {"name": "Tenant 42"},
+            }
+        )
+        assert entry.kind == "meta"
+        assert entry.id == "_meta"
 
 
 class TestEntryFields:

--- a/tests/v2/test_mongo_entry_repo.py
+++ b/tests/v2/test_mongo_entry_repo.py
@@ -779,3 +779,28 @@ class TestMongoCatalogConfigUnifiedCollection:
             catalog_entries_collection="custom_entries",
         )
         assert config.catalog_entries_collection == "custom_entries"
+
+
+class TestMetaEntryRoundTrip:
+    """Story 17.2 — Mongo repo round-trips a ``kind="meta"`` entry."""
+
+    def test_meta_entry_round_trips(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="tenant-42",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="namespace meta",
+            payload={"name": "Tenant 42", "description": "primary tenant", "properties": {}},
+        )
+        repo.put(meta)
+        # All three readers return the meta entry.
+        assert repo.get("tenant-42", "_meta") == meta
+        rows = repo.list_by_namespace("tenant-42")
+        assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
+        assert repo.get_by_kind("tenant-42", "meta") == meta

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -383,7 +383,7 @@ class TestSectionHeadersAndSpacing:
         for kind in ("team", "agent"):
             header = _KIND_HEADERS[kind]
             header_pos = text.index(header)
-            after_header = text[header_pos + len(header):]
+            after_header = text[header_pos + len(header) :]
             # Exactly one newline ends the header line; no empty line before the first entry key.
             assert after_header.startswith("\n  "), (
                 f"Expected header for {kind!r} to be followed immediately by an entry key line, "
@@ -440,3 +440,58 @@ class TestSectionHeadersAndSpacing:
         ]
         doc = yaml.safe_load(text)
         assert doc["user_id"] is None
+
+
+# --- Story 17.2 — meta entry emit order and round-trip ---------------------
+
+
+_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _meta(
+    namespace: str = "ns-1",
+    user_id: str | None = "alice",
+    entry_id: str = "_meta",
+) -> Entry:
+    return Entry(
+        id=entry_id,
+        kind="meta",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_META_TYPE,
+        description="namespace meta",
+        payload={"name": "Tenant", "description": "primary tenant", "properties": {}},
+    )
+
+
+class TestMetaEmitOrderAndRoundTrip:
+    """Story 17.2 AC9 / AC10 — meta is emitted between team and agent."""
+
+    def test_meta_section_header_present_between_team_and_agent(self) -> None:
+        """When a bundle carries team + meta + agent, the Meta header sits between them."""
+        entries = [_team(), _meta(), _agent("a1")]
+        text = dump_namespace(entries)
+        team_header = _KIND_HEADERS["team"]
+        meta_header = _KIND_HEADERS["meta"]
+        agent_header = _KIND_HEADERS["agent"]
+        team_pos = text.index(team_header)
+        meta_pos = text.index(meta_header)
+        agent_pos = text.index(agent_header)
+        assert team_pos < meta_pos < agent_pos
+
+    def test_meta_entry_round_trips_through_dump_load(self) -> None:
+        """``load_namespace(dump_namespace([team, meta, agent]))`` returns equal entries."""
+        entries = [_team(), _meta(), _agent("a1")]
+        text = dump_namespace(entries)
+        recovered = load_namespace(text)
+        sort_key = lambda e: (e.kind, e.id)  # noqa: E731
+        assert [e.model_dump() for e in sorted(recovered, key=sort_key)] == [
+            e.model_dump() for e in sorted(entries, key=sort_key)
+        ]
+
+    def test_meta_emit_order_index_one(self) -> None:
+        """Bundle with team + meta + agent emits in (team, meta, agent) order."""
+        text = dump_namespace([_agent("a1"), _meta(), _team()])
+        doc = yaml.safe_load(text)
+        # Outer keys are emitted in (kind emit order, id) — team @ 0, meta @ 1, agent @ 2.
+        assert list(doc["entries"].keys()) == ["team", "_meta", "a1"]

--- a/tests/v2/test_validation.py
+++ b/tests/v2/test_validation.py
@@ -261,6 +261,63 @@ class TestValidateEntriesGlobalErrors:
         assert any("no team entry" in m for m in report.global_errors)
         assert not any("!= team user_id" in m for m in report.global_errors)
 
+    # --- AC3 / Story 17.2 — meta singleton invariant in _global_checks ---
+
+    def test_zero_meta_entries_with_team_is_ok(self) -> None:
+        """AC3: zero kind=meta entries does NOT add a global error."""
+        repo = SpyRepository()
+        team = _seed_team()
+        report = validate_entries([team], repo)
+        assert not any("multiple meta entries" in m for m in report.global_errors)
+        # And the report is overall ok.
+        assert report.ok is True
+
+    def test_one_meta_entry_with_team_is_ok(self) -> None:
+        """AC3: exactly one kind=meta entry does NOT add a global error."""
+        repo = SpyRepository()
+        team = _seed_team()
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            payload={"name": "ns-1"},
+        )
+        report = validate_entries([team, meta], repo)
+        assert not any("multiple meta entries" in m for m in report.global_errors)
+        assert report.ok is True
+
+    def test_two_meta_entries_flagged(self) -> None:
+        """AC3: two kind=meta entries surface the multi-meta error."""
+        repo = SpyRepository()
+        team = _seed_team()
+        meta_a = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            payload={"name": "primary"},
+        )
+        meta_b = make_entry(
+            id="meta-extra",
+            kind="meta",
+            namespace="ns-1",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            payload={"name": "extra"},
+        )
+        report = validate_entries([team, meta_a, meta_b], repo)
+        multi = [m for m in report.global_errors if "has multiple meta entries" in m]
+        assert len(multi) == 1
+        # Sorted ids must appear in the message.
+        assert "'_meta'" in multi[0]
+        assert "'meta-extra'" in multi[0]
+        # Namespace is interpolated into the message.
+        assert "namespace 'ns-1'" in multi[0]
+        assert report.ok is False
+
 
 # --- validate_entries per-entry-error coverage (AC31) -----------------------
 

--- a/tests/v2/test_yaml_entry_repo.py
+++ b/tests/v2/test_yaml_entry_repo.py
@@ -654,3 +654,28 @@ class TestReadConsistency:
         repo.put(make_entry(namespace="ns", id="e1", kind="tool"))
         repo.reload("ns")
         assert repo.get("ns", "e1") is not None
+
+
+class TestMetaEntryRoundTrip:
+    """Story 17.2 — YAML repo round-trips a ``kind="meta"`` entry."""
+
+    def test_meta_entry_round_trips(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="tenant-42",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="namespace meta",
+            payload={"name": "Tenant 42", "description": "primary tenant", "properties": {}},
+        )
+        repo.put(meta)
+        # File lands under root/{namespace}/meta/{id}.yaml.
+        path = tmp_path / "tenant-42" / "meta" / "_meta.yaml"
+        assert path.exists()
+        # All three readers return it.
+        assert repo.get("tenant-42", "_meta") == meta
+        rows = repo.list_by_namespace("tenant-42")
+        assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
+        assert repo.get_by_kind("tenant-42", "meta") == meta


### PR DESCRIPTION
## Summary

Implements Story 17.2 from Epic 17 (ADR-008 §D1) — namespace metadata entry kind, the `NamespaceMeta` payload model, the meta-singleton invariant, and the namespace-route meta-then-team fallback.

- New payload model `NamespaceMeta` (three pinned fields: `name`, `description`, `properties`); plain `BaseModel` (catalog payload, not actor message).
- `EntryKind` literal widened to `Literal["team", "agent", "tool", "model", "prompt", "meta"]`.
- Singleton invariant enforced in three places with grep-stable messages: `validation._global_checks._check_meta_singleton`, `Catalog._validate_bundle_invariants` (bundle import), and `Catalog._check_meta_singleton` (write-time, between duplicate and bootstrap checks).
- `GET /catalog/namespaces` reads `_meta` per team and falls back to team values when meta is absent or its `name` is missing/empty (graceful degradation).
- New always-on routes `GET/PUT /catalog/namespace/{namespace}/meta`; `PUT` upserts a `NamespaceMeta` body (201 create / 200 update) and substitutes `id` / `kind` / `namespace` / `model_type` / `user_id` server-side.
- Bundle emit order: `team → meta → agent → prompt → tool → model`; new `Meta` section header (80-col aligned).
- CLI: `meta` sub-app registered automatically via `_ENTRY_KINDS` extension.
- Architecture shards 03 / 05 / 06 / 07 updated to describe the kind, the singleton invariant, and the namespace-route fallback.

## Test plan

- [x] `pytest packages/akgentic-catalog/tests/` — 812 passed, 23 skipped, coverage 92%.
- [x] `ruff check` clean on modified source and tests.
- [x] `mypy --strict packages/akgentic-catalog/src/` clean.
- [x] CI green on `feat/160-namespace-meta-entry` (run 25556161150).

Closes #160
