### PR TITLE
feat(akgentic-catalog): cross-namespace references — resolver allowlist + delete guard

### DIFF
--- a/src/akgentic/catalog/__init__.py
+++ b/src/akgentic/catalog/__init__.py
@@ -22,6 +22,7 @@ from akgentic.catalog.models.queries import CloneRequest, EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.repositories.yaml import YamlEntryRepository
 from akgentic.catalog.resolver import (
+    NAMESPACE_KEY,
     REF_KEY,
     TYPE_KEY,
     load_model_type,
@@ -33,6 +34,7 @@ from akgentic.catalog.resolver import (
 )
 
 __all__ = [
+    "NAMESPACE_KEY",
     "REF_KEY",
     "TYPE_KEY",
     "Catalog",

--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -39,6 +39,7 @@ def create_app(
     mongo_config: MongoCatalogConfig | None = None,
     postgres_config: PostgresCatalogConfig | None = None,
     router_settings: CatalogRouterSettings | None = None,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> FastAPI:
     """Create a FastAPI app serving the unified ``/catalog`` router.
 
@@ -60,6 +61,11 @@ def create_app(
             (Story 16.7). Defaults to
             :meth:`CatalogRouterSettings.from_env` — reads
             ``AKGENTIC_CATALOG_EXPOSE_GENERIC_KIND_CRUD``.
+        cross_namespace_refs_allowed: Frozenset of namespaces that may be
+            referenced cross-namespace (ADR-008 §D2). Forwarded to
+            :class:`Catalog` verbatim. Default ``frozenset()`` keeps
+            pre-existing call sites byte-identical post-upgrade — cross-ns
+            is configured at app-factory time, not over the wire.
 
     Returns:
         A configured ``FastAPI`` app with the catalog router mounted and
@@ -75,7 +81,10 @@ def create_app(
         mongo_config=mongo_config,
         postgres_config=postgres_config,
     )
-    catalog = Catalog(repository=repo)
+    catalog = Catalog(
+        repository=repo,
+        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+    )
     set_catalog(catalog)
 
     app = FastAPI(title="Akgentic Catalog")

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -43,7 +43,12 @@ from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
 from akgentic.catalog.models.queries import EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
-from akgentic.catalog.resolver import REF_KEY, prepare_for_write, validate_delete
+from akgentic.catalog.resolver import (
+    NAMESPACE_KEY,
+    REF_KEY,
+    prepare_for_write,
+    validate_delete,
+)
 from akgentic.catalog.resolver import resolve as _resolve
 from akgentic.catalog.serialization import dump_namespace, load_namespace
 from akgentic.catalog.validation import NamespaceValidationReport, validate_entries
@@ -85,13 +90,28 @@ class Catalog:
         '3fa85f64-5717-4562-b3fc-2c963f66afa6'
     """
 
-    def __init__(self, repository: EntryRepository) -> None:
+    def __init__(
+        self,
+        repository: EntryRepository,
+        *,
+        cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    ) -> None:
         """Store ``repository`` on ``self._repository``; no I/O.
 
         Args:
             repository: Any concrete ``EntryRepository`` implementation.
+            cross_namespace_refs_allowed: Frozenset of namespaces that may be
+                referenced cross-namespace from any other namespace served by
+                this ``Catalog`` (ADR-008 §D2). Default ``frozenset()`` means
+                no cross-ns refs are permitted — same-namespace refs work
+                exactly as before. Operators opt in by passing a non-empty
+                frozenset (e.g. ``frozenset({"global", "default"})``).
+                Cross-ns refs are also gated on the target's ``user_id is
+                None`` privacy constraint, so only globally-scoped entries
+                in allowlisted namespaces can be referenced.
         """
         self._repository: EntryRepository = repository
+        self._cross_namespace_refs_allowed: frozenset[str] = cross_namespace_refs_allowed
 
     # --- Read -----------------------------------------------------------------
 
@@ -170,7 +190,11 @@ class Catalog:
             self._check_bootstrap(entry.namespace)
             self._check_ownership(entry)
 
-        prepared = prepare_for_write(entry, self._repository)
+        prepared = prepare_for_write(
+            entry,
+            self._repository,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
         self._repository.put(prepared)
         return prepared
 
@@ -211,7 +235,11 @@ class Catalog:
         existing = self._repository.get(entry.namespace, entry.id)
         if existing is None:
             raise EntryNotFoundError(f"Entry ({entry.namespace}, {entry.id}) not found")
-        prepared = prepare_for_write(entry, self._repository)
+        prepared = prepare_for_write(
+            entry,
+            self._repository,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
         self._check_lineage_unchanged_or_reset(existing, prepared)
         if prepared.kind != "team":
             self._check_ownership(prepared)
@@ -236,9 +264,41 @@ class Catalog:
         if self._repository.get(namespace, id) is None:
             raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
         errors = validate_delete(namespace, id, self._repository)
+        # ADR-008 §D2 — when the deleted entry is in an allowlisted namespace
+        # (i.e. it is a possible cross-ns ref target), widen the guard to a
+        # global-scope check so cross-tenant referrers also block the delete.
+        # Scope: every namespace currently present in the repository (cross-ns
+        # refs may originate from any tenant the operator has provisioned;
+        # the configured allowlist enumerates only the *referenceable* target
+        # namespaces, not the source namespaces — see ADR-008 §D2).
+        if self._cross_namespace_refs_allowed and namespace in self._cross_namespace_refs_allowed:
+            global_referrers = self._repository.find_references_global(
+                namespace, id, self._global_scope_for_delete()
+            )
+            errors = errors + [
+                f"Entry '{r.id}' (kind={r.kind}) in namespace '{r.namespace}' references '{id}'"
+                for r in global_referrers
+            ]
         if errors:
             raise CatalogValidationError(errors)
         self._repository.delete(namespace, id)
+
+    def _global_scope_for_delete(self) -> frozenset[str]:
+        """Return every namespace the global delete-guard should scan.
+
+        Enumerates all namespaces present in the repository. Cross-ns refs
+        may originate from any tenant the operator has provisioned; the
+        configured ``cross_namespace_refs_allowed`` lists only the
+        *referenceable* target namespaces, not the source namespaces, so
+        the delete guard cannot use it as the scan scope.
+        """
+        # Pulls every entry once to enumerate namespaces. Backends could
+        # offer a cheaper "list_namespaces" primitive but the protocol does
+        # not expose one today; the cost is acceptable because delete is a
+        # rare admin operation and the scan is the same shape as the
+        # existing ``EntryQuery`` listing.
+        all_entries = self._repository.list(EntryQuery())
+        return frozenset(e.namespace for e in all_entries)
 
     # --- Clone ----------------------------------------------------------------
 
@@ -314,7 +374,11 @@ class Catalog:
 
     def resolve(self, entry: Entry) -> BaseModel:
         """Hydrate ``entry`` into a runtime Pydantic instance — delegates to resolver."""
-        return _resolve(entry, self._repository)
+        return _resolve(
+            entry,
+            self._repository,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
 
     def resolve_by_id(self, namespace: str, id: str) -> BaseModel:
         """Convenience: ``self.resolve(self.get(namespace, id))``."""
@@ -346,8 +410,17 @@ class Catalog:
         if not team_entries:
             raise CatalogValidationError([f"Namespace '{namespace}' has no team entry"])
         team_entry = team_entries[0]
-        in_memory = _InMemoryEntryRepository(entries)
-        result = _resolve(team_entry, in_memory)
+        # Fall back to the live repository for cross-ns ref lookups so a team
+        # payload that references entries in an allowlisted namespace (e.g.
+        # ``global.shared-prompt``) still resolves while preserving the
+        # single-query invariant for the local namespace.
+        fallback = self._repository if self._cross_namespace_refs_allowed else None
+        in_memory = _InMemoryEntryRepository(entries, fallback=fallback)
+        result = _resolve(
+            team_entry,
+            in_memory,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
         if not isinstance(result, TeamCard):
             raise CatalogValidationError(
                 [f"Team entry's model_type resolved to {type(result).__name__}, expected TeamCard"]
@@ -418,7 +491,14 @@ class Catalog:
         # the bundle into an overlay repository so `populate_refs` can find
         # bundle-internal targets alongside current namespace state.
         overlay = _BundleOverlayRepository(self._repository, parsed)
-        prepared = [prepare_for_write(e, overlay) for e in parsed]
+        prepared = [
+            prepare_for_write(
+                e,
+                overlay,
+                cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            )
+            for e in parsed
+        ]
         self._validate_bundle_invariants(prepared)
         self._check_bundle_refs(prepared)
         namespace = prepared[0].namespace
@@ -437,9 +517,18 @@ class Catalog:
         lists. The report's ``namespace`` is patched back to the caller's
         ``namespace`` when ``validate_entries`` saw zero entries, so the caller
         sees the requested label in the report even on an empty namespace.
+
+        The cross-namespace allowlist (Catalog ctor argument) is threaded
+        through to ``validate_entries`` so transient validation surfaces
+        cross-ns errors (allowlist violations, ownership violations) per
+        entry.
         """
         entries = self._repository.list_by_namespace(namespace)
-        report = validate_entries(entries, self._repository)
+        report = validate_entries(
+            entries,
+            self._repository,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
         if report.namespace is None:
             report = report.model_copy(update={"namespace": namespace})
         return report
@@ -474,7 +563,11 @@ class Catalog:
                 global_errors=list(exc.errors),
                 entry_issues=[],
             )
-        return validate_entries(entries, self._repository)
+        return validate_entries(
+            entries,
+            self._repository,
+            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+        )
 
     # --- Private helpers ------------------------------------------------------
 
@@ -778,17 +871,39 @@ class Catalog:
             suffix += 1
 
 
+def _is_cross_ns_marker(node: dict[str, Any]) -> bool:
+    """Return ``True`` when ``node`` is a ref marker carrying a cross-ns hint.
+
+    A cross-ns marker carries either an explicit ``__namespace__`` key OR a
+    shorthand ``<ns>.<id>`` form in ``__ref__`` (a string value containing a
+    dot). Same-namespace markers (no ``__namespace__``, no dot in
+    ``__ref__``) return ``False`` and remain subject to local-ref rewrite
+    and bundle dangling-ref collection (ADR-008 §D2).
+    """
+    if NAMESPACE_KEY in node:
+        return True
+    raw_ref = node.get(REF_KEY)
+    return isinstance(raw_ref, str) and "." in raw_ref
+
+
 def _iter_ref_targets(node: Any) -> list[str]:
-    """Return every ``__ref__`` target id reachable inside ``node``.
+    """Return every same-namespace ``__ref__`` target id reachable inside ``node``.
 
     Walks dicts and lists recursively. A dict carrying a ``REF_KEY`` entry
-    contributes its target id and does NOT recurse into the same dict's other
-    keys (``__type__`` is a sibling hint, not a nested ref). Non-ref dicts
-    and lists recurse structurally; leaves contribute nothing.
+    contributes its target id ONLY when the marker is same-namespace
+    (cross-ns markers — those with an ``__namespace__`` key OR a
+    ``<ns>.<id>`` shorthand in ``__ref__`` — are external by design and
+    therefore excluded from the bundle dangling-ref check). The walker
+    does NOT recurse into a ref-marker dict's other keys regardless of
+    same-/cross-ns shape (``__type__`` and sibling-override values are
+    handled at the resolver layer, not here). Non-ref dicts and lists
+    recurse structurally; leaves contribute nothing.
     """
     results: list[str] = []
     if isinstance(node, dict):
         if REF_KEY in node:
+            if _is_cross_ns_marker(node):
+                return results
             target = node[REF_KEY]
             if isinstance(target, str):
                 results.append(target)
@@ -803,12 +918,16 @@ def _iter_ref_targets(node: Any) -> list[str]:
 
 
 def _rewrite_refs(node: Any, clone_target: Any) -> Any:
-    """Recursively copy ``node``, replacing ref targets via ``clone_target``.
+    """Recursively copy ``node``, replacing local ref targets via ``clone_target``.
 
     Dicts carrying a ``REF_KEY`` entry have their target id replaced by
-    ``clone_target(target_id)`` — the callback is typically a recursive clone
-    invocation that also clones the target entry. ``TYPE_KEY`` (if present) is
-    preserved verbatim. Non-ref dicts and lists recurse structurally; leaves
+    ``clone_target(target_id)`` — the callback is typically a recursive
+    clone invocation that also clones the target entry. ``TYPE_KEY`` (if
+    present) is preserved verbatim. Cross-ns markers (those with an
+    ``__namespace__`` key OR a ``<ns>.<id>`` shorthand in ``__ref__``) are
+    preserved **verbatim** — clone never rewrites cross-ns refs because the
+    target lives in a separate namespace owned by a different operator
+    (ADR-008 §D2). Non-ref dicts and lists recurse structurally; leaves
     pass through unchanged.
 
     Args:
@@ -817,11 +936,16 @@ def _rewrite_refs(node: Any, clone_target: Any) -> Any:
             destination target id (with side effect of cloning the target).
 
     Returns:
-        A new payload subtree with every ref marker pointing at the newly
-        minted destination ids.
+        A new payload subtree with every same-namespace ref marker pointing
+        at the newly minted destination ids; cross-ns markers preserved
+        byte-for-byte.
     """
     if isinstance(node, dict):
         if REF_KEY in node:
+            if _is_cross_ns_marker(node):
+                # Cross-ns marker — preserve verbatim. Take a shallow copy so
+                # the caller's subtree is not aliased into the destination.
+                return dict(node)
             new: dict[str, Any] = dict(node)
             new[REF_KEY] = clone_target(node[REF_KEY])
             return new
@@ -876,6 +1000,11 @@ class _BundleOverlayRepository:
     def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
         return self._inner.find_references(namespace, target_id)
 
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> _list[Entry]:
+        return self._inner.find_references_global(namespace, target_id, scope)
+
 
 class _InMemoryEntryRepository:
     """Pre-loaded ``EntryRepository`` wrapper serving ``get`` from a list.
@@ -888,13 +1017,32 @@ class _InMemoryEntryRepository:
     repository.
     """
 
-    def __init__(self, entries: list[Entry]) -> None:
-        """Index ``entries`` by ``(namespace, id)`` for O(1) ``get`` lookups."""
+    def __init__(
+        self,
+        entries: list[Entry],
+        fallback: EntryRepository | None = None,
+    ) -> None:
+        """Index ``entries`` by ``(namespace, id)`` for O(1) ``get`` lookups.
+
+        Args:
+            entries: The pre-loaded namespace-bounded entry list.
+            fallback: Optional outer repository consulted when ``get`` misses
+                the in-memory index. Used by :meth:`Catalog.load_team` to
+                resolve cross-namespace ref targets in allowlisted namespaces
+                without sacrificing the single-query invariant for the local
+                namespace.
+        """
         self._by_key: dict[tuple[str, str], Entry] = {(e.namespace, e.id): e for e in entries}
+        self._fallback: EntryRepository | None = fallback
 
     def get(self, namespace: str, id: str) -> Entry | None:
-        """Return the pre-loaded entry or ``None`` if absent."""
-        return self._by_key.get((namespace, id))
+        """Return the pre-loaded entry, fall back to the outer repo, or ``None``."""
+        hit = self._by_key.get((namespace, id))
+        if hit is not None:
+            return hit
+        if self._fallback is not None:
+            return self._fallback.get(namespace, id)
+        return None
 
     def put(self, entry: Entry) -> Entry:  # noqa: ARG002
         raise NotImplementedError(
@@ -927,6 +1075,17 @@ class _InMemoryEntryRepository:
         )
 
     def find_references(self, namespace: str, target_id: str) -> _list[Entry]:  # noqa: ARG002
+        raise NotImplementedError(
+            "InMemoryEntryRepository supports only .get(); use the real repository "
+            "for other operations"
+        )
+
+    def find_references_global(
+        self,
+        namespace: str,  # noqa: ARG002
+        target_id: str,  # noqa: ARG002
+        scope: frozenset[str],  # noqa: ARG002
+    ) -> _list[Entry]:
         raise NotImplementedError(
             "InMemoryEntryRepository supports only .get(); use the real repository "
             "for other operations"

--- a/src/akgentic/catalog/models/entry.py
+++ b/src/akgentic/catalog/models/entry.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BaseModel, Field, model_validator
+from pydantic import AfterValidator, BaseModel, Field, field_validator, model_validator
 
 from ._types import NonEmptyStr
 
@@ -149,6 +149,25 @@ class Entry(BaseModel):
             "the resolver."
         ),
     )
+
+    @field_validator("namespace")
+    @classmethod
+    def _forbid_dot_in_namespace(cls, v: str) -> str:
+        """Reject namespace values containing ``.`` (ADR-008 §D2).
+
+        Dots are reserved for the cross-namespace ref shorthand
+        ``{"__ref__": "<ns>.<id>"}`` parsed at the resolver layer; allowing a
+        ``.`` inside a namespace identifier would make the shorthand
+        ambiguous (every dot-positioned split would be a candidate). Banning
+        the character at the Pydantic field-validator (Layer 1) means the
+        invariant fires before any service or repository code sees the value.
+        """
+        if "." in v:
+            raise ValueError(
+                f"Entry.namespace must not contain '.': '{v}' — "
+                f"dots are reserved for cross-namespace ref shorthand"
+            )
+        return v
 
     @model_validator(mode="after")
     def _check_parent_pair(self) -> Entry:

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -46,3 +46,29 @@ class EntryRepository(Protocol):
 
     def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
         """Return entries in ``namespace`` whose payload references ``target_id``."""
+
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> _list[Entry]:
+        """Return entries whose payload carries a cross-ns ref to ``(namespace, target_id)``.
+
+        Implements ADR-008 §D2 — the global-scope referrer walker that widens
+        the namespace-bounded delete guard to a cross-tenant guard for
+        allowlisted shared namespaces. The match shape recognises both the
+        canonical sentinel (``__namespace__ == namespace`` AND
+        ``__ref__ == target_id``) and the shorthand form (``__ref__ ==
+        "<namespace>.<target_id>"``).
+
+        Args:
+            namespace: Target namespace of the (potential) cross-ns ref.
+            target_id: Target id of the (potential) cross-ns ref.
+            scope: Frozenset of namespaces to scan. Entries whose own
+                ``namespace`` is NOT in ``scope`` are excluded — same-ns
+                inbound refs continue to be served by ``find_references``.
+                When ``scope`` is empty, return ``[]`` without touching the
+                backend (short-circuit).
+
+        Returns:
+            The list of referring entries across the namespaces in ``scope``.
+            Empty when no referrer exists or when ``scope`` is empty.
+        """

--- a/src/akgentic/catalog/repositories/mongo.py
+++ b/src/akgentic/catalog/repositories/mongo.py
@@ -56,7 +56,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.queries import EntryQuery
-from akgentic.catalog.repositories.yaml import _payload_has_ref
+from akgentic.catalog.repositories.yaml import _payload_has_cross_ns_ref, _payload_has_ref
 
 if TYPE_CHECKING:
     import pymongo
@@ -453,4 +453,24 @@ class MongoEntryRepository:
             entry
             for entry in self.list_by_namespace(namespace)
             if _payload_has_ref(entry.payload, target_id)
+        ]
+
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> _list[Entry]:
+        """Return entries in ``scope`` namespaces whose payload carries a cross-ns ref.
+
+        Issues one ``find({"namespace": {"$in": list(scope)}})`` and applies
+        the shared :func:`_payload_has_cross_ns_ref` walker per document.
+        Empty ``scope`` short-circuits to ``[]`` without a server round-trip
+        (ADR-008 §D2). No JSONB / wildcard payload index — same shape as
+        the existing ``find_references`` walker.
+        """
+        if not scope:
+            return []
+        cursor = self._collection.find({"namespace": {"$in": list(scope)}})
+        return [
+            entry
+            for entry in (self._from_document(doc) for doc in cursor)
+            if _payload_has_cross_ns_ref(entry.payload, namespace, target_id)
         ]

--- a/src/akgentic/catalog/repositories/postgres/repository.py
+++ b/src/akgentic/catalog/repositories/postgres/repository.py
@@ -45,7 +45,7 @@ from typing import TYPE_CHECKING, Any
 
 from akgentic.catalog.models.entry import Entry, EntryKind
 from akgentic.catalog.models.queries import EntryQuery
-from akgentic.catalog.repositories.yaml import _payload_has_ref
+from akgentic.catalog.repositories.yaml import _payload_has_cross_ns_ref, _payload_has_ref
 
 if TYPE_CHECKING:
     # Type-only imports — not loaded at runtime. The `if TYPE_CHECKING:`
@@ -261,6 +261,31 @@ class PostgresEntryRepository:
             entry
             for entry in self.list_by_namespace(namespace)
             if _payload_has_ref(entry.payload, target_id)
+        ]
+
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> _list[Entry]:
+        """Return entries in ``scope`` namespaces carrying a cross-ns ref.
+
+        Issues one ``SELECT … FROM catalog_entries WHERE namespace = ANY(%s)``
+        with ``list(scope)`` bound as the parameter, then applies the shared
+        :func:`_payload_has_cross_ns_ref` walker per row. Empty ``scope``
+        short-circuits to ``[]`` without a database round-trip (ADR-008 §D2).
+        No JSONB containment / wildcard payload index — parity with the
+        existing :meth:`find_references` walker.
+        """
+        if not scope:
+            return []
+        from nagra import Transaction
+
+        sql = f"{_SELECT_ALL_COLUMNS} WHERE namespace = ANY(%s)"
+        with Transaction(self._conn_string) as trn:
+            rows = trn.execute(sql, (list(scope),)).fetchall()
+        return [
+            entry
+            for entry in (self._row_to_entry(row) for row in rows)
+            if _payload_has_cross_ns_ref(entry.payload, namespace, target_id)
         ]
 
     def list(self, query: EntryQuery) -> _list[Entry]:

--- a/src/akgentic/catalog/repositories/yaml.py
+++ b/src/akgentic/catalog/repositories/yaml.py
@@ -88,6 +88,53 @@ def _payload_has_ref(node: object, target_id: str) -> bool:
     return False
 
 
+def _payload_has_cross_ns_ref(node: object, target_namespace: str, target_id: str) -> bool:
+    """Depth-first scan for a cross-ns ref marker pointing at ``(target_namespace, target_id)``.
+
+    Recognises both ADR-008 §D2 cross-ns marker shapes:
+
+    * Canonical: ``{"__ref__": target_id, "__namespace__": target_namespace}``.
+    * Shorthand: ``{"__ref__": "<target_namespace>.<target_id>"}``.
+
+    Same-namespace markers (no ``__namespace__``, no dot in ``__ref__``) are
+    NOT matched — they are served by :func:`_payload_has_ref` and the
+    namespace-bounded :func:`find_references` path. The walker treats a dict
+    carrying ``__ref__`` as a leaf — it does NOT recurse into the marker's
+    other keys (``__type__``, ``__namespace__``, sibling overrides). Like
+    :func:`_payload_has_ref` the sentinel keys are hard-coded to avoid a
+    cross-module import.
+
+    Args:
+        node: Arbitrary payload subtree (dict, list, or leaf value).
+        target_namespace: The target namespace to match.
+        target_id: The target id to match.
+
+    Returns:
+        ``True`` if any dict in the tree carries a cross-ns ref marker
+        whose target equals ``(target_namespace, target_id)``.
+    """
+    if isinstance(node, dict):
+        if "__ref__" in node:
+            raw_ref = node["__ref__"]
+            explicit_ns = node.get("__namespace__")
+            # Canonical form: explicit __namespace__ + __ref__ (the value is
+            # the bare id; no dot semantics).
+            if explicit_ns is not None:
+                return bool(explicit_ns == target_namespace and raw_ref == target_id)
+            # Shorthand form: __ref__ == "<ns>.<id>" with no explicit
+            # __namespace__. Split on the first dot only — ids may
+            # legitimately contain dots.
+            if isinstance(raw_ref, str) and "." in raw_ref:
+                shorthand_ns, shorthand_id = raw_ref.split(".", 1)
+                return shorthand_ns == target_namespace and shorthand_id == target_id
+            # Same-namespace marker — not a cross-ns referrer.
+            return False
+        return any(_payload_has_cross_ns_ref(v, target_namespace, target_id) for v in node.values())
+    if isinstance(node, list):
+        return any(_payload_has_cross_ns_ref(v, target_namespace, target_id) for v in node)
+    return False
+
+
 class YamlEntryRepository:
     """Per-namespace, per-kind, per-file v2 ``EntryRepository`` on the filesystem.
 
@@ -322,6 +369,28 @@ class YamlEntryRepository:
             for entry in self._scan_namespace(namespace)
             if _payload_has_ref(entry.payload, target_id)
         ]
+
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> _list[Entry]:
+        """Return entries in ``scope`` namespaces whose payload carries a cross-ns ref.
+
+        Iterates each namespace directory under ``root`` whose name appears
+        in ``scope`` and walks each entry's payload via the shared
+        :func:`_payload_has_cross_ns_ref` helper. Empty ``scope`` short-
+        circuits to ``[]`` without touching the filesystem. Documented as
+        O(N) where N = total entries across the namespaces in ``scope``
+        (ADR-008 §D2; no JSONB / wildcard index — same shape as the
+        existing ``find_references`` walker).
+        """
+        if not scope:
+            return []
+        results: _list[Entry] = []
+        for ns in sorted(scope):
+            for entry in self._scan_namespace(ns):
+                if _payload_has_cross_ns_ref(entry.payload, namespace, target_id):
+                    results.append(entry)
+        return results
 
     def reload(self, namespace: str | None = None) -> None:
         """Invalidate the internal cache.

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -324,11 +324,10 @@ def _check_cross_ns_allowlist(
                 f"not allowed (allowlist is empty)"
             ]
         )
-    sorted_allowlist = set(sorted(cross_namespace_refs_allowed))
     raise CatalogValidationError(
         [
             f"Cross-namespace ref to '{target_namespace}.{target_id}' is "
-            f"not in the allowlist {sorted_allowlist}"
+            f"not in the allowlist {set(cross_namespace_refs_allowed)}"
         ]
     )
 

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -56,6 +56,7 @@ from .models.errors import CatalogValidationError
 from .repositories.base import EntryRepository
 
 __all__ = [
+    "NAMESPACE_KEY",
     "REF_KEY",
     "TYPE_KEY",
     "enumerate_allowlisted_model_types",
@@ -82,12 +83,26 @@ Emitted next to ``REF_KEY`` so the resolver can validate the target's type
 without loading the target entry eagerly.
 """
 
+NAMESPACE_KEY: Final[str] = "__namespace__"
+"""Sentinel dict key carrying the target namespace of a cross-namespace ref.
+
+Implements ADR-008 §D2 — the canonical cross-ns sentinel. A ref-marker dict
+may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
+to address an entry in a different namespace; the resolver gates the lookup
+on the ``Catalog``'s ``cross_namespace_refs_allowed`` allowlist and on the
+target's ``user_id is None`` privacy constraint. The shorthand
+``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
+the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
+``__ref__``) bypass both gates entirely and behave exactly as they did
+pre-17.3.
+"""
+
 # Runtime allowlist for ``load_model_type``. Duplicated intentionally in
 # ``models.entry`` for the annotation-layer defence — two layers, two
 # policies that only happen to agree today. See Story 15.1 Dev Notes.
 _ALLOWED_PREFIXES: tuple[str, ...] = ("akgentic.",)
 
-_RESERVED_KEYS: frozenset[str] = frozenset({REF_KEY, TYPE_KEY})
+_RESERVED_KEYS: frozenset[str] = frozenset({REF_KEY, TYPE_KEY, NAMESPACE_KEY})
 
 
 def load_model_type(path: str) -> type[BaseModel]:
@@ -135,6 +150,8 @@ def populate_refs(
     repository: EntryRepository,
     namespace: str,
     _visiting: set[tuple[str, str]] | None = None,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> Any:
     """Recursively replace ref markers in ``node`` with their resolved payloads.
 
@@ -193,13 +210,127 @@ def populate_refs(
 
     if isinstance(node, dict):
         if REF_KEY in node:
-            return _populate_ref_marker(node, repository, namespace, visiting)
-        return {k: populate_refs(v, repository, namespace, visiting) for k, v in node.items()}
+            return _populate_ref_marker(
+                node,
+                repository,
+                namespace,
+                visiting,
+                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            )
+        return {
+            k: populate_refs(
+                v,
+                repository,
+                namespace,
+                visiting,
+                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            )
+            for k, v in node.items()
+        }
 
     if isinstance(node, list):
-        return [populate_refs(v, repository, namespace, visiting) for v in node]
+        return [
+            populate_refs(
+                v,
+                repository,
+                namespace,
+                visiting,
+                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            )
+            for v in node
+        ]
 
     return node
+
+
+def _resolve_target_namespace(
+    node: dict[str, Any],
+    current_namespace: str,
+) -> tuple[str, str]:
+    """Return ``(target_namespace, target_id)`` for a ref-marker dict.
+
+    Implements ADR-008 §D2 cross-namespace ref shape resolution. The
+    canonical form carries an explicit ``__namespace__`` key; the shorthand
+    encodes the namespace as a ``<ns>.<id>`` prefix on the ``__ref__`` value
+    and the resolver splits on the FIRST dot only (so ids may continue to
+    contain ``.``). When both shapes are present and disagree, raise.
+
+    Args:
+        node: The ref-marker dict (must contain ``REF_KEY``).
+        current_namespace: The enclosing namespace passed by ``populate_refs``;
+            used when neither shorthand nor explicit ``__namespace__`` is set.
+
+    Returns:
+        A pair ``(target_namespace, target_id)``. ``target_namespace`` equals
+        ``current_namespace`` when the marker carries no cross-ns hint.
+
+    Raises:
+        CatalogValidationError: When shorthand and explicit ``__namespace__``
+            both appear and disagree.
+    """
+    raw_ref: Any = node[REF_KEY]
+    explicit_ns: str | None = node.get(NAMESPACE_KEY)
+    # Shorthand parsing — first-dot split. Ids may continue to contain dots.
+    if isinstance(raw_ref, str) and "." in raw_ref:
+        shorthand_ns, shorthand_id = raw_ref.split(".", 1)
+        if explicit_ns is not None and explicit_ns != shorthand_ns:
+            raise CatalogValidationError(
+                [
+                    f"Ref marker has both shorthand 'ns.id' and explicit "
+                    f"__namespace__ — these disagree: '{shorthand_ns}' vs "
+                    f"'{explicit_ns}'"
+                ]
+            )
+        return shorthand_ns, shorthand_id
+    if explicit_ns is not None:
+        return explicit_ns, raw_ref
+    return current_namespace, raw_ref
+
+
+def _check_cross_ns_allowlist(
+    target_namespace: str,
+    target_id: str,
+    current_namespace: str,
+    cross_namespace_refs_allowed: frozenset[str],
+) -> None:
+    """Raise when a cross-ns ref points at a non-allowlisted namespace.
+
+    The same-namespace path is exempt — a marker resolving to
+    ``current_namespace`` is not a cross-ns ref and is never gated by the
+    allowlist regardless of its contents.
+
+    Args:
+        target_namespace: The namespace resolved from the marker (canonical
+            ``__namespace__`` or shorthand prefix).
+        target_id: The id resolved from the marker (used for the error
+            message only).
+        current_namespace: The enclosing namespace; refs resolving to this
+            namespace bypass the gate.
+        cross_namespace_refs_allowed: The configured allowlist; an empty
+            ``frozenset()`` means no cross-ns refs are permitted.
+
+    Raises:
+        CatalogValidationError: When ``target_namespace != current_namespace``
+            and ``target_namespace`` is absent from the allowlist.
+    """
+    if target_namespace == current_namespace:
+        return
+    if target_namespace in cross_namespace_refs_allowed:
+        return
+    if not cross_namespace_refs_allowed:
+        raise CatalogValidationError(
+            [
+                f"Cross-namespace ref to '{target_namespace}.{target_id}' is "
+                f"not allowed (allowlist is empty)"
+            ]
+        )
+    sorted_allowlist = set(sorted(cross_namespace_refs_allowed))
+    raise CatalogValidationError(
+        [
+            f"Cross-namespace ref to '{target_namespace}.{target_id}' is "
+            f"not in the allowlist {sorted_allowlist}"
+        ]
+    )
 
 
 def _populate_ref_marker(
@@ -207,47 +338,70 @@ def _populate_ref_marker(
     repository: EntryRepository,
     namespace: str,
     visiting: set[tuple[str, str]],
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> Any:
     """Resolve a single ref-marker dict into a typed Pydantic instance.
 
-    Checks run in order — cycle, missing target, ``__type__`` mismatch, then
-    (Story 15.6) recursive population of nested refs inside the target's
-    payload, optional shallow merge of non-reserved siblings on top of that
-    payload (Story 20.1 / ADR-010), ``load_model_type`` on the target's
-    declared ``model_type``, and ``cls.model_validate`` to build a typed
-    instance.
+    Checks run in order — parse target namespace (canonical
+    ``__namespace__`` or first-dot shorthand), allowlist gate (cross-ns
+    only), cycle, missing target, cross-ns ownership gate (target's
+    ``user_id`` MUST be ``None``), ``__type__`` mismatch, then (Story 15.6)
+    recursive population of nested refs inside the target's payload,
+    optional shallow merge of non-reserved siblings on top of that payload
+    (Story 20.1 / ADR-010), ``load_model_type`` on the target's declared
+    ``model_type``, and ``cls.model_validate`` to build a typed instance.
 
-    Cycle comes first to avoid a redundant repository lookup when we already
-    know we are looping; missing-target comes second because the ``__type__``
-    check needs the fetched target in hand. Every pre-instantiation failure
-    raises ``CatalogValidationError`` with the existing substring-stable
-    messages (``"cycle"``, ``"not found"``, ``"expected X"`` + ``"got Y"``).
-    A validation failure at instantiation time raises
-    ``CatalogValidationError`` naming the referenced entry's id and
-    ``model_type`` so authoring errors point at the offending entry, not at
-    the parent that happens to reference it.
+    Order rationale: the allowlist gate fires BEFORE the repository lookup
+    so a denied cross-ns ref produces the allowlist error even when the
+    target id genuinely does not exist (ADR-008 §D2 — denying access takes
+    precedence over reporting "not found"). Cycle comes next because the
+    cross-ns target may be visited along a chain we already walked.
+    Ownership fires AFTER the lookup so the message can name the offending
+    ``user_id``. ``__type__`` mismatch and downstream pure-data errors
+    follow.
 
     Sibling-override semantics (ADR-010): any keys on ``node`` other than
-    ``__ref__`` / ``__type__`` are collected as overrides. When non-empty,
-    the override dict is itself run through :func:`populate_refs` (sharing
-    the same ``visiting | {key}`` cycle-detection set as the target-payload
-    recursion), then shallow-merged on top of the populated target payload
-    via ``{**target, **overrides}``. The merge is top-level — no recursive
-    descent into shared subkeys — and runs before ``cls.model_validate``.
-    When the ref marker has no non-reserved siblings, this branch is
-    skipped entirely and behaviour is observationally identical to the
-    pre-20.1 baseline.
+    ``__ref__`` / ``__type__`` / ``__namespace__`` are collected as
+    overrides. When non-empty, the override dict is itself run through
+    :func:`populate_refs` against the **target's namespace** (so nested
+    cross-ns refs in the override are subject to the same allowlist +
+    ownership gates), then shallow-merged on top of the populated target
+    payload via ``{**target, **overrides}``. The merge is top-level — no
+    recursive descent into shared subkeys — and runs before
+    ``cls.model_validate``. When the ref marker has no non-reserved
+    siblings, this branch is skipped entirely.
     """
-    target_id = node[REF_KEY]
+    target_namespace, target_id = _resolve_target_namespace(node, namespace)
     expected = node.get(TYPE_KEY)
-    key = (namespace, target_id)
+    key = (target_namespace, target_id)
+
+    # Allowlist gate fires BEFORE repository.get so a denied cross-ns ref
+    # raises the allowlist error even when the target id does not exist.
+    _check_cross_ns_allowlist(target_namespace, target_id, namespace, cross_namespace_refs_allowed)
 
     if key in visiting:
-        raise CatalogValidationError([f"Reference cycle detected at ({namespace}, {target_id})"])
+        raise CatalogValidationError(
+            [f"Reference cycle detected at ({target_namespace}, {target_id})"]
+        )
 
-    target = repository.get(namespace, target_id)
+    target = repository.get(target_namespace, target_id)
     if target is None:
-        raise CatalogValidationError([f"Ref '{target_id}' not found in namespace '{namespace}'"])
+        raise CatalogValidationError(
+            [f"Ref '{target_id}' not found in namespace '{target_namespace}'"]
+        )
+
+    # Cross-ns ownership gate (ADR-008 §D2): cross-ns refs may only target
+    # globally-scoped entries. This fires AFTER the lookup so the message
+    # can name the offending user_id.
+    if target_namespace != namespace and target.user_id is not None:
+        raise CatalogValidationError(
+            [
+                f"Cross-namespace ref target '{target_namespace}.{target_id}' "
+                f"has user_id={target.user_id!r} — only globally-scoped "
+                f"entries (user_id=None) can be referenced cross-namespace"
+            ]
+        )
 
     if expected is not None and target.model_type != expected:
         raise CatalogValidationError(
@@ -256,16 +410,29 @@ def _populate_ref_marker(
 
     # Story 15.6: recurse into the target's payload (resolves nested refs),
     # then validate against the target's declared model_type so the splice
-    # becomes a typed instance — Pydantic accepts a subclass instance where
-    # the parent field is annotated with its base class.
-    populated_payload = populate_refs(target.payload, repository, namespace, visiting | {key})
+    # becomes a typed instance. Recursion runs in the TARGET's namespace so
+    # nested same-ns refs in a cross-ns target's payload resolve correctly.
+    populated_payload = populate_refs(
+        target.payload,
+        repository,
+        target_namespace,
+        visiting | {key},
+        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+    )
 
     # Story 20.1 / ADR-010: merge non-reserved siblings on top of the target
-    # payload as a shallow override. When no siblings exist, skip this branch
-    # entirely so the no-override code path stays byte-identical to baseline.
+    # payload as a shallow override. The override dict is resolved against
+    # the TARGET's namespace so nested cross-ns refs in the override are
+    # gated by the same allowlist + ownership rules.
     overrides = {k: v for k, v in node.items() if k not in _RESERVED_KEYS}
     if overrides:
-        resolved_overrides = populate_refs(overrides, repository, namespace, visiting | {key})
+        resolved_overrides = populate_refs(
+            overrides,
+            repository,
+            target_namespace,
+            visiting | {key},
+            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        )
         # resolved_overrides is always a dict here: populate_refs preserves
         # the dict shape of any non-ref-marker dict input (the outer override
         # dict has no __ref__ at its top level — only its values may).
@@ -292,7 +459,12 @@ def _populate_ref_marker(
         ) from e
 
 
-def resolve(entry: Entry, repository: EntryRepository) -> BaseModel:
+def resolve(
+    entry: Entry,
+    repository: EntryRepository,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+) -> BaseModel:
     """Hydrate ``entry`` into an instance of its declared runtime Pydantic class.
 
     Composition: ``cls = load_model_type(entry.model_type)``; ``populated =
@@ -326,7 +498,12 @@ def resolve(entry: Entry, repository: EntryRepository) -> BaseModel:
             against"`` followed by the ``model_type`` string.
     """
     cls = load_model_type(entry.model_type)
-    populated = populate_refs(entry.payload, repository, entry.namespace)
+    populated = populate_refs(
+        entry.payload,
+        repository,
+        entry.namespace,
+        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+    )
     try:
         return cls.model_validate(populated)
     except ValidationError as e:
@@ -395,7 +572,12 @@ def _reconcile_dict(input_node: dict[str, Any], dumped_node: Any) -> dict[str, A
     return result
 
 
-def prepare_for_write(entry: Entry, repository: EntryRepository) -> Entry:
+def prepare_for_write(
+    entry: Entry,
+    repository: EntryRepository,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+) -> Entry:
     """Run the five-step write pipeline and return a ref-preserving ``Entry``.
 
     Pipeline (each step's failure short-circuits the remainder, raising
@@ -431,7 +613,12 @@ def prepare_for_write(entry: Entry, repository: EntryRepository) -> Entry:
     Raises:
         CatalogValidationError: From any pipeline step that fails.
     """
-    resolved = populate_refs(entry.payload, repository, entry.namespace)
+    resolved = populate_refs(
+        entry.payload,
+        repository,
+        entry.namespace,
+        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+    )
     cls = load_model_type(entry.model_type)
     obj = _validate_payload(cls, resolved, entry.model_type)
     dumped = obj.model_dump(mode="python", exclude_unset=True)

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -71,7 +71,10 @@ class NamespaceValidationReport(BaseModel):
 
 
 def validate_entries(
-    entries: list[Entry], repository: EntryRepository
+    entries: list[Entry],
+    repository: EntryRepository,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> NamespaceValidationReport:
     """Run every check against ``entries``; return a structured report.
 
@@ -88,6 +91,9 @@ def validate_entries(
         entries: The list of entries to validate. May be empty.
         repository: Entry repository used for transient-validation ref
             resolution (read-only).
+        cross_namespace_refs_allowed: Forwarded to ``populate_refs`` so
+            cross-ns ref errors (allowlist + ownership) surface as per-entry
+            issues in the returned report (ADR-008 §D2).
 
     Returns:
         A :class:`NamespaceValidationReport` with ``ok`` derived from the
@@ -103,7 +109,12 @@ def validate_entries(
 
     namespace = entries[0].namespace
     global_errors = _global_checks(entries, namespace)
-    entry_issues = _collect_entry_issues(entries, repository, namespace)
+    entry_issues = _collect_entry_issues(
+        entries,
+        repository,
+        namespace,
+        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+    )
 
     return NamespaceValidationReport(
         namespace=namespace,
@@ -221,18 +232,33 @@ def _iter_payload_ref_targets(node: Any) -> Iterable[str]:
 
 
 def _collect_entry_issues(
-    entries: list[Entry], repository: EntryRepository, namespace: str
+    entries: list[Entry],
+    repository: EntryRepository,
+    namespace: str,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> list[EntryValidationIssue]:
     """Build per-entry issues; skip entries with empty error lists."""
     issues: list[EntryValidationIssue] = []
     for e in entries:
-        errs = _per_entry_checks(e, repository, namespace)
+        errs = _per_entry_checks(
+            e,
+            repository,
+            namespace,
+            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        )
         if errs:
             issues.append(EntryValidationIssue(entry_id=e.id, kind=e.kind, errors=errs))
     return issues
 
 
-def _per_entry_checks(entry: Entry, repository: EntryRepository, namespace: str) -> list[str]:
+def _per_entry_checks(
+    entry: Entry,
+    repository: EntryRepository,
+    namespace: str,
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+) -> list[str]:
     """Run allowlist, lineage-pair, and transient-validation checks for ``entry``."""
     errors: list[str] = []
     cls: type[BaseModel] | None = None
@@ -242,7 +268,15 @@ def _per_entry_checks(entry: Entry, repository: EntryRepository, namespace: str)
         errors.extend(exc.errors)
     errors.extend(_check_lineage_pair(entry))
     if cls is not None:
-        errors.extend(_check_transient_validation(entry, repository, namespace, cls))
+        errors.extend(
+            _check_transient_validation(
+                entry,
+                repository,
+                namespace,
+                cls,
+                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            )
+        )
     return errors
 
 
@@ -259,11 +293,21 @@ def _check_lineage_pair(entry: Entry) -> list[str]:
 
 
 def _check_transient_validation(
-    entry: Entry, repository: EntryRepository, namespace: str, cls: type[BaseModel]
+    entry: Entry,
+    repository: EntryRepository,
+    namespace: str,
+    cls: type[BaseModel],
+    *,
+    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> list[str]:
     """Run ``populate_refs`` + ``cls.model_validate`` and collect every message."""
     try:
-        populated = populate_refs(entry.payload, repository, namespace)
+        populated = populate_refs(
+            entry.payload,
+            repository,
+            namespace,
+            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        )
     except CatalogValidationError as exc:
         return list(exc.errors)
     try:

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, ValidationError, model_validator
 from akgentic.catalog.models.entry import Entry, EntryKind, NonEmptyStr
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.repositories.base import EntryRepository
-from akgentic.catalog.resolver import REF_KEY, load_model_type, populate_refs
+from akgentic.catalog.resolver import NAMESPACE_KEY, REF_KEY, load_model_type, populate_refs
 
 __all__ = ["EntryValidationIssue", "NamespaceValidationReport", "validate_entries"]
 
@@ -216,10 +216,24 @@ def _check_dangling_refs(entries: list[Entry], namespace: str) -> list[str]:
 
 
 def _iter_payload_ref_targets(node: Any) -> Iterable[str]:
-    """Yield every ``__ref__`` target id reachable under ``node`` (dict/list walk)."""
+    """Yield every same-namespace ``__ref__`` target id reachable under ``node``.
+
+    Cross-ns markers (those carrying an explicit ``__namespace__`` key OR a
+    ``<ns>.<id>`` shorthand in ``__ref__``) are external by design and are
+    excluded from the bundle dangling-ref walker (ADR-008 §D2). Surfacing
+    cross-ns errors is the resolver's job and they must appear in
+    :class:`EntryValidationIssue.errors`, not in ``global_errors`` — see
+    AC18 in story 17.3.
+    """
     if isinstance(node, dict):
         if REF_KEY in node:
             target = node[REF_KEY]
+            if NAMESPACE_KEY in node:
+                # Canonical cross-ns marker — external by design.
+                return
+            if isinstance(target, str) and "." in target:
+                # Shorthand cross-ns marker — external by design.
+                return
             if isinstance(target, str):
                 yield target
             return

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -30,6 +30,9 @@ from akgentic.catalog.repositories.yaml import (
     YamlEntryRepository,
 )
 from akgentic.catalog.repositories.yaml import (
+    _payload_has_cross_ns_ref as _payload_has_cross_ns_ref,
+)
+from akgentic.catalog.repositories.yaml import (
     _payload_has_ref as _payload_has_ref,
 )
 
@@ -165,6 +168,17 @@ class FakeEntryRepository:
                 out.append(e)
         return out
 
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> list[Entry]:
+        if not scope:
+            return []
+        out: list[Entry] = []
+        for (ns, _), e in self._store.items():
+            if ns in scope and _payload_has_cross_ns_ref(e.payload, namespace, target_id):
+                out.append(e)
+        return out
+
 
 class CountingEntryRepository:
     """Decorator repository recording every method invocation.
@@ -218,6 +232,12 @@ class CountingEntryRepository:
     def find_references(self, namespace: str, target_id: str) -> list[Entry]:
         self._record("find_references", (namespace, target_id), {})
         return self.inner.find_references(namespace, target_id)
+
+    def find_references_global(
+        self, namespace: str, target_id: str, scope: frozenset[str]
+    ) -> list[Entry]:
+        self._record("find_references_global", (namespace, target_id, scope), {})
+        return self.inner.find_references_global(namespace, target_id, scope)
 
     def count(self, method_name: str) -> int:
         """Return the number of recorded calls to ``method_name``."""

--- a/tests/v2/test_app_factory_cross_ns.py
+++ b/tests/v2/test_app_factory_cross_ns.py
@@ -1,0 +1,67 @@
+"""Tests for Story 17.3 / AC19 — ``create_app(cross_namespace_refs_allowed=...)``.
+
+Asserts the app-factory threads the allowlist into the injected ``Catalog``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_create_app_threads_cross_namespace_refs_allowed(tmp_path: Path) -> None:
+    pytest.importorskip("fastapi")
+    from akgentic.catalog.api import router as router_module
+    from akgentic.catalog.api.app import create_app
+
+    create_app(
+        backend="yaml",
+        yaml_base_path=tmp_path,
+        cross_namespace_refs_allowed=frozenset({"global"}),
+    )
+    catalog = router_module._get_catalog()
+    assert catalog._cross_namespace_refs_allowed == frozenset({"global"})
+
+
+def test_create_app_default_empty_allowlist(tmp_path: Path) -> None:
+    pytest.importorskip("fastapi")
+    from akgentic.catalog.api import router as router_module
+    from akgentic.catalog.api.app import create_app
+
+    create_app(backend="yaml", yaml_base_path=tmp_path)
+    catalog = router_module._get_catalog()
+    assert catalog._cross_namespace_refs_allowed == frozenset()
+
+
+class TestCatalogCtorAllowlistKwarg:
+    """Story 17.3 / AC1 — ``Catalog.__init__`` ctor argument shape."""
+
+    def test_default_empty_frozenset(self) -> None:
+        from akgentic.catalog.catalog import Catalog
+
+        from .conftest import FakeEntryRepository
+
+        catalog = Catalog(FakeEntryRepository())
+        assert catalog._cross_namespace_refs_allowed == frozenset()
+
+    def test_kwarg_stored(self) -> None:
+        from akgentic.catalog.catalog import Catalog
+
+        from .conftest import FakeEntryRepository
+
+        catalog = Catalog(
+            FakeEntryRepository(),
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert catalog._cross_namespace_refs_allowed == frozenset({"global"})
+
+    def test_positional_arg_rejected(self) -> None:
+        from akgentic.catalog.catalog import Catalog
+
+        from .conftest import FakeEntryRepository
+
+        with pytest.raises(TypeError):
+            Catalog(  # type: ignore[misc]
+                FakeEntryRepository(), frozenset({"global"})
+            )

--- a/tests/v2/test_catalog_clone.py
+++ b/tests/v2/test_catalog_clone.py
@@ -426,9 +426,9 @@ class TestCloneSkipsPrepareForWrite:
         calls: list[Entry] = []
         real = catalog_module.prepare_for_write
 
-        def _spy(entry: Entry, repository: Any) -> Entry:
+        def _spy(entry: Entry, repository: Any, **kwargs: Any) -> Entry:
             calls.append(entry)
-            return real(entry, repository)
+            return real(entry, repository, **kwargs)
 
         monkeypatch.setattr(catalog_module, "prepare_for_write", _spy)
         calls.clear()
@@ -439,3 +439,181 @@ class TestCloneSkipsPrepareForWrite:
             dst_user_id="alice",
         )
         assert calls == []
+
+
+class TestCloneCrossNs:
+    """Story 17.3 / AC13 — cross-ns refs survive clone byte-for-byte."""
+
+    def _seed_target_with_cross_ns_payload(
+        self,
+        catalog: Catalog,
+        src_namespace: str,
+        cross_ns_marker: dict[str, Any],
+        root_type: str,
+    ) -> None:
+        """Persist a team + a root entry whose payload carries a cross-ns ref."""
+        _seed_team(catalog, namespace=src_namespace, user_id=None)
+        # Use a permissive root model — _RootModel.manager accepts any subkeys.
+        catalog.create(
+            Entry(
+                id="root",
+                kind="agent",
+                namespace=src_namespace,
+                user_id=None,
+                model_type=root_type,
+                payload={"manager": cross_ns_marker, "name": "root"},
+            )
+        )
+
+    def test_canonical_cross_ns_marker_preserved(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from akgentic.catalog.repositories.yaml import YamlEntryRepository
+
+        leaf, _sub, root = _register_models(monkeypatch)
+        # The catalog must be configured with the allowlist so the source
+        # entry passes prepare_for_write at create() time.
+        repo = YamlEntryRepository(tmp_path)
+        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+        # Seed the cross-ns target.
+        _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        cross_ns_marker = {
+            "model_cfg": {
+                "__ref__": "shared-prompt",
+                "__namespace__": "global",
+            }
+        }
+        self._seed_target_with_cross_ns_payload(
+            catalog,
+            src_namespace="tenant-A",
+            cross_ns_marker=cross_ns_marker,
+            root_type=root,
+        )
+        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        cloned = catalog.clone(
+            src_namespace="tenant-A",
+            src_id="root",
+            dst_namespace="tenant-B",
+            dst_user_id=None,
+        )
+        # The cross-ns marker survives verbatim.
+        marker = cloned.payload["manager"]["model_cfg"]
+        assert marker == {
+            "__ref__": "shared-prompt",
+            "__namespace__": "global",
+        }
+
+    def test_shorthand_cross_ns_marker_preserved(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        from akgentic.catalog.repositories.yaml import YamlEntryRepository
+
+        leaf, _sub, root = _register_models(monkeypatch)
+        repo = YamlEntryRepository(tmp_path)
+        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+        _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        cross_ns_marker = {
+            "model_cfg": {"__ref__": "global.shared-prompt"},
+        }
+        self._seed_target_with_cross_ns_payload(
+            catalog,
+            src_namespace="tenant-A",
+            cross_ns_marker=cross_ns_marker,
+            root_type=root,
+        )
+        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        cloned = catalog.clone(
+            src_namespace="tenant-A",
+            src_id="root",
+            dst_namespace="tenant-B",
+            dst_user_id=None,
+        )
+        # Shorthand survives verbatim — not rewritten.
+        assert cloned.payload["manager"]["model_cfg"] == {"__ref__": "global.shared-prompt"}
+
+    def test_mixed_local_and_cross_ns_refs_round_trip(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Local refs are rewritten to dst ids; cross-ns refs survive verbatim."""
+        from akgentic.catalog.repositories.yaml import YamlEntryRepository
+
+        leaf, sub, root = _register_models(monkeypatch)
+        repo = YamlEntryRepository(tmp_path)
+        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+
+        # Seed global cross-ns target.
+        _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(
+            Entry(
+                id="global-leaf",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "global"},
+            )
+        )
+
+        # Seed tenant-A: a local sub-entry + a root with a local ref + a cross-ns ref.
+        _seed_team(catalog, namespace="tenant-A", user_id=None)
+        catalog.create(
+            Entry(
+                id="local-sub",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=sub,
+                payload={"model_cfg": {"provider": "local"}},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="root",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=root,
+                payload={
+                    "manager": {"__ref__": "local-sub"},
+                    "assistant": {
+                        "model_cfg": {"__ref__": "global.global-leaf"},
+                    },
+                    "name": "root",
+                },
+            )
+        )
+
+        # Same-namespace clone: local-sub gets a numeric suffix; cross-ns survives.
+        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        cloned = catalog.clone(
+            src_namespace="tenant-A",
+            src_id="root",
+            dst_namespace="tenant-B",
+            dst_user_id=None,
+        )
+        # Cross-ns ref survives verbatim.
+        assert cloned.payload["assistant"]["model_cfg"] == {"__ref__": "global.global-leaf"}
+        # Local ref is rewritten to the cloned dst id (cross-ns clone reuses src id).
+        assert cloned.payload["manager"] == {"__ref__": "local-sub"}
+        # And the cloned local-sub now exists in tenant-B.
+        assert repo.get("tenant-B", "local-sub") is not None

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -382,9 +382,9 @@ class TestCreateRunsPrepareForWrite:
 
         real = catalog_module.prepare_for_write
 
-        def _spy(entry: Entry, repository: EntryRepository) -> Entry:
+        def _spy(entry: Entry, repository: EntryRepository, **kwargs: Any) -> Entry:
             calls.append((entry, repository))
-            return real(entry, repository)
+            return real(entry, repository, **kwargs)
 
         monkeypatch.setattr(catalog_module, "prepare_for_write", _spy)
 

--- a/tests/v2/test_catalog_delete_global.py
+++ b/tests/v2/test_catalog_delete_global.py
@@ -1,0 +1,190 @@
+"""Tests for Story 17.3 / AC16 — ``Catalog.delete`` widens to a global-scope check.
+
+When the deleted entry's namespace is in the configured
+``cross_namespace_refs_allowed`` allowlist, ``Catalog.delete`` runs the
+existing namespace-local ``validate_delete`` AND the new
+``repository.find_references_global(...)`` walker; their referrer messages
+are concatenated into a single ``CatalogValidationError``.
+
+When the deleted entry's namespace is OUTSIDE the allowlist (or the
+allowlist is empty), the global check short-circuits — no extra repository
+call, no behaviour change vs. the pre-17.3 baseline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError
+
+from .conftest import (
+    CountingEntryRepository,
+    FakeEntryRepository,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+class _Leaf(BaseModel):
+    """Permissive leaf used for cross-ns ref payloads."""
+
+    provider: str = "openai"
+
+
+class _Holder(BaseModel):
+    """Holder payload for cross-ns ref tests."""
+
+    model_cfg: _Leaf | None = None
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture
+def model_paths(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_17_3_delete_global",
+        Leaf=_Leaf,
+        Holder=_Holder,
+    )
+    return f"{module_name}.Leaf", f"{module_name}.Holder"
+
+
+def _seed_team(catalog: Catalog, namespace: str) -> None:
+    catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=None,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+class TestGlobalScopeBlocksDelete:
+    """AC16 — cross-tenant referrer to a global entry blocks the delete."""
+
+    def test_global_ns_target_blocked_by_tenant_referrer(
+        self, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(
+            repo,
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        _seed_team(catalog, "global")
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        # tenant-A references global.shared-prompt
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.delete("global", "shared-prompt")
+        # The error's errors list contains a referrer message naming tenant-A.
+        joined = " | ".join(exc_info.value.errors)
+        assert "tenant-A" in joined
+        assert "agent-1" in joined
+
+
+class TestOutsideAllowlistShortCircuits:
+    """AC16 — deleted entry outside the allowlist skips the global scan."""
+
+    def test_outside_scope_no_global_call(self, model_paths: tuple[str, str]) -> None:
+        leaf, _holder = model_paths
+        inner = FakeEntryRepository()
+        counting = CountingEntryRepository(inner)
+        catalog = Catalog(
+            counting,  # type: ignore[arg-type]
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="leaf-1",
+                kind="prompt",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "x"},
+            )
+        )
+        counting.reset()
+        # Deleting from tenant-A (outside the {"global"} allowlist) ⇒ no
+        # find_references_global call.
+        catalog.delete("tenant-A", "leaf-1")
+        assert counting.count("find_references_global") == 0
+
+
+class TestEmptyAllowlistByteIdentical:
+    """AC16 — empty allowlist ⇒ no new repository call (baseline behaviour)."""
+
+    def test_empty_allowlist_no_global_call(self, model_paths: tuple[str, str]) -> None:
+        leaf, _holder = model_paths
+        inner = FakeEntryRepository()
+        counting = CountingEntryRepository(inner)
+        # Default empty allowlist.
+        catalog = Catalog(counting)  # type: ignore[arg-type]
+        _seed_team(catalog, "global")
+        catalog.create(
+            Entry(
+                id="leaf-1",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "x"},
+            )
+        )
+        counting.reset()
+        catalog.delete("global", "leaf-1")
+        assert counting.count("find_references_global") == 0

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -504,3 +504,131 @@ class TestBundleImportMetaSingleton:
         catalog.import_namespace_yaml(yaml_text)
         ids = {e.id for e in repo.list_by_namespace("tenant-42")}
         assert ids == {"team", "_meta"}
+
+
+class TestImportBundleCrossNs:
+    """Story 17.3 / AC17 — cross-ns markers exempt from bundle dangling-ref rule."""
+
+    def test_cross_ns_ref_with_allowlist_target_imports(
+        self,
+        catalog_factory: CatalogFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Bundle agent payload references global.shared — target exists, allowlisted."""
+        agent_type, leaf_type = _register_agent_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        # Reconstruct catalog with the allowlist (factory doesn't take it).
+        catalog_with_allow = Catalog(
+            repo,
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        # Seed the global target via the allow-enabled catalog.
+        _seed_team(catalog_with_allow, "global", user_id=None)
+        catalog_with_allow.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "shared"},
+            )
+        )
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            ),
+        ]
+        yaml_text = dump_namespace(bundle)
+        catalog_with_allow.import_namespace_yaml(yaml_text)
+        ids = {e.id for e in repo.list_by_namespace("tenant-A")}
+        assert ids == {"team", "agent-1"}
+
+    def test_cross_ns_ref_without_allowlist_rejected(
+        self,
+        catalog_factory: CatalogFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default (no allowlist) ⇒ bundle with cross-ns ref fails at prepare_for_write."""
+        agent_type, _leaf = _register_agent_models(monkeypatch)
+        catalog, _repo = catalog_factory()
+        # Use the catalog returned by factory — default empty allowlist.
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=agent_type,
+                payload={"model_cfg": {"__ref__": "global.shared-prompt"}},
+            ),
+        ]
+        yaml_text = dump_namespace(bundle)
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.import_namespace_yaml(yaml_text)
+        msg = " | ".join(exc_info.value.errors)
+        assert "is not allowed (allowlist is empty)" in msg
+
+    def test_cross_ns_ref_target_missing_in_allowlist_namespace(
+        self,
+        catalog_factory: CatalogFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Allowlist includes 'global' but target id missing ⇒ standard not-found."""
+        agent_type, _leaf = _register_agent_models(monkeypatch)
+        _catalog, repo = catalog_factory()
+        catalog_with_allow = Catalog(
+            repo,
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        # No global entry seeded — no target.
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=agent_type,
+                payload={"model_cfg": {"__ref__": "global.does-not-exist"}},
+            ),
+        ]
+        yaml_text = dump_namespace(bundle)
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog_with_allow.import_namespace_yaml(yaml_text)
+        msg = " | ".join(exc_info.value.errors)
+        assert "not found in namespace" in msg
+        assert "global" in msg

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -328,3 +328,53 @@ class TestValidateNamespaceYamlIsReadOnly:
 
         assert counting.count("put") == 0
         assert counting.count("delete") == 0
+
+
+class TestValidateNamespaceCrossNs:
+    """Story 17.3 / AC18 — validate_namespace surfaces cross-ns errors per entry."""
+
+    def test_unallowlisted_cross_ns_ref_appears_in_entry_issues(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        _catalog, repo = catalog_factory()
+        # First seed via an allow-enabled catalog so prepare_for_write accepts
+        # the cross-ns ref; the persisted state then carries the marker.
+        catalog_with_allow = Catalog(
+            repo,
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        # Seed the global target so the first create() passes prepare_for_write.
+        _seed_team(catalog_with_allow, "global", user_id=None)
+        catalog_with_allow.create(
+            Entry(
+                id="shared",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=_AGENT_TYPE,
+                payload=_agent_payload("shared"),
+            )
+        )
+        _seed_team(catalog_with_allow, "tenant-A")
+        _seed_agent(
+            catalog_with_allow,
+            "tenant-A",
+            "agent-1",
+            payload={
+                "role": "r",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "a", "role": "r"},
+                "routes_to": [],
+                "metadata": {"ptr": {"__ref__": "global.shared"}},
+            },
+        )
+        # Now validate via a Catalog whose allowlist is empty — the cross-ns
+        # marker surfaces as a per-entry issue.
+        catalog_default = Catalog(repo)
+        report = catalog_default.validate_namespace("tenant-A")
+        assert report.ok is False
+        assert report.entry_issues, "expected per-entry issue for cross-ns ref"
+        joined = " | ".join(err for issue in report.entry_issues for err in issue.errors)
+        assert "is not allowed (allowlist is empty)" in joined

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -378,3 +378,57 @@ class TestValidateNamespaceCrossNs:
         assert report.entry_issues, "expected per-entry issue for cross-ns ref"
         joined = " | ".join(err for issue in report.entry_issues for err in issue.errors)
         assert "is not allowed (allowlist is empty)" in joined
+        # AC18: cross-ns errors live in entry_issues only — the dangling-ref
+        # walker must NOT flag the cross-ns marker as a global-error.
+        assert not any("dangling ref" in m for m in report.global_errors), (
+            f"unexpected dangling-ref leak for cross-ns marker: "
+            f"global_errors={report.global_errors!r}"
+        )
+
+    def test_canonical_cross_ns_marker_not_flagged_as_dangling(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """AC18 — canonical {__ref__: id, __namespace__: ns} marker is not dangling.
+
+        The dangling-ref walker is the bundle-internal completeness check;
+        cross-ns markers are external by design and must not be reported as
+        missing from the bundle (regardless of allowlist state).
+        """
+        _catalog, repo = catalog_factory()
+        catalog_with_allow = Catalog(
+            repo,
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        _seed_team(catalog_with_allow, "global", user_id=None)
+        catalog_with_allow.create(
+            Entry(
+                id="shared",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=_AGENT_TYPE,
+                payload=_agent_payload("shared"),
+            )
+        )
+        _seed_team(catalog_with_allow, "tenant-B")
+        _seed_agent(
+            catalog_with_allow,
+            "tenant-B",
+            "agent-c",
+            payload={
+                "role": "r",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "a", "role": "r"},
+                "routes_to": [],
+                "metadata": {"ptr": {"__ref__": "shared", "__namespace__": "global"}},
+            },
+        )
+        report = catalog_with_allow.validate_namespace("tenant-B")
+        # Cross-ns ref is allowlisted and the target exists — report ok.
+        assert report.ok is True, (
+            f"expected ok, got entry_issues={report.entry_issues!r} "
+            f"global_errors={report.global_errors!r}"
+        )
+        assert not any("dangling ref" in m for m in report.global_errors)

--- a/tests/v2/test_entry.py
+++ b/tests/v2/test_entry.py
@@ -175,3 +175,22 @@ class TestNamespaceRequired:
                 model_type="akgentic.core.agent_card.AgentCard",
                 payload={},
             )
+
+
+class TestNamespaceDotForbidden:
+    """Story 17.3 / AC5 — ``Entry.namespace`` must not contain ``.``."""
+
+    @pytest.mark.parametrize(
+        "bad_ns",
+        ["my.ns", "global.shared", "a.b.c", "."],
+    )
+    def test_dot_in_namespace_rejected(self, bad_ns: str) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            make_entry(namespace=bad_ns)
+        assert "must not contain '.'" in str(exc_info.value)
+
+    def test_dotted_id_still_accepted(self) -> None:
+        """``Entry.id`` continues to allow dots — only ``namespace`` is restricted."""
+        entry = make_entry(namespace="ok-ns", id="x.y.z")
+        assert entry.id == "x.y.z"
+        assert entry.namespace == "ok-ns"

--- a/tests/v2/test_entry_repo_parity.py
+++ b/tests/v2/test_entry_repo_parity.py
@@ -185,3 +185,85 @@ class TestEntryRepositoryParity:
         # user_id="alice" AND user_id_set=False → contradiction; zero entries.
         got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=False))
         assert got == []
+
+
+class TestFindReferencesGlobalParity:
+    """Story 17.3 / AC15 — `find_references_global` parity across backends."""
+
+    def _seed_cross_ns_referrers(self, backend: EntryRepository) -> None:
+        """Seed canonical + shorthand cross-ns referrers across two tenants."""
+        backend.put(
+            make_entry(
+                id="shared",
+                kind="prompt",
+                namespace="global",
+                payload={"x": 1},
+            )
+        )
+        backend.put(
+            make_entry(
+                id="agent-A",
+                kind="agent",
+                namespace="tenant-A",
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+        backend.put(
+            make_entry(
+                id="agent-B",
+                kind="agent",
+                namespace="tenant-B",
+                payload={"model_cfg": {"__ref__": "global.shared"}},
+            )
+        )
+        # Out-of-scope referrer (different namespace not in scan scope).
+        backend.put(
+            make_entry(
+                id="agent-C",
+                kind="agent",
+                namespace="tenant-C",
+                payload={"model_cfg": {"__ref__": "global.shared"}},
+            )
+        )
+        # Same-ns ref (must NOT count — find_references_global excludes
+        # canonical/shorthand markers pointing at the same namespace as the
+        # entry's own namespace? Actually, the walker ALWAYS matches by
+        # target marker shape; the scope filter is applied at the scan level).
+        # An unrelated entry that does not reference shared.
+        backend.put(
+            make_entry(
+                id="bystander",
+                kind="prompt",
+                namespace="tenant-A",
+                payload={"x": 2},
+            )
+        )
+
+    def test_returns_referrers_in_scope_namespaces(self, backend: EntryRepository) -> None:
+        self._seed_cross_ns_referrers(backend)
+        got = backend.find_references_global(
+            "global", "shared", frozenset({"tenant-A", "tenant-B"})
+        )
+        assert {e.id for e in got} == {"agent-A", "agent-B"}
+
+    def test_excludes_out_of_scope_namespaces(self, backend: EntryRepository) -> None:
+        self._seed_cross_ns_referrers(backend)
+        got = backend.find_references_global("global", "shared", frozenset({"tenant-A"}))
+        assert {e.id for e in got} == {"agent-A"}
+
+    def test_empty_scope_returns_empty(self, backend: EntryRepository) -> None:
+        self._seed_cross_ns_referrers(backend)
+        assert backend.find_references_global("global", "shared", frozenset()) == []
+
+    def test_no_match_returns_empty(self, backend: EntryRepository) -> None:
+        self._seed_cross_ns_referrers(backend)
+        # Target id that no payload references.
+        got = backend.find_references_global(
+            "global", "does-not-exist", frozenset({"tenant-A", "tenant-B"})
+        )
+        assert got == []

--- a/tests/v2/test_prepare_for_write.py
+++ b/tests/v2/test_prepare_for_write.py
@@ -32,9 +32,9 @@ class TestPipelineOrdering:
         real_load = resolver_module.load_model_type
         real_reconcile = resolver_module.reconcile_refs
 
-        def spy_populate(node: Any, repo: Any, ns: str, visiting: Any = None) -> Any:
+        def spy_populate(node: Any, repo: Any, ns: str, visiting: Any = None, **kwargs: Any) -> Any:
             call_log.append("populate_refs")
-            return real_populate(node, repo, ns, visiting)
+            return real_populate(node, repo, ns, visiting, **kwargs)
 
         def spy_load(path: str) -> Any:
             call_log.append("load_model_type")

--- a/tests/v2/test_request_body_declarations.py
+++ b/tests/v2/test_request_body_declarations.py
@@ -104,9 +104,7 @@ class TestOpenAPISchema:
         schema: dict[str, Any] = response.json()
         return schema
 
-    def _request_body(
-        self, schema: dict[str, Any], path: str
-    ) -> dict[str, Any]:
+    def _request_body(self, schema: dict[str, Any], path: str) -> dict[str, Any]:
         """Extract the ``requestBody`` dict for ``POST {path}``."""
         op = schema["paths"][path]["post"]
         request_body = op.get("requestBody")
@@ -114,17 +112,13 @@ class TestOpenAPISchema:
         assert isinstance(request_body, dict)
         return request_body
 
-    def test_import_declares_request_body(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_import_declares_request_body(self, api_client: tuple[TestClient, Catalog]) -> None:
         schema = self._openapi(api_client)
         body = self._request_body(schema, "/catalog/namespace/import")
         assert body.get("required") is True
         assert "application/yaml" in body["content"]
 
-    def test_validate_declares_request_body(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_validate_declares_request_body(self, api_client: tuple[TestClient, Catalog]) -> None:
         schema = self._openapi(api_client)
         body = self._request_body(schema, "/catalog/namespace/validate")
         assert body.get("required") is True
@@ -137,16 +131,12 @@ class TestOpenAPISchema:
 class TestMissingBody:
     """Empty-body POSTs surface as HTTP 422 for both routes."""
 
-    def test_import_missing_body_422(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_import_missing_body_422(self, api_client: tuple[TestClient, Catalog]) -> None:
         client, _ = api_client
         response = client.post("/catalog/namespace/import")
         assert response.status_code == 422
 
-    def test_validate_missing_body_422(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_validate_missing_body_422(self, api_client: tuple[TestClient, Catalog]) -> None:
         client, _ = api_client
         response = client.post("/catalog/namespace/validate")
         assert response.status_code == 422

--- a/tests/v2/test_resolver_allowlist.py
+++ b/tests/v2/test_resolver_allowlist.py
@@ -1,4 +1,10 @@
-"""Tests for ``akgentic.catalog.resolver.load_model_type`` and constants."""
+"""Tests for ``akgentic.catalog.resolver.load_model_type`` and constants.
+
+The cross-namespace tests in this file pin ADR-008 §D2 — canonical
+``__namespace__`` sentinel + ``<ns>.<id>`` shorthand parsing, allowlist
+gate, ownership gate, cycle detection across namespaces, and the
+``populate_refs`` keyword threading.
+"""
 
 from __future__ import annotations
 
@@ -9,9 +15,15 @@ from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 
 from akgentic.catalog.models.errors import CatalogValidationError
-from akgentic.catalog.resolver import REF_KEY, TYPE_KEY, load_model_type
+from akgentic.catalog.resolver import (
+    NAMESPACE_KEY,
+    REF_KEY,
+    TYPE_KEY,
+    load_model_type,
+    populate_refs,
+)
 
-from .conftest import register_akgentic_test_module
+from .conftest import FakeEntryRepository, make_entry, register_akgentic_test_module
 
 
 def _model_with_reserved_field(reserved_name: str) -> type[BaseModel]:
@@ -129,3 +141,363 @@ class TestLoadModelTypeHappyPath:
 
         result = load_model_type("akgentic.core.agent_card.AgentCard")
         assert result is AgentCard
+
+
+class TestNamespaceKeyConstant:
+    """Story 17.3 / AC2 — ``NAMESPACE_KEY`` literal value + reserved-key gate."""
+
+    def test_namespace_key_value(self) -> None:
+        assert NAMESPACE_KEY == "__namespace__"
+
+    def test_namespace_key_collision_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A class declaring a Pydantic field ``__namespace__`` is rejected."""
+        colliding_model = _model_with_reserved_field(NAMESPACE_KEY)
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_17_3_ns",
+            CollidingNsModel=colliding_model,
+        )
+
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_model_type(f"{module_name}.CollidingNsModel")
+
+        message = exc_info.value.errors[0]
+        assert "reserved ref-sentinel fields" in message
+        assert NAMESPACE_KEY in message
+
+
+class _Coord(BaseModel):
+    """Throwaway model for cross-ns ref payload validation."""
+
+    text: str = ""
+
+
+@pytest.fixture
+def coord_module(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Register ``_Coord`` under an ``akgentic.*`` path so model_type loads it."""
+    return register_akgentic_test_module(monkeypatch, "tests_fixture_17_3_coord", Coord=_Coord)
+
+
+class TestCrossNamespaceShorthandParsing:
+    """Story 17.3 / AC3 — ``__ref__`` value with ``.`` is split on the FIRST dot."""
+
+    def test_single_dot_parses_ns_then_id(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="prompt",
+                namespace="global",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "hi"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.prompt"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "hi"
+
+    def test_multi_dot_id_split_on_first_only(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="x.y.z",
+                namespace="global",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "compound"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.x.y.z"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "compound"
+
+    def test_no_dot_is_same_namespace(self, coord_module: str) -> None:
+        """No dot ⇒ same-namespace ref, allowlist not consulted."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="local-prompt",
+                namespace="tenant-A",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "local"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "local-prompt"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset(),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "local"
+
+    def test_dot_only_prefix_yields_empty_namespace_rejected(
+        self,
+        coord_module: str,  # noqa: ARG002
+    ) -> None:
+        """``"."<id>"`` ⇒ namespace="" — gated by NonEmptyStr / allowlist."""
+        repo = FakeEntryRepository()
+        # Empty namespace cannot be in the allowlist (NonEmptyStr is enforced
+        # on Entry.namespace) so the cross-ns gate fires.
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": ".foo"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"global"}),
+            )
+        msg = exc_info.value.errors[0]
+        assert "is not in the allowlist" in msg
+
+
+class TestExplicitAndShorthandAgreement:
+    """Story 17.3 / AC4 — explicit + shorthand same → ok; different → reject."""
+
+    def test_agreement_accepted(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="x",
+                namespace="global",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "ok"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.x", "__namespace__": "global"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+
+    def test_disagreement_rejected(self) -> None:
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "A.x", "__namespace__": "B"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"A", "B"}),
+            )
+        msg = exc_info.value.errors[0]
+        assert "shorthand 'ns.id' and explicit __namespace__" in msg
+        assert "'A'" in msg
+        assert "'B'" in msg
+
+    def test_canonical_form_no_dot_uses_namespace_verbatim(self, coord_module: str) -> None:
+        """``__namespace__`` set + ``__ref__`` without dot uses ``__namespace__``."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="bare-id",
+                namespace="global",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "verbatim"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "bare-id", "__namespace__": "global"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "verbatim"
+
+
+class TestPopulateRefsKwarg:
+    """Story 17.3 / AC6 — ``populate_refs`` accepts the keyword argument."""
+
+    def test_kwarg_default_empty(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="local",
+                namespace="tenant-A",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "ok"},
+            )
+        )
+        # Default arg ⇒ same-ns refs work, no behaviour change.
+        result = populate_refs({"__ref__": "local"}, repo, "tenant-A")
+        assert isinstance(result, _Coord)
+
+
+class TestCrossNamespaceAllowlistGate:
+    """Story 17.3 / AC8, AC9 — allowlist gate fires before repository lookup."""
+
+    def test_empty_allowlist_rejects_cross_ns(self) -> None:
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "global.x"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset(),
+            )
+        msg = exc_info.value.errors[0]
+        assert "is not allowed (allowlist is empty)" in msg
+        assert "global.x" in msg
+
+    def test_non_empty_allowlist_miss_rejects(self) -> None:
+        repo = FakeEntryRepository()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "other-ns.x"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"global"}),
+            )
+        msg = exc_info.value.errors[0]
+        assert "is not in the allowlist" in msg
+        assert "other-ns.x" in msg
+
+    def test_allowlist_hit_resolves(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="p",
+                namespace="global",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "shared"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.p"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "shared"
+
+    def test_gate_fires_before_repo_lookup(self) -> None:
+        """Denied cross-ns ref raises allowlist error even if target id is missing."""
+        repo = FakeEntryRepository()  # empty repo — no global.does-not-exist
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "global.does-not-exist"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset(),
+            )
+        # The allowlist message wins; "not found" is never reached.
+        assert "is not allowed (allowlist is empty)" in exc_info.value.errors[0]
+
+    def test_same_ns_unaffected_by_empty_allowlist(self, coord_module: str) -> None:
+        """A same-namespace ref resolves regardless of the (empty) allowlist."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="p",
+                namespace="tenant-A",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "ok"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "p"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset(),
+        )
+        assert isinstance(result, _Coord)
+
+
+class TestCrossNamespaceOwnershipGate:
+    """Story 17.3 / AC10 — cross-ns ref to user-scoped target rejected."""
+
+    def test_user_scoped_target_rejected(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="user-p",
+                namespace="global",
+                user_id="alice",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "user-only"},
+            )
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "global.user-p"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"global"}),
+            )
+        msg = exc_info.value.errors[0]
+        assert "only globally-scoped entries (user_id=None)" in msg
+        assert "global.user-p" in msg
+
+    def test_global_target_accepted(self, coord_module: str) -> None:
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="global-p",
+                namespace="global",
+                user_id=None,
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "shared"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.global-p"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, _Coord)
+
+
+class _RefHolder(BaseModel):
+    """A small ref-holder model used for cycle tests."""
+
+    next: _Coord | None = None
+
+
+class TestCrossNamespaceCycleDetection:
+    """Story 17.3 / AC11 — 3-hop cross-ns cycle reuses the existing message."""
+
+    def test_three_hop_cross_ns_cycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Register both Coord and RefHolder as akgentic.* model_types.
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_17_3_holder",
+            Coord=_Coord,
+            RefHolder=_RefHolder,
+        )
+        repo = FakeEntryRepository()
+        # tenant-A.x → global.y → tenant-A.x (cycle returns to start)
+        repo.put(
+            make_entry(
+                id="x",
+                namespace="tenant-A",
+                model_type=f"{module_name}.RefHolder",
+                payload={"next": {"__ref__": "global.y"}},
+            )
+        )
+        repo.put(
+            make_entry(
+                id="y",
+                namespace="global",
+                model_type=f"{module_name}.RefHolder",
+                payload={"next": {"__ref__": "tenant-A.x"}},
+            )
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {"__ref__": "x"},
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"tenant-A", "global"}),
+            )
+        assert "Reference cycle detected" in exc_info.value.errors[0]

--- a/tests/v2/test_resolver_sibling_overrides.py
+++ b/tests/v2/test_resolver_sibling_overrides.py
@@ -94,9 +94,7 @@ def prompt_template_module() -> str:
 class TestShallowOverrideMergesMotivating:
     """AC #1 — the concrete ``PromptTemplate`` reuse case."""
 
-    def test_ref_with_params_override_shallow_merges(
-        self, prompt_template_module: str
-    ) -> None:
+    def test_ref_with_params_override_shallow_merges(self, prompt_template_module: str) -> None:
         from akgentic.llm.prompts import PromptTemplate
 
         repo = FakeEntryRepository()
@@ -143,9 +141,7 @@ class TestShallowOverrideMergesMotivating:
             )
         )
         snapshot = copy.deepcopy(target_payload)
-        populate_refs(
-            {"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1"
-        )
+        populate_refs({"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1")
         assert target_payload == snapshot
 
     def test_fresh_instance_on_each_call(self, prompt_template_module: str) -> None:
@@ -159,12 +155,8 @@ class TestShallowOverrideMergesMotivating:
                 payload={"template": "T", "params": {"role": "assistant"}},
             )
         )
-        a = populate_refs(
-            {"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1"
-        )
-        b = populate_refs(
-            {"__ref__": "id_prompt", "params": {"role": "Expert"}}, repo, "ns-1"
-        )
+        a = populate_refs({"__ref__": "id_prompt", "params": {"role": "Manager"}}, repo, "ns-1")
+        b = populate_refs({"__ref__": "id_prompt", "params": {"role": "Expert"}}, repo, "ns-1")
         assert a is not b
         assert a.params == {"role": "Manager"}  # type: ignore[attr-defined]
         assert b.params == {"role": "Expert"}  # type: ignore[attr-defined]
@@ -217,9 +209,7 @@ class TestNoOverrideBackwardsCompatible:
 class TestOverrideIsShallow:
     """AC #3 — the override replaces the base's top-level value wholesale."""
 
-    def test_override_replaces_nested_dict_wholesale(
-        self, prompt_template_module: str
-    ) -> None:
+    def test_override_replaces_nested_dict_wholesale(self, prompt_template_module: str) -> None:
         from akgentic.llm.prompts import PromptTemplate
 
         repo = FakeEntryRepository()
@@ -480,9 +470,7 @@ class TestWritePathRoundTrip:
         rehydrated = Parent.model_validate(
             populate_refs(prepared.payload, repo, prepared.namespace)
         )
-        original = Parent.model_validate(
-            populate_refs(entry.payload, repo, entry.namespace)
-        )
+        original = Parent.model_validate(populate_refs(entry.payload, repo, entry.namespace))
         assert rehydrated.model_dump(mode="python", exclude_unset=True) == original.model_dump(
             mode="python", exclude_unset=True
         )
@@ -597,3 +585,70 @@ class TestSharedPromptAcrossAgents:
         assert prompt.template == "You are a helpful {role}. {instructions}"
         # Per-agent overrides.
         assert prompt.params == expected_params
+
+
+class TestCrossNamespaceSiblingOverrides:
+    """Story 17.3 / AC12 — overrides on a cross-ns ref merge in the target's namespace."""
+
+    def test_override_on_cross_ns_ref_merges(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_17_3_sibling_target",
+            Target=Anything,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="shared-prompt",
+                namespace="global",
+                user_id=None,
+                model_type=f"{module_name}.Target",
+                payload={"role": "Helper", "tone": "calm"},
+            )
+        )
+        result = populate_refs(
+            {"__ref__": "global.shared-prompt", "role": "Manager"},
+            repo,
+            "tenant-A",
+            cross_namespace_refs_allowed=frozenset({"global"}),
+        )
+        assert isinstance(result, Anything)
+        dumped = result.model_dump()
+        # Override field wins.
+        assert dumped["role"] == "Manager"
+        # Target's other field preserved.
+        assert dumped["tone"] == "calm"
+
+    def test_nested_cross_ns_ref_in_override_gated_by_allowlist(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A nested cross-ns ref inside an override value is gated."""
+        module_name = register_akgentic_test_module(
+            monkeypatch,
+            "tests_fixture_17_3_sibling_nested",
+            Target=Anything,
+        )
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="shared",
+                namespace="global",
+                user_id=None,
+                model_type=f"{module_name}.Target",
+                payload={"x": 1},
+            )
+        )
+        # The override's nested ref points at a non-allowlisted namespace.
+        with pytest.raises(CatalogValidationError) as exc_info:
+            populate_refs(
+                {
+                    "__ref__": "global.shared",
+                    "params": {"nested_ref": {"__ref__": "other-ns.x"}},
+                },
+                repo,
+                "tenant-A",
+                cross_namespace_refs_allowed=frozenset({"global"}),
+            )
+        msg = exc_info.value.errors[0]
+        assert "is not in the allowlist" in msg
+        assert "other-ns.x" in msg

--- a/tests/v2/test_resolver_typed_splice.py
+++ b/tests/v2/test_resolver_typed_splice.py
@@ -113,9 +113,7 @@ class TestPopulateRefsTypedOnFixture:
         agent_entry = agent_team_v1_repo.get("agent-team-v1", agent_id)
         assert agent_entry is not None
 
-        populated = populate_refs(
-            agent_entry.payload, agent_team_v1_repo, agent_entry.namespace
-        )
+        populated = populate_refs(agent_entry.payload, agent_team_v1_repo, agent_entry.namespace)
         tool_instances = populated["config"]["tools"]
         # Every tool in the populated tree is a concrete ToolCard subclass,
         # not a bare dict — this is the failure mode Story 15.6 fixes.


### PR DESCRIPTION
## Summary

Implements ADR-008 §D2 — cross-namespace references with a canonical
`__namespace__` sentinel and a `<ns>.<id>` shorthand parsed at the
resolver layer, gated by a per-`Catalog` `cross_namespace_refs_allowed`
allowlist and a `target.user_id is None` ownership constraint. Default
allowlist is `frozenset()` so existing deployments are byte-identical
post-upgrade.

Highlights:

- Resolver: shorthand parser splits on the first `.`; allowlist gate
  fires before the repository lookup; ownership gate fires after the
  lookup so the message names the offending `user_id`.
- `Entry.namespace` rejects values containing `.` at the Pydantic field
  validator (Layer 1).
- `NAMESPACE_KEY` added to `_RESERVED_KEYS` so model classes declaring
  a `__namespace__` field are rejected by `load_model_type`.
- `EntryRepository.find_references_global(namespace, target_id, scope)`
  added to the Protocol; YAML / Mongo / Postgres each implement it with
  an empty-scope short-circuit and a shared `_payload_has_cross_ns_ref`
  walker recognising both canonical and shorthand marker shapes.
- `Catalog.delete` widens to a global-scope check when the deleted
  entry's namespace is in the allowlist; cross-tenant referrers
  contribute one error each.
- Bundle import exempts cross-ns markers from the in-bundle dangling-ref
  rule; cross-ns markers stay subject to the allowlist + ownership
  gates at `prepare_for_write` time.
- `Catalog.clone` preserves cross-ns markers verbatim; `_rewrite_refs`
  only rewrites local refs.
- `validate_namespace` threads the allowlist through to surface cross-ns
  errors per entry; the dangling-ref walker now skips cross-ns markers
  so cross-ns errors live exclusively in `entry_issues`.
- `create_app(cross_namespace_refs_allowed=...)` plumbs the value
  through to `Catalog`; no new REST routes.

Architecture shards 03–07 updated alongside the implementation.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
