### PR TITLE
Story 17.4: data-driven sharing via meta.properties[shared] flag

### DIFF
--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -39,7 +39,6 @@ def create_app(
     mongo_config: MongoCatalogConfig | None = None,
     postgres_config: PostgresCatalogConfig | None = None,
     router_settings: CatalogRouterSettings | None = None,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
 ) -> FastAPI:
     """Create a FastAPI app serving the unified ``/catalog`` router.
 
@@ -61,11 +60,6 @@ def create_app(
             (Story 16.7). Defaults to
             :meth:`CatalogRouterSettings.from_env` — reads
             ``AKGENTIC_CATALOG_EXPOSE_GENERIC_KIND_CRUD``.
-        cross_namespace_refs_allowed: Frozenset of namespaces that may be
-            referenced cross-namespace (ADR-008 §D2). Forwarded to
-            :class:`Catalog` verbatim. Default ``frozenset()`` keeps
-            pre-existing call sites byte-identical post-upgrade — cross-ns
-            is configured at app-factory time, not over the wire.
 
     Returns:
         A configured ``FastAPI`` app with the catalog router mounted and
@@ -74,6 +68,12 @@ def create_app(
     Raises:
         ValueError: If the backend identifier is unknown or required arguments
             are missing.
+
+    Cross-namespace sharing is data-driven (ADR-008 §D2 as updated
+    2026-05-08): a namespace declares itself shareable through its own
+    ``_meta`` entry's ``properties["shared"] == "true"`` flag. Operators
+    provision shared namespaces via bundle import; no app-factory wiring
+    is required.
     """
     repo = _build_repository(
         backend=backend,
@@ -81,10 +81,7 @@ def create_app(
         mongo_config=mongo_config,
         postgres_config=postgres_config,
     )
-    catalog = Catalog(
-        repository=repo,
-        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
-    )
+    catalog = Catalog(repository=repo)
     set_catalog(catalog)
 
     app = FastAPI(title="Akgentic Catalog")

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -90,28 +90,28 @@ class Catalog:
         '3fa85f64-5717-4562-b3fc-2c963f66afa6'
     """
 
-    def __init__(
-        self,
-        repository: EntryRepository,
-        *,
-        cross_namespace_refs_allowed: frozenset[str] = frozenset(),
-    ) -> None:
+    def __init__(self, repository: EntryRepository) -> None:
         """Store ``repository`` on ``self._repository``; no I/O.
 
         Args:
             repository: Any concrete ``EntryRepository`` implementation.
-            cross_namespace_refs_allowed: Frozenset of namespaces that may be
-                referenced cross-namespace from any other namespace served by
-                this ``Catalog`` (ADR-008 §D2). Default ``frozenset()`` means
-                no cross-ns refs are permitted — same-namespace refs work
-                exactly as before. Operators opt in by passing a non-empty
-                frozenset (e.g. ``frozenset({"global", "default"})``).
-                Cross-ns refs are also gated on the target's ``user_id is
-                None`` privacy constraint, so only globally-scoped entries
-                in allowlisted namespaces can be referenced.
+
+        Cross-namespace sharing (ADR-008 §D2 as updated 2026-05-08) is
+        data-driven: a namespace declares itself shareable through its own
+        ``_meta`` entry (``properties["shared"] == "true"``). The catalog
+        consults the meta entry on demand via :meth:`_is_namespace_shared`
+        and caches the answer on ``self._shared_flag_cache`` for the
+        lifetime of the instance; meta-entry mutations (any
+        ``create``/``update``/``delete`` of a ``kind="meta"`` entry)
+        invalidate the affected cache slot.
         """
         self._repository: EntryRepository = repository
-        self._cross_namespace_refs_allowed: frozenset[str] = cross_namespace_refs_allowed
+        # Per-instance cache: namespace -> shared boolean. Populated lazily on
+        # first cross-ns ref resolution touching that namespace; invalidated
+        # whenever a meta entry in that namespace is created / updated /
+        # deleted (see ``_invalidate_shared_flag_cache`` callsites in the
+        # write paths).
+        self._shared_flag_cache: dict[str, bool] = {}
 
     # --- Read -----------------------------------------------------------------
 
@@ -193,9 +193,10 @@ class Catalog:
         prepared = prepare_for_write(
             entry,
             self._repository,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
         self._repository.put(prepared)
+        self._invalidate_shared_flag_cache(prepared)
         return prepared
 
     def update(self, entry: Entry) -> Entry:
@@ -238,12 +239,13 @@ class Catalog:
         prepared = prepare_for_write(
             entry,
             self._repository,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
         self._check_lineage_unchanged_or_reset(existing, prepared)
         if prepared.kind != "team":
             self._check_ownership(prepared)
         self._repository.put(prepared)
+        self._invalidate_shared_flag_cache(prepared)
         return prepared
 
     def delete(self, namespace: str, id: str) -> None:
@@ -261,20 +263,18 @@ class Catalog:
             EntryNotFoundError: If the target does not exist.
             CatalogValidationError: If any inbound refs would be broken.
         """
-        if self._repository.get(namespace, id) is None:
+        target = self._repository.get(namespace, id)
+        if target is None:
             raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
         errors = validate_delete(namespace, id, self._repository)
-        # ADR-008 §D2 — when the deleted entry is in an allowlisted namespace
-        # (i.e. it is a possible cross-ns ref target), widen the guard to a
-        # global-scope check so cross-tenant referrers also block the delete.
-        # Scope: every namespace currently present in the repository (cross-ns
-        # refs may originate from any tenant the operator has provisioned;
-        # the configured allowlist enumerates only the *referenceable* target
-        # namespaces, not the source namespaces — see ADR-008 §D2).
-        if self._cross_namespace_refs_allowed and namespace in self._cross_namespace_refs_allowed:
-            global_referrers = self._repository.find_references_global(
-                namespace, id, self._global_scope_for_delete()
-            )
+        # ADR-008 §D2 (updated 2026-05-08) — when the deleted entry's namespace
+        # is shared (its `_meta` carries `properties["shared"] == "true"`),
+        # widen the guard to a global-scope check so cross-tenant referrers
+        # also block the delete. Otherwise, the shared-flag gate would have
+        # rejected any cross-ns referrer at create time, so the namespace-
+        # local check is sufficient.
+        if self._is_namespace_shared(namespace):
+            global_referrers = self._repository.find_references_global(namespace, id)
             errors = errors + [
                 f"Entry '{r.id}' (kind={r.kind}) in namespace '{r.namespace}' references '{id}'"
                 for r in global_referrers
@@ -282,23 +282,7 @@ class Catalog:
         if errors:
             raise CatalogValidationError(errors)
         self._repository.delete(namespace, id)
-
-    def _global_scope_for_delete(self) -> frozenset[str]:
-        """Return every namespace the global delete-guard should scan.
-
-        Enumerates all namespaces present in the repository. Cross-ns refs
-        may originate from any tenant the operator has provisioned; the
-        configured ``cross_namespace_refs_allowed`` lists only the
-        *referenceable* target namespaces, not the source namespaces, so
-        the delete guard cannot use it as the scan scope.
-        """
-        # Pulls every entry once to enumerate namespaces. Backends could
-        # offer a cheaper "list_namespaces" primitive but the protocol does
-        # not expose one today; the cost is acceptable because delete is a
-        # rare admin operation and the scan is the same shape as the
-        # existing ``EntryQuery`` listing.
-        all_entries = self._repository.list(EntryQuery())
-        return frozenset(e.namespace for e in all_entries)
+        self._invalidate_shared_flag_cache(target)
 
     # --- Clone ----------------------------------------------------------------
 
@@ -377,7 +361,7 @@ class Catalog:
         return _resolve(
             entry,
             self._repository,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
 
     def resolve_by_id(self, namespace: str, id: str) -> BaseModel:
@@ -411,15 +395,17 @@ class Catalog:
             raise CatalogValidationError([f"Namespace '{namespace}' has no team entry"])
         team_entry = team_entries[0]
         # Fall back to the live repository for cross-ns ref lookups so a team
-        # payload that references entries in an allowlisted namespace (e.g.
+        # payload that references entries in a shared namespace (e.g.
         # ``global.shared-prompt``) still resolves while preserving the
-        # single-query invariant for the local namespace.
-        fallback = self._repository if self._cross_namespace_refs_allowed else None
-        in_memory = _InMemoryEntryRepository(entries, fallback=fallback)
+        # single-query invariant for the local namespace. The fallback is
+        # always wired — the shared-flag gate (consulted via
+        # ``self._is_namespace_shared``) is the authoritative permission
+        # check, not the presence of a fallback.
+        in_memory = _InMemoryEntryRepository(entries, fallback=self._repository)
         result = _resolve(
             team_entry,
             in_memory,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
         if not isinstance(result, TeamCard):
             raise CatalogValidationError(
@@ -495,7 +481,7 @@ class Catalog:
             prepare_for_write(
                 e,
                 overlay,
-                cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+                is_namespace_shared=self._is_namespace_shared,
             )
             for e in parsed
         ]
@@ -518,16 +504,16 @@ class Catalog:
         ``namespace`` when ``validate_entries`` saw zero entries, so the caller
         sees the requested label in the report even on an empty namespace.
 
-        The cross-namespace allowlist (Catalog ctor argument) is threaded
-        through to ``validate_entries`` so transient validation surfaces
-        cross-ns errors (allowlist violations, ownership violations) per
+        The shared-flag check (per ADR-008 §D2 as updated 2026-05-08) is
+        threaded into ``validate_entries`` so transient validation surfaces
+        cross-ns errors (shared-flag violations, ownership violations) per
         entry.
         """
         entries = self._repository.list_by_namespace(namespace)
         report = validate_entries(
             entries,
             self._repository,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
         if report.namespace is None:
             report = report.model_copy(update={"namespace": namespace})
@@ -566,7 +552,7 @@ class Catalog:
         return validate_entries(
             entries,
             self._repository,
-            cross_namespace_refs_allowed=self._cross_namespace_refs_allowed,
+            is_namespace_shared=self._is_namespace_shared,
         )
 
     # --- Private helpers ------------------------------------------------------
@@ -659,10 +645,13 @@ class Catalog:
         stale_team = [e for e in stale if e.kind == "team"]
         for e in stale_non_team:
             self._repository.delete(namespace, e.id)
+            self._invalidate_shared_flag_cache(e)
         for e in stale_team:
             self._repository.delete(namespace, e.id)
+            self._invalidate_shared_flag_cache(e)
         for e in ordered:
             self._repository.put(e)
+            self._invalidate_shared_flag_cache(e)
 
     def _mint_team_namespace(self, entry: Entry) -> Entry:
         """Return a copy of ``entry`` with ``namespace`` set to a fresh UUID string."""
@@ -772,6 +761,54 @@ class Catalog:
                 "Reset to None to detach a clone from its source."
             ]
         )
+
+    def _is_namespace_shared(self, namespace: str) -> bool:
+        """Return ``True`` iff ``namespace``'s ``_meta`` has ``properties["shared"] == "true"``.
+
+        Per ADR-008 §D2 (updated 2026-05-08), a namespace is cross-namespace-
+        referenceable iff its meta entry carries the literal lowercase
+        string ``"true"`` under ``properties["shared"]``. The check is
+        exact-string equality — no truthy-string coercion, no case folding —
+        so operators must opt in unambiguously.
+
+        The result is cached on ``self._shared_flag_cache`` keyed by
+        namespace; subsequent calls for the same namespace return the
+        cached boolean without re-querying the repository. Cache
+        invalidation happens in :meth:`create`, :meth:`update`, and
+        :meth:`delete` whenever a ``kind="meta"`` entry is written or
+        removed.
+
+        Args:
+            namespace: The target namespace to interrogate.
+
+        Returns:
+            ``True`` if a meta entry exists in ``namespace`` and carries
+            ``properties["shared"] == "true"``; ``False`` otherwise (no
+            meta entry, missing key, or any other value).
+        """
+        cached = self._shared_flag_cache.get(namespace)
+        if cached is not None:
+            return cached
+        meta = self._repository.get(namespace, "_meta")
+        shared = False
+        if meta is not None:
+            properties = meta.payload.get("properties") if isinstance(meta.payload, dict) else None
+            if isinstance(properties, dict):
+                shared = properties.get("shared") == "true"
+        self._shared_flag_cache[namespace] = shared
+        return shared
+
+    def _invalidate_shared_flag_cache(self, entry: Entry) -> None:
+        """Drop the cached shared-flag for ``entry.namespace`` if ``entry`` is a meta entry.
+
+        Called from ``create`` / ``update`` / ``delete`` after the
+        repository write commits, so the next ``_is_namespace_shared``
+        lookup re-reads the meta entry. A non-meta entry write is a
+        no-op — the cache only depends on the meta entry's
+        ``properties["shared"]`` value.
+        """
+        if entry.kind == "meta":
+            self._shared_flag_cache.pop(entry.namespace, None)
 
     def _check_ownership(self, entry: Entry) -> None:
         """Ensure ``entry.user_id == team_entry.user_id`` within ``entry.namespace``."""
@@ -1000,10 +1037,8 @@ class _BundleOverlayRepository:
     def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
         return self._inner.find_references(namespace, target_id)
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> _list[Entry]:
-        return self._inner.find_references_global(namespace, target_id, scope)
+    def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
+        return self._inner.find_references_global(namespace, target_id)
 
 
 class _InMemoryEntryRepository:
@@ -1084,7 +1119,6 @@ class _InMemoryEntryRepository:
         self,
         namespace: str,  # noqa: ARG002
         target_id: str,  # noqa: ARG002
-        scope: frozenset[str],  # noqa: ARG002
     ) -> _list[Entry]:
         raise NotImplementedError(
             "InMemoryEntryRepository supports only .get(); use the real repository "

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -41,6 +41,24 @@ class NamespaceMeta(BaseModel):
       tenant-level metadata (display tier, owner team, custom labels) that
       should NOT pollute :class:`~akgentic.team.models.TeamCard`.
 
+    Reserved property key — ``"shared"``:
+
+    The single catalog-reserved key in ``properties`` is ``"shared"``. When
+    ``properties["shared"] == "true"`` (the literal lowercase string, exact
+    match), the namespace is cross-namespace-referenceable as a target —
+    other namespaces may carry refs into this one (subject to the existing
+    ``user_id is None`` ownership gate). Any other value (``"false"``,
+    ``"True"``, ``"1"``, ``""``, …) or absence of the key means the
+    namespace is **not** shared. The catalog gate is exact-string equality —
+    no truthy-string coercion, no case folding — so operators must opt in
+    unambiguously.
+
+    All keys in ``properties`` other than ``"shared"`` remain free-form
+    operator annotations: the catalog never inspects them. Pydantic does
+    NOT enforce the value of ``"shared"`` at the model layer; the
+    enforcement happens in the resolver pipeline at write / resolve time
+    (per ADR-008 §D2 as updated 2026-05-08).
+
     Convention id is ``"_meta"``; the route fallback in
     ``GET /catalog/namespaces`` reads ``payload["name"]`` /
     ``description`` from the meta entry and falls back to the team entry

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -47,28 +47,27 @@ class EntryRepository(Protocol):
     def find_references(self, namespace: str, target_id: str) -> _list[Entry]:
         """Return entries in ``namespace`` whose payload references ``target_id``."""
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> _list[Entry]:
+    def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
         """Return entries whose payload carries a cross-ns ref to ``(namespace, target_id)``.
 
-        Implements ADR-008 §D2 — the global-scope referrer walker that widens
-        the namespace-bounded delete guard to a cross-tenant guard for
-        allowlisted shared namespaces. The match shape recognises both the
-        canonical sentinel (``__namespace__ == namespace`` AND
+        Implements ADR-008 §D2 (updated 2026-05-08) — the global-scope
+        referrer walker that widens the namespace-bounded delete guard to
+        a cross-tenant guard for shared namespaces (target's ``_meta`` has
+        ``properties["shared"] == "true"``). The match shape recognises
+        both the canonical sentinel (``__namespace__ == namespace`` AND
         ``__ref__ == target_id``) and the shorthand form (``__ref__ ==
         "<namespace>.<target_id>"``).
+
+        Implementations enumerate every namespace persisted in the
+        repository (no caller-supplied scope, no empty-scope short-
+        circuit) and apply the in-memory walker per entry. Documented as
+        O(N) over total entries.
 
         Args:
             namespace: Target namespace of the (potential) cross-ns ref.
             target_id: Target id of the (potential) cross-ns ref.
-            scope: Frozenset of namespaces to scan. Entries whose own
-                ``namespace`` is NOT in ``scope`` are excluded — same-ns
-                inbound refs continue to be served by ``find_references``.
-                When ``scope`` is empty, return ``[]`` without touching the
-                backend (short-circuit).
 
         Returns:
-            The list of referring entries across the namespaces in ``scope``.
-            Empty when no referrer exists or when ``scope`` is empty.
+            The list of referring entries across every namespace in the
+            repository. Empty when no referrer exists.
         """

--- a/src/akgentic/catalog/repositories/mongo.py
+++ b/src/akgentic/catalog/repositories/mongo.py
@@ -455,20 +455,15 @@ class MongoEntryRepository:
             if _payload_has_ref(entry.payload, target_id)
         ]
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> _list[Entry]:
-        """Return entries in ``scope`` namespaces whose payload carries a cross-ns ref.
+    def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries across every namespace whose payload carries a cross-ns ref.
 
-        Issues one ``find({"namespace": {"$in": list(scope)}})`` and applies
-        the shared :func:`_payload_has_cross_ns_ref` walker per document.
-        Empty ``scope`` short-circuits to ``[]`` without a server round-trip
-        (ADR-008 §D2). No JSONB / wildcard payload index — same shape as
-        the existing ``find_references`` walker.
+        Issues one unfiltered ``find({})`` and applies the shared
+        :func:`_payload_has_cross_ns_ref` walker per document (ADR-008
+        §D2 as updated 2026-05-08). No JSONB / wildcard payload index —
+        same shape as the existing ``find_references`` walker.
         """
-        if not scope:
-            return []
-        cursor = self._collection.find({"namespace": {"$in": list(scope)}})
+        cursor = self._collection.find({})
         return [
             entry
             for entry in (self._from_document(doc) for doc in cursor)

--- a/src/akgentic/catalog/repositories/postgres/repository.py
+++ b/src/akgentic/catalog/repositories/postgres/repository.py
@@ -263,25 +263,20 @@ class PostgresEntryRepository:
             if _payload_has_ref(entry.payload, target_id)
         ]
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> _list[Entry]:
-        """Return entries in ``scope`` namespaces carrying a cross-ns ref.
+    def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries across every namespace carrying a cross-ns ref.
 
-        Issues one ``SELECT … FROM catalog_entries WHERE namespace = ANY(%s)``
-        with ``list(scope)`` bound as the parameter, then applies the shared
-        :func:`_payload_has_cross_ns_ref` walker per row. Empty ``scope``
-        short-circuits to ``[]`` without a database round-trip (ADR-008 §D2).
-        No JSONB containment / wildcard payload index — parity with the
-        existing :meth:`find_references` walker.
+        Issues one unfiltered ``SELECT … FROM catalog_entries`` and applies
+        the shared :func:`_payload_has_cross_ns_ref` walker per row
+        (ADR-008 §D2 as updated 2026-05-08). No JSONB containment /
+        wildcard payload index — parity with the existing
+        :meth:`find_references` walker.
         """
-        if not scope:
-            return []
         from nagra import Transaction
 
-        sql = f"{_SELECT_ALL_COLUMNS} WHERE namespace = ANY(%s)"
+        sql = _SELECT_ALL_COLUMNS
         with Transaction(self._conn_string) as trn:
-            rows = trn.execute(sql, (list(scope),)).fetchall()
+            rows = trn.execute(sql, ()).fetchall()
         return [
             entry
             for entry in (self._row_to_entry(row) for row in rows)

--- a/src/akgentic/catalog/repositories/yaml.py
+++ b/src/akgentic/catalog/repositories/yaml.py
@@ -370,24 +370,23 @@ class YamlEntryRepository:
             if _payload_has_ref(entry.payload, target_id)
         ]
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> _list[Entry]:
-        """Return entries in ``scope`` namespaces whose payload carries a cross-ns ref.
+    def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
+        """Return entries across every namespace whose payload carries a cross-ns ref.
 
-        Iterates each namespace directory under ``root`` whose name appears
-        in ``scope`` and walks each entry's payload via the shared
-        :func:`_payload_has_cross_ns_ref` helper. Empty ``scope`` short-
-        circuits to ``[]`` without touching the filesystem. Documented as
-        O(N) where N = total entries across the namespaces in ``scope``
-        (ADR-008 §D2; no JSONB / wildcard index — same shape as the
+        Iterates every namespace directory under ``root`` (no caller-
+        supplied scope) and walks each entry's payload via the shared
+        :func:`_payload_has_cross_ns_ref` helper. Documented as O(N)
+        where N = total entries on disk (ADR-008 §D2 as updated
+        2026-05-08; no JSONB / wildcard index — same shape as the
         existing ``find_references`` walker).
         """
-        if not scope:
+        if not self._root.exists():
             return []
         results: _list[Entry] = []
-        for ns in sorted(scope):
-            for entry in self._scan_namespace(ns):
+        for namespace_dir in sorted(self._root.iterdir()):
+            if not namespace_dir.is_dir():
+                continue
+            for entry in self._scan_namespace(namespace_dir.name):
                 if _payload_has_cross_ns_ref(entry.payload, namespace, target_id):
                     results.append(entry)
         return results

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -45,6 +45,7 @@ right place to decide whether ownership enforcement lives inside
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from typing import Any, Final
 
 from pydantic import BaseModel, ValidationError
@@ -55,10 +56,16 @@ from .models.entry import Entry
 from .models.errors import CatalogValidationError
 from .repositories.base import EntryRepository
 
+# Type alias for the shared-flag check threaded through the resolver.
+# A callable that takes a target namespace and returns True if the
+# namespace's ``_meta`` entry carries ``properties["shared"] == "true"``.
+IsNamespaceSharedFn = Callable[[str], bool]
+
 __all__ = [
     "NAMESPACE_KEY",
     "REF_KEY",
     "TYPE_KEY",
+    "IsNamespaceSharedFn",
     "enumerate_allowlisted_model_types",
     "load_model_type",
     "populate_refs",
@@ -89,12 +96,12 @@ NAMESPACE_KEY: Final[str] = "__namespace__"
 Implements ADR-008 §D2 — the canonical cross-ns sentinel. A ref-marker dict
 may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
 to address an entry in a different namespace; the resolver gates the lookup
-on the ``Catalog``'s ``cross_namespace_refs_allowed`` allowlist and on the
-target's ``user_id is None`` privacy constraint. The shorthand
+on the data-driven shared-flag (the target namespace's ``_meta`` entry has
+``properties["shared"] == "true"`` — ADR-008 §D2 as updated 2026-05-08) and
+on the target's ``user_id is None`` privacy constraint. The shorthand
 ``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
 the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
-``__ref__``) bypass both gates entirely and behave exactly as they did
-pre-17.3.
+``__ref__``) bypass both gates entirely.
 """
 
 # Runtime allowlist for ``load_model_type``. Duplicated intentionally in
@@ -151,7 +158,7 @@ def populate_refs(
     namespace: str,
     _visiting: set[tuple[str, str]] | None = None,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> Any:
     """Recursively replace ref markers in ``node`` with their resolved payloads.
 
@@ -189,6 +196,15 @@ def populate_refs(
         _visiting: Internal cycle-detection set of ``(namespace, target_id)``
             pairs already traversed on the current ref chain. Callers pass
             ``None`` (the default); the function builds a fresh set per call.
+        is_namespace_shared: Optional callable answering "is this namespace
+            cross-namespace-referenceable?". The resolver invokes it for every
+            cross-ns marker — when it returns ``False`` (or when the argument
+            is ``None``), the marker is rejected with the substring
+            ``"is not shared"``. Same-namespace refs bypass the gate. Per
+            ADR-008 §D2 (updated 2026-05-08) the canonical implementation
+            consults the target namespace's ``_meta`` entry and answers
+            ``True`` iff ``properties["shared"] == "true"``. Default ``None``
+            ⇒ no namespace is shared (cross-ns refs unconditionally rejected).
 
     Returns:
         A new payload subtree with every ref marker replaced by a typed
@@ -215,7 +231,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+                is_namespace_shared=is_namespace_shared,
             )
         return {
             k: populate_refs(
@@ -223,7 +239,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+                is_namespace_shared=is_namespace_shared,
             )
             for k, v in node.items()
         }
@@ -235,7 +251,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+                is_namespace_shared=is_namespace_shared,
             )
             for v in node
         ]
@@ -287,17 +303,24 @@ def _resolve_target_namespace(
     return current_namespace, raw_ref
 
 
-def _check_cross_ns_allowlist(
+def _check_cross_ns_shared_flag(
     target_namespace: str,
     target_id: str,
     current_namespace: str,
-    cross_namespace_refs_allowed: frozenset[str],
+    is_namespace_shared: IsNamespaceSharedFn | None,
 ) -> None:
-    """Raise when a cross-ns ref points at a non-allowlisted namespace.
+    """Raise when a cross-ns ref points at a non-shared namespace.
 
     The same-namespace path is exempt — a marker resolving to
     ``current_namespace`` is not a cross-ns ref and is never gated by the
-    allowlist regardless of its contents.
+    shared-flag check.
+
+    Per ADR-008 §D2 (updated 2026-05-08), a namespace is "shared" iff its
+    ``_meta`` entry's ``payload["properties"]["shared"]`` equals the literal
+    lowercase string ``"true"``. The check is delegated to the
+    ``is_namespace_shared`` callable so the resolver stays a pure function
+    over the repository protocol — the per-``Catalog`` shared-flag cache
+    lives on the ``Catalog`` instance and is consulted via this callback.
 
     Args:
         target_namespace: The namespace resolved from the marker (canonical
@@ -306,28 +329,25 @@ def _check_cross_ns_allowlist(
             message only).
         current_namespace: The enclosing namespace; refs resolving to this
             namespace bypass the gate.
-        cross_namespace_refs_allowed: The configured allowlist; an empty
-            ``frozenset()`` means no cross-ns refs are permitted.
+        is_namespace_shared: Callable answering "is this namespace shared?"
+            or ``None``. ``None`` is interpreted as "no namespace is shared"
+            — every cross-ns ref is unconditionally rejected with the
+            ``"is not shared"`` substring.
 
     Raises:
         CatalogValidationError: When ``target_namespace != current_namespace``
-            and ``target_namespace`` is absent from the allowlist.
+            and ``is_namespace_shared`` returns ``False`` (or is ``None``).
+            The message carries the substring
+            ``"namespace '<target_namespace>' is not shared"``.
     """
     if target_namespace == current_namespace:
         return
-    if target_namespace in cross_namespace_refs_allowed:
+    if is_namespace_shared is not None and is_namespace_shared(target_namespace):
         return
-    if not cross_namespace_refs_allowed:
-        raise CatalogValidationError(
-            [
-                f"Cross-namespace ref to '{target_namespace}.{target_id}' is "
-                f"not allowed (allowlist is empty)"
-            ]
-        )
     raise CatalogValidationError(
         [
-            f"Cross-namespace ref to '{target_namespace}.{target_id}' is "
-            f"not in the allowlist {set(cross_namespace_refs_allowed)}"
+            f"Cross-namespace ref to '{target_namespace}.{target_id}': "
+            f"namespace '{target_namespace}' is not shared"
         ]
     )
 
@@ -338,12 +358,12 @@ def _populate_ref_marker(
     namespace: str,
     visiting: set[tuple[str, str]],
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> Any:
     """Resolve a single ref-marker dict into a typed Pydantic instance.
 
     Checks run in order — parse target namespace (canonical
-    ``__namespace__`` or first-dot shorthand), allowlist gate (cross-ns
+    ``__namespace__`` or first-dot shorthand), shared-flag gate (cross-ns
     only), cycle, missing target, cross-ns ownership gate (target's
     ``user_id`` MUST be ``None``), ``__type__`` mismatch, then (Story 15.6)
     recursive population of nested refs inside the target's payload,
@@ -351,20 +371,20 @@ def _populate_ref_marker(
     (Story 20.1 / ADR-010), ``load_model_type`` on the target's declared
     ``model_type``, and ``cls.model_validate`` to build a typed instance.
 
-    Order rationale: the allowlist gate fires BEFORE the repository lookup
-    so a denied cross-ns ref produces the allowlist error even when the
-    target id genuinely does not exist (ADR-008 §D2 — denying access takes
-    precedence over reporting "not found"). Cycle comes next because the
-    cross-ns target may be visited along a chain we already walked.
-    Ownership fires AFTER the lookup so the message can name the offending
-    ``user_id``. ``__type__`` mismatch and downstream pure-data errors
-    follow.
+    Order rationale: the shared-flag gate fires BEFORE the repository
+    lookup so a denied cross-ns ref produces the ``"is not shared"`` error
+    even when the target id genuinely does not exist (ADR-008 §D2 —
+    denying access takes precedence over reporting "not found"). Cycle
+    comes next because the cross-ns target may be visited along a chain we
+    already walked. Ownership fires AFTER the lookup so the message can
+    name the offending ``user_id``. ``__type__`` mismatch and downstream
+    pure-data errors follow.
 
     Sibling-override semantics (ADR-010): any keys on ``node`` other than
     ``__ref__`` / ``__type__`` / ``__namespace__`` are collected as
     overrides. When non-empty, the override dict is itself run through
     :func:`populate_refs` against the **target's namespace** (so nested
-    cross-ns refs in the override are subject to the same allowlist +
+    cross-ns refs in the override are subject to the same shared-flag +
     ownership gates), then shallow-merged on top of the populated target
     payload via ``{**target, **overrides}``. The merge is top-level — no
     recursive descent into shared subkeys — and runs before
@@ -375,9 +395,9 @@ def _populate_ref_marker(
     expected = node.get(TYPE_KEY)
     key = (target_namespace, target_id)
 
-    # Allowlist gate fires BEFORE repository.get so a denied cross-ns ref
-    # raises the allowlist error even when the target id does not exist.
-    _check_cross_ns_allowlist(target_namespace, target_id, namespace, cross_namespace_refs_allowed)
+    # Shared-flag gate fires BEFORE repository.get so a denied cross-ns ref
+    # raises the "is not shared" error even when the target id does not exist.
+    _check_cross_ns_shared_flag(target_namespace, target_id, namespace, is_namespace_shared)
 
     if key in visiting:
         raise CatalogValidationError(
@@ -416,13 +436,13 @@ def _populate_ref_marker(
         repository,
         target_namespace,
         visiting | {key},
-        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        is_namespace_shared=is_namespace_shared,
     )
 
     # Story 20.1 / ADR-010: merge non-reserved siblings on top of the target
     # payload as a shallow override. The override dict is resolved against
     # the TARGET's namespace so nested cross-ns refs in the override are
-    # gated by the same allowlist + ownership rules.
+    # gated by the same shared-flag + ownership rules.
     overrides = {k: v for k, v in node.items() if k not in _RESERVED_KEYS}
     if overrides:
         resolved_overrides = populate_refs(
@@ -430,7 +450,7 @@ def _populate_ref_marker(
             repository,
             target_namespace,
             visiting | {key},
-            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            is_namespace_shared=is_namespace_shared,
         )
         # resolved_overrides is always a dict here: populate_refs preserves
         # the dict shape of any non-ref-marker dict input (the outer override
@@ -462,7 +482,7 @@ def resolve(
     entry: Entry,
     repository: EntryRepository,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> BaseModel:
     """Hydrate ``entry`` into an instance of its declared runtime Pydantic class.
 
@@ -501,7 +521,7 @@ def resolve(
         entry.payload,
         repository,
         entry.namespace,
-        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        is_namespace_shared=is_namespace_shared,
     )
     try:
         return cls.model_validate(populated)
@@ -575,7 +595,7 @@ def prepare_for_write(
     entry: Entry,
     repository: EntryRepository,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> Entry:
     """Run the five-step write pipeline and return a ref-preserving ``Entry``.
 
@@ -616,7 +636,7 @@ def prepare_for_write(
         entry.payload,
         repository,
         entry.namespace,
-        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        is_namespace_shared=is_namespace_shared,
     )
     cls = load_model_type(entry.model_type)
     obj = _validate_payload(cls, resolved, entry.model_type)

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -29,7 +29,13 @@ from pydantic import BaseModel, ValidationError, model_validator
 from akgentic.catalog.models.entry import Entry, EntryKind, NonEmptyStr
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.repositories.base import EntryRepository
-from akgentic.catalog.resolver import NAMESPACE_KEY, REF_KEY, load_model_type, populate_refs
+from akgentic.catalog.resolver import (
+    NAMESPACE_KEY,
+    REF_KEY,
+    IsNamespaceSharedFn,
+    load_model_type,
+    populate_refs,
+)
 
 __all__ = ["EntryValidationIssue", "NamespaceValidationReport", "validate_entries"]
 
@@ -74,7 +80,7 @@ def validate_entries(
     entries: list[Entry],
     repository: EntryRepository,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> NamespaceValidationReport:
     """Run every check against ``entries``; return a structured report.
 
@@ -91,9 +97,10 @@ def validate_entries(
         entries: The list of entries to validate. May be empty.
         repository: Entry repository used for transient-validation ref
             resolution (read-only).
-        cross_namespace_refs_allowed: Forwarded to ``populate_refs`` so
-            cross-ns ref errors (allowlist + ownership) surface as per-entry
-            issues in the returned report (ADR-008 §D2).
+        is_namespace_shared: Forwarded to ``populate_refs`` so cross-ns
+            ref errors (shared-flag + ownership) surface as per-entry
+            issues in the returned report (ADR-008 §D2 as updated
+            2026-05-08).
 
     Returns:
         A :class:`NamespaceValidationReport` with ``ok`` derived from the
@@ -113,7 +120,7 @@ def validate_entries(
         entries,
         repository,
         namespace,
-        cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+        is_namespace_shared=is_namespace_shared,
     )
 
     return NamespaceValidationReport(
@@ -250,7 +257,7 @@ def _collect_entry_issues(
     repository: EntryRepository,
     namespace: str,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> list[EntryValidationIssue]:
     """Build per-entry issues; skip entries with empty error lists."""
     issues: list[EntryValidationIssue] = []
@@ -259,7 +266,7 @@ def _collect_entry_issues(
             e,
             repository,
             namespace,
-            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            is_namespace_shared=is_namespace_shared,
         )
         if errs:
             issues.append(EntryValidationIssue(entry_id=e.id, kind=e.kind, errors=errs))
@@ -271,9 +278,9 @@ def _per_entry_checks(
     repository: EntryRepository,
     namespace: str,
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> list[str]:
-    """Run allowlist, lineage-pair, and transient-validation checks for ``entry``."""
+    """Run model-type allowlist, lineage-pair, and transient-validation checks for ``entry``."""
     errors: list[str] = []
     cls: type[BaseModel] | None = None
     try:
@@ -288,7 +295,7 @@ def _per_entry_checks(
                 repository,
                 namespace,
                 cls,
-                cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+                is_namespace_shared=is_namespace_shared,
             )
         )
     return errors
@@ -312,7 +319,7 @@ def _check_transient_validation(
     namespace: str,
     cls: type[BaseModel],
     *,
-    cross_namespace_refs_allowed: frozenset[str] = frozenset(),
+    is_namespace_shared: IsNamespaceSharedFn | None = None,
 ) -> list[str]:
     """Run ``populate_refs`` + ``cls.model_validate`` and collect every message."""
     try:
@@ -320,7 +327,7 @@ def _check_transient_validation(
             entry.payload,
             repository,
             namespace,
-            cross_namespace_refs_allowed=cross_namespace_refs_allowed,
+            is_namespace_shared=is_namespace_shared,
         )
     except CatalogValidationError as exc:
         return list(exc.errors)

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -40,6 +40,51 @@ if TYPE_CHECKING:
     import pymongo.collection
 
 
+_NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def make_meta_entry(
+    namespace: str,
+    *,
+    shared: bool | str = True,
+    name: str | None = None,
+    description: str = "",
+    extra_properties: dict[str, str] | None = None,
+    user_id: str | None = None,
+) -> Entry:
+    """Build a ``kind="meta"`` Entry with the canonical id ``"_meta"``.
+
+    Used by cross-ns shared-flag tests to opt the target namespace into
+    being a cross-ns ref target. ``shared=True`` writes the literal
+    ``"true"`` string under ``properties["shared"]``; ``shared=False``
+    writes ``"false"``; ``shared`` may also be passed as a raw string for
+    edge-case tests asserting that anything other than ``"true"`` is
+    treated as not-shared.
+    """
+    properties: dict[str, str] = {}
+    if shared is True:
+        properties["shared"] = "true"
+    elif shared is False:
+        properties["shared"] = "false"
+    elif isinstance(shared, str):
+        properties["shared"] = shared
+    if extra_properties:
+        properties.update(extra_properties)
+    payload = {
+        "name": name if name is not None else namespace,
+        "description": description,
+        "properties": properties,
+    }
+    return Entry(
+        id="_meta",
+        kind="meta",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_NAMESPACE_META_TYPE,
+        payload=payload,
+    )
+
+
 def make_entry(**overrides: Any) -> Entry:
     """Build a minimal valid ``Entry`` with sensible defaults, overridable by kwargs.
 
@@ -168,14 +213,10 @@ class FakeEntryRepository:
                 out.append(e)
         return out
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> list[Entry]:
-        if not scope:
-            return []
+    def find_references_global(self, namespace: str, target_id: str) -> list[Entry]:
         out: list[Entry] = []
-        for (ns, _), e in self._store.items():
-            if ns in scope and _payload_has_cross_ns_ref(e.payload, namespace, target_id):
+        for _key, e in self._store.items():
+            if _payload_has_cross_ns_ref(e.payload, namespace, target_id):
                 out.append(e)
         return out
 
@@ -233,11 +274,9 @@ class CountingEntryRepository:
         self._record("find_references", (namespace, target_id), {})
         return self.inner.find_references(namespace, target_id)
 
-    def find_references_global(
-        self, namespace: str, target_id: str, scope: frozenset[str]
-    ) -> list[Entry]:
-        self._record("find_references_global", (namespace, target_id, scope), {})
-        return self.inner.find_references_global(namespace, target_id, scope)
+    def find_references_global(self, namespace: str, target_id: str) -> list[Entry]:
+        self._record("find_references_global", (namespace, target_id), {})
+        return self.inner.find_references_global(namespace, target_id)
 
     def count(self, method_name: str) -> int:
         """Return the number of recorded calls to ``method_name``."""

--- a/tests/v2/test_app_factory_cross_ns.py
+++ b/tests/v2/test_app_factory_cross_ns.py
@@ -1,6 +1,10 @@
-"""Tests for Story 17.3 / AC19 — ``create_app(cross_namespace_refs_allowed=...)``.
+"""Story 17.4 — assert the removed allowlist API surfaces are gone.
 
-Asserts the app-factory threads the allowlist into the injected ``Catalog``.
+Story 17.3 shipped ``create_app(cross_namespace_refs_allowed=...)`` and
+``Catalog(repo, cross_namespace_refs_allowed=...)``. Story 17.4 deletes
+both per Epic 17 Addendum (2026-05-08) — the data-driven shared-flag
+mechanism replaces them. These tests pin the deletion: passing the
+removed kwarg raises ``TypeError`` ("unexpected keyword argument").
 """
 
 from __future__ import annotations
@@ -10,58 +14,38 @@ from pathlib import Path
 import pytest
 
 
-def test_create_app_threads_cross_namespace_refs_allowed(tmp_path: Path) -> None:
+def test_create_app_rejects_removed_cross_ns_kwarg(tmp_path: Path) -> None:
     pytest.importorskip("fastapi")
-    from akgentic.catalog.api import router as router_module
     from akgentic.catalog.api.app import create_app
 
-    create_app(
-        backend="yaml",
-        yaml_base_path=tmp_path,
-        cross_namespace_refs_allowed=frozenset({"global"}),
-    )
-    catalog = router_module._get_catalog()
-    assert catalog._cross_namespace_refs_allowed == frozenset({"global"})
-
-
-def test_create_app_default_empty_allowlist(tmp_path: Path) -> None:
-    pytest.importorskip("fastapi")
-    from akgentic.catalog.api import router as router_module
-    from akgentic.catalog.api.app import create_app
-
-    create_app(backend="yaml", yaml_base_path=tmp_path)
-    catalog = router_module._get_catalog()
-    assert catalog._cross_namespace_refs_allowed == frozenset()
-
-
-class TestCatalogCtorAllowlistKwarg:
-    """Story 17.3 / AC1 — ``Catalog.__init__`` ctor argument shape."""
-
-    def test_default_empty_frozenset(self) -> None:
-        from akgentic.catalog.catalog import Catalog
-
-        from .conftest import FakeEntryRepository
-
-        catalog = Catalog(FakeEntryRepository())
-        assert catalog._cross_namespace_refs_allowed == frozenset()
-
-    def test_kwarg_stored(self) -> None:
-        from akgentic.catalog.catalog import Catalog
-
-        from .conftest import FakeEntryRepository
-
-        catalog = Catalog(
-            FakeEntryRepository(),
+    with pytest.raises(TypeError):
+        create_app(  # type: ignore[call-arg]
+            backend="yaml",
+            yaml_base_path=tmp_path,
             cross_namespace_refs_allowed=frozenset({"global"}),
         )
-        assert catalog._cross_namespace_refs_allowed == frozenset({"global"})
 
-    def test_positional_arg_rejected(self) -> None:
+
+class TestCatalogCtorRejectsRemovedKwarg:
+    """Story 17.4 / AC4 — ``Catalog.__init__`` no longer accepts the kwarg."""
+
+    def test_keyword_argument_rejected(self) -> None:
         from akgentic.catalog.catalog import Catalog
 
         from .conftest import FakeEntryRepository
 
         with pytest.raises(TypeError):
-            Catalog(  # type: ignore[misc]
-                FakeEntryRepository(), frozenset({"global"})
+            Catalog(  # type: ignore[call-arg]
+                FakeEntryRepository(),
+                cross_namespace_refs_allowed=frozenset({"global"}),
             )
+
+    def test_constructor_takes_only_repository(self) -> None:
+        """Sanity: the public signature is now ``__init__(self, repository)``."""
+        from akgentic.catalog.catalog import Catalog
+
+        from .conftest import FakeEntryRepository
+
+        catalog = Catalog(FakeEntryRepository())
+        # The internal cache attribute is still per-instance state.
+        assert catalog._shared_flag_cache == {}

--- a/tests/v2/test_catalog_clone.py
+++ b/tests/v2/test_catalog_clone.py
@@ -19,6 +19,7 @@ from .conftest import (
     CatalogFactory,
     CountingEntryRepository,
     FakeEntryRepository,
+    make_meta_entry,
     register_akgentic_test_module,
 )
 
@@ -471,12 +472,13 @@ class TestCloneCrossNs:
         from akgentic.catalog.repositories.yaml import YamlEntryRepository
 
         leaf, _sub, root = _register_models(monkeypatch)
-        # The catalog must be configured with the allowlist so the source
-        # entry passes prepare_for_write at create() time.
+        # The target namespace must be marked shared so the source entry
+        # passes prepare_for_write at create() time.
         repo = YamlEntryRepository(tmp_path)
-        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+        catalog = Catalog(repo)
         # Seed the cross-ns target.
         _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -520,8 +522,9 @@ class TestCloneCrossNs:
 
         leaf, _sub, root = _register_models(monkeypatch)
         repo = YamlEntryRepository(tmp_path)
-        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+        catalog = Catalog(repo)
         _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -559,10 +562,11 @@ class TestCloneCrossNs:
 
         leaf, sub, root = _register_models(monkeypatch)
         repo = YamlEntryRepository(tmp_path)
-        catalog = Catalog(repo, cross_namespace_refs_allowed=frozenset({"global"}))
+        catalog = Catalog(repo)
 
-        # Seed global cross-ns target.
+        # Seed global cross-ns target with a shared meta entry.
         _seed_team(catalog, namespace="global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
         catalog.create(
             Entry(
                 id="global-leaf",

--- a/tests/v2/test_catalog_delete_global.py
+++ b/tests/v2/test_catalog_delete_global.py
@@ -1,14 +1,14 @@
-"""Tests for Story 17.3 / AC16 — ``Catalog.delete`` widens to a global-scope check.
+"""Tests for Story 17.4 — ``Catalog.delete`` widens to a global-scope check.
 
-When the deleted entry's namespace is in the configured
-``cross_namespace_refs_allowed`` allowlist, ``Catalog.delete`` runs the
-existing namespace-local ``validate_delete`` AND the new
+When the deleted entry's namespace is shared (its ``_meta`` carries
+``properties["shared"] == "true"``), ``Catalog.delete`` runs the existing
+namespace-local ``validate_delete`` AND the new
 ``repository.find_references_global(...)`` walker; their referrer messages
 are concatenated into a single ``CatalogValidationError``.
 
-When the deleted entry's namespace is OUTSIDE the allowlist (or the
-allowlist is empty), the global check short-circuits — no extra repository
-call, no behaviour change vs. the pre-17.3 baseline.
+When the deleted entry's namespace is NOT shared (no meta entry, or meta
+entry with ``shared != "true"``), the global check short-circuits — no
+extra repository call, no behaviour change vs. the pre-17.3 baseline.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from akgentic.catalog.models.errors import CatalogValidationError
 from .conftest import (
     CountingEntryRepository,
     FakeEntryRepository,
+    make_meta_entry,
     register_akgentic_test_module,
 )
 
@@ -67,7 +68,7 @@ def _team_payload() -> dict[str, Any]:
 def model_paths(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
     module_name = register_akgentic_test_module(
         monkeypatch,
-        "tests_fixture_17_3_delete_global",
+        "tests_fixture_17_4_delete_global",
         Leaf=_Leaf,
         Holder=_Holder,
     )
@@ -87,19 +88,22 @@ def _seed_team(catalog: Catalog, namespace: str) -> None:
     )
 
 
-class TestGlobalScopeBlocksDelete:
-    """AC16 — cross-tenant referrer to a global entry blocks the delete."""
+def _mark_shared(catalog: Catalog, namespace: str) -> None:
+    """Seed a meta entry making ``namespace`` cross-namespace-referenceable."""
+    catalog.create(make_meta_entry(namespace, shared=True))
 
-    def test_global_ns_target_blocked_by_tenant_referrer(
+
+class TestGlobalScopeBlocksDelete:
+    """Cross-tenant referrer to a shared entry blocks the delete."""
+
+    def test_shared_ns_target_blocked_by_tenant_referrer(
         self, model_paths: tuple[str, str]
     ) -> None:
         leaf, holder = model_paths
         repo = FakeEntryRepository()
-        catalog = Catalog(
-            repo,
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
+        catalog = Catalog(repo)
         _seed_team(catalog, "global")
+        _mark_shared(catalog, "global")
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -136,17 +140,15 @@ class TestGlobalScopeBlocksDelete:
         assert "agent-1" in joined
 
 
-class TestOutsideAllowlistShortCircuits:
-    """AC16 — deleted entry outside the allowlist skips the global scan."""
+class TestNonSharedNamespaceShortCircuits:
+    """Deleting from a non-shared namespace skips the global scan."""
 
-    def test_outside_scope_no_global_call(self, model_paths: tuple[str, str]) -> None:
+    def test_no_meta_entry_skips_global_call(self, model_paths: tuple[str, str]) -> None:
         leaf, _holder = model_paths
         inner = FakeEntryRepository()
         counting = CountingEntryRepository(inner)
-        catalog = Catalog(
-            counting,  # type: ignore[arg-type]
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
+        # No meta entry on 'tenant-A' — namespace is not shared.
+        catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "tenant-A")
         catalog.create(
             Entry(
@@ -159,22 +161,42 @@ class TestOutsideAllowlistShortCircuits:
             )
         )
         counting.reset()
-        # Deleting from tenant-A (outside the {"global"} allowlist) ⇒ no
-        # find_references_global call.
+        catalog.delete("tenant-A", "leaf-1")
+        assert counting.count("find_references_global") == 0
+
+    def test_shared_false_skips_global_call(self, model_paths: tuple[str, str]) -> None:
+        leaf, _holder = model_paths
+        inner = FakeEntryRepository()
+        counting = CountingEntryRepository(inner)
+        catalog = Catalog(counting)  # type: ignore[arg-type]
+        _seed_team(catalog, "tenant-A")
+        # Meta entry with shared="false" ⇒ not shared.
+        catalog.create(make_meta_entry("tenant-A", shared=False))
+        catalog.create(
+            Entry(
+                id="leaf-1",
+                kind="prompt",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "x"},
+            )
+        )
+        counting.reset()
         catalog.delete("tenant-A", "leaf-1")
         assert counting.count("find_references_global") == 0
 
 
-class TestEmptyAllowlistByteIdentical:
-    """AC16 — empty allowlist ⇒ no new repository call (baseline behaviour)."""
+class TestNoMetaEntryByteIdentical:
+    """A namespace without a meta entry behaves like the pre-17.3 baseline."""
 
-    def test_empty_allowlist_no_global_call(self, model_paths: tuple[str, str]) -> None:
+    def test_no_meta_no_global_call(self, model_paths: tuple[str, str]) -> None:
         leaf, _holder = model_paths
         inner = FakeEntryRepository()
         counting = CountingEntryRepository(inner)
-        # Default empty allowlist.
         catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "global")
+        # No meta entry for global — namespace is not shared by default.
         catalog.create(
             Entry(
                 id="leaf-1",

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -21,6 +21,7 @@ from akgentic.catalog.serialization import dump_namespace, load_namespace
 from .conftest import (
     CatalogFactory,
     CountingEntryRepository,
+    make_meta_entry,
     register_akgentic_test_module,
 )
 
@@ -507,24 +508,20 @@ class TestBundleImportMetaSingleton:
 
 
 class TestImportBundleCrossNs:
-    """Story 17.3 / AC17 — cross-ns markers exempt from bundle dangling-ref rule."""
+    """Story 17.4 — cross-ns markers exempt from bundle dangling-ref rule + shared-flag gate."""
 
-    def test_cross_ns_ref_with_allowlist_target_imports(
+    def test_cross_ns_ref_with_shared_target_imports(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bundle agent payload references global.shared — target exists, allowlisted."""
+        """Bundle agent payload references global.shared — target exists in a shared namespace."""
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, repo = catalog_factory()
-        # Reconstruct catalog with the allowlist (factory doesn't take it).
-        catalog_with_allow = Catalog(
-            repo,
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
-        # Seed the global target via the allow-enabled catalog.
-        _seed_team(catalog_with_allow, "global", user_id=None)
-        catalog_with_allow.create(
+        # Seed the global target + meta with shared=true.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
             Entry(
                 id="shared-prompt",
                 kind="prompt",
@@ -558,19 +555,19 @@ class TestImportBundleCrossNs:
             ),
         ]
         yaml_text = dump_namespace(bundle)
-        catalog_with_allow.import_namespace_yaml(yaml_text)
+        catalog.import_namespace_yaml(yaml_text)
         ids = {e.id for e in repo.list_by_namespace("tenant-A")}
         assert ids == {"team", "agent-1"}
 
-    def test_cross_ns_ref_without_allowlist_rejected(
+    def test_cross_ns_ref_to_non_shared_namespace_rejected(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Default (no allowlist) ⇒ bundle with cross-ns ref fails at prepare_for_write."""
+        """Bundle with cross-ns ref to a non-shared namespace fails at prepare_for_write."""
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
-        # Use the catalog returned by factory — default empty allowlist.
+        # global has no meta entry — namespace is not shared.
         bundle = [
             Entry(
                 id="team",
@@ -593,21 +590,19 @@ class TestImportBundleCrossNs:
         with pytest.raises(CatalogValidationError) as exc_info:
             catalog.import_namespace_yaml(yaml_text)
         msg = " | ".join(exc_info.value.errors)
-        assert "is not allowed (allowlist is empty)" in msg
+        assert "is not shared" in msg
 
-    def test_cross_ns_ref_target_missing_in_allowlist_namespace(
+    def test_cross_ns_ref_target_missing_in_shared_namespace(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Allowlist includes 'global' but target id missing ⇒ standard not-found."""
+        """Shared namespace exists but target id missing ⇒ standard not-found."""
         agent_type, _leaf = _register_agent_models(monkeypatch)
-        _catalog, repo = catalog_factory()
-        catalog_with_allow = Catalog(
-            repo,
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
-        # No global entry seeded — no target.
+        catalog, _repo = catalog_factory()
+        # Mark global shared but seed no target id.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
         bundle = [
             Entry(
                 id="team",
@@ -628,7 +623,7 @@ class TestImportBundleCrossNs:
         ]
         yaml_text = dump_namespace(bundle)
         with pytest.raises(CatalogValidationError) as exc_info:
-            catalog_with_allow.import_namespace_yaml(yaml_text)
+            catalog.import_namespace_yaml(yaml_text)
         msg = " | ".join(exc_info.value.errors)
         assert "not found in namespace" in msg
         assert "global" in msg

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -15,7 +15,7 @@ from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.resolver import REF_KEY
 from akgentic.catalog.validation import NamespaceValidationReport
 
-from .conftest import CatalogFactory, CountingEntryRepository
+from .conftest import CatalogFactory, CountingEntryRepository, make_meta_entry
 
 _TEAM_TYPE = "akgentic.team.models.TeamCard"
 _AGENT_TYPE = "akgentic.core.agent_card.AgentCard"
@@ -331,21 +331,16 @@ class TestValidateNamespaceYamlIsReadOnly:
 
 
 class TestValidateNamespaceCrossNs:
-    """Story 17.3 / AC18 — validate_namespace surfaces cross-ns errors per entry."""
+    """Story 17.4 — validate_namespace surfaces cross-ns shared-flag errors per entry."""
 
-    def test_unallowlisted_cross_ns_ref_appears_in_entry_issues(
+    def test_non_shared_cross_ns_ref_appears_in_entry_issues(
         self, catalog_factory: CatalogFactory
     ) -> None:
-        _catalog, repo = catalog_factory()
-        # First seed via an allow-enabled catalog so prepare_for_write accepts
-        # the cross-ns ref; the persisted state then carries the marker.
-        catalog_with_allow = Catalog(
-            repo,
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
-        # Seed the global target so the first create() passes prepare_for_write.
-        _seed_team(catalog_with_allow, "global", user_id=None)
-        catalog_with_allow.create(
+        catalog, repo = catalog_factory()
+        # Seed global target via shared-flag-enabled global namespace.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
             Entry(
                 id="shared",
                 kind="prompt",
@@ -355,9 +350,9 @@ class TestValidateNamespaceCrossNs:
                 payload=_agent_payload("shared"),
             )
         )
-        _seed_team(catalog_with_allow, "tenant-A")
+        _seed_team(catalog, "tenant-A")
         _seed_agent(
-            catalog_with_allow,
+            catalog,
             "tenant-A",
             "agent-1",
             payload={
@@ -370,15 +365,15 @@ class TestValidateNamespaceCrossNs:
                 "metadata": {"ptr": {"__ref__": "global.shared"}},
             },
         )
-        # Now validate via a Catalog whose allowlist is empty — the cross-ns
-        # marker surfaces as a per-entry issue.
-        catalog_default = Catalog(repo)
-        report = catalog_default.validate_namespace("tenant-A")
+        # Flip global to not-shared so the cross-ns marker now fails the gate.
+        catalog._repository.delete("global", "_meta")
+        catalog._shared_flag_cache.pop("global", None)
+        report = catalog.validate_namespace("tenant-A")
         assert report.ok is False
         assert report.entry_issues, "expected per-entry issue for cross-ns ref"
         joined = " | ".join(err for issue in report.entry_issues for err in issue.errors)
-        assert "is not allowed (allowlist is empty)" in joined
-        # AC18: cross-ns errors live in entry_issues only — the dangling-ref
+        assert "is not shared" in joined
+        # Cross-ns errors live in entry_issues only — the dangling-ref
         # walker must NOT flag the cross-ns marker as a global-error.
         assert not any("dangling ref" in m for m in report.global_errors), (
             f"unexpected dangling-ref leak for cross-ns marker: "
@@ -388,19 +383,16 @@ class TestValidateNamespaceCrossNs:
     def test_canonical_cross_ns_marker_not_flagged_as_dangling(
         self, catalog_factory: CatalogFactory
     ) -> None:
-        """AC18 — canonical {__ref__: id, __namespace__: ns} marker is not dangling.
+        """Canonical {__ref__: id, __namespace__: ns} marker is not dangling.
 
         The dangling-ref walker is the bundle-internal completeness check;
         cross-ns markers are external by design and must not be reported as
-        missing from the bundle (regardless of allowlist state).
+        missing from the bundle (regardless of shared-flag state).
         """
-        _catalog, repo = catalog_factory()
-        catalog_with_allow = Catalog(
-            repo,
-            cross_namespace_refs_allowed=frozenset({"global"}),
-        )
-        _seed_team(catalog_with_allow, "global", user_id=None)
-        catalog_with_allow.create(
+        catalog, _repo = catalog_factory()
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
             Entry(
                 id="shared",
                 kind="prompt",
@@ -410,9 +402,9 @@ class TestValidateNamespaceCrossNs:
                 payload=_agent_payload("shared"),
             )
         )
-        _seed_team(catalog_with_allow, "tenant-B")
+        _seed_team(catalog, "tenant-B")
         _seed_agent(
-            catalog_with_allow,
+            catalog,
             "tenant-B",
             "agent-c",
             payload={
@@ -425,8 +417,9 @@ class TestValidateNamespaceCrossNs:
                 "metadata": {"ptr": {"__ref__": "shared", "__namespace__": "global"}},
             },
         )
-        report = catalog_with_allow.validate_namespace("tenant-B")
-        # Cross-ns ref is allowlisted and the target exists — report ok.
+        report = catalog.validate_namespace("tenant-B")
+        # Cross-ns ref target's namespace is shared and the target exists —
+        # report ok.
         assert report.ok is True, (
             f"expected ok, got entry_issues={report.entry_issues!r} "
             f"global_errors={report.global_errors!r}"

--- a/tests/v2/test_catalog_shared_flag_cache.py
+++ b/tests/v2/test_catalog_shared_flag_cache.py
@@ -1,0 +1,329 @@
+"""Tests for Story 17.4 / AC10, AC11 — per-Catalog shared-flag cache + invalidation.
+
+The resolver caches the per-namespace shared flag for the lifetime of a
+``Catalog`` instance, with cache invalidation on meta-entry mutation
+(create / update / delete).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError
+
+from .conftest import (
+    CountingEntryRepository,
+    FakeEntryRepository,
+    make_meta_entry,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+class _Leaf(BaseModel):
+    provider: str = "openai"
+
+
+class _Holder(BaseModel):
+    model_cfg: _Leaf | None = None
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture
+def model_paths(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_17_4_cache",
+        Leaf=_Leaf,
+        Holder=_Holder,
+    )
+    return f"{module_name}.Leaf", f"{module_name}.Holder"
+
+
+def _seed_team(catalog: Catalog, namespace: str) -> None:
+    catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=None,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+class TestSharedFlagCacheHit:
+    """AC10 — repeated cross-ns resolves issue exactly one ``repository.get`` per ns."""
+
+    def test_repeated_resolve_does_not_reissue_meta_lookup(
+        self, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        inner = FakeEntryRepository()
+        counting = CountingEntryRepository(inner)
+        catalog = Catalog(counting)  # type: ignore[arg-type]
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+        # Cold cache: first resolve hits the meta lookup once.
+        catalog.resolve_by_id("tenant-A", "agent-1")
+        counting.reset()
+        # Second resolve: cache should serve, no meta lookup.
+        catalog.resolve_by_id("tenant-A", "agent-1")
+        meta_lookups = sum(
+            1 for name, args, _ in counting.calls if name == "get" and args == ("global", "_meta")
+        )
+        assert meta_lookups == 0, f"expected 0 meta lookups, got {meta_lookups}: {counting.calls}"
+
+
+class TestSharedFlagCacheInvalidation:
+    """AC10 — flipping the meta entry invalidates the cache."""
+
+    def test_flip_shared_true_to_false_makes_resolve_fail(
+        self, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(repo)
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+        # Cold resolve succeeds.
+        catalog.resolve_by_id("tenant-A", "agent-1")
+
+        # Flip global meta to shared=false via update — this must invalidate
+        # the cache so the next resolve fails.
+        catalog.update(make_meta_entry("global", shared=False))
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.resolve_by_id("tenant-A", "agent-1")
+        assert "is not shared" in exc_info.value.errors[0]
+
+    def test_delete_meta_invalidates_cache(self, model_paths: tuple[str, str]) -> None:
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(repo)
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+        # Prime the cache.
+        catalog.resolve_by_id("tenant-A", "agent-1")
+
+        # Deleting the meta entry must invalidate the cache.
+        catalog.delete("global", "_meta")
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.resolve_by_id("tenant-A", "agent-1")
+        assert "is not shared" in exc_info.value.errors[0]
+
+    def test_create_meta_invalidates_cache(self, model_paths: tuple[str, str]) -> None:
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(repo)
+        # No meta on global initially.
+        _seed_team(catalog, "global")
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        # Prime the negative cache by trying a resolve that fails.
+        try:
+            catalog.resolve(
+                Entry(
+                    id="probe",
+                    kind="agent",
+                    namespace="tenant-A",
+                    user_id="alice",
+                    model_type=holder,
+                    payload={
+                        "model_cfg": {
+                            "__ref__": "shared-prompt",
+                            "__namespace__": "global",
+                        }
+                    },
+                )
+            )
+        except CatalogValidationError:
+            pass
+        # Now mark global shared by creating a meta entry — cache should
+        # invalidate so the next resolve succeeds.
+        catalog.create(make_meta_entry("global", shared=True))
+        # Now we can create the agent without hitting the gate.
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+
+
+class TestSharedFlagCachePerInstance:
+    """AC11 — the cache is per-Catalog-instance, not module-global."""
+
+    def test_two_catalogs_have_independent_caches(self) -> None:
+        repo = FakeEntryRepository()
+        c1 = Catalog(repo)
+        c2 = Catalog(repo)
+        # Independent dicts — mutating one must not affect the other.
+        c1._shared_flag_cache["global"] = True
+        assert c2._shared_flag_cache == {}
+
+
+class TestSharedFlagExactStringSemantics:
+    """AC1 — only the literal lowercase string "true" enables sharing."""
+
+    @pytest.mark.parametrize(
+        "shared_value",
+        ["false", "True", "TRUE", "1", "", "yes"],
+    )
+    def test_non_true_values_are_not_shared(
+        self, shared_value: str, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(repo)
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shared=shared_value))
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.create(
+                Entry(
+                    id="agent-1",
+                    kind="agent",
+                    namespace="tenant-A",
+                    user_id=None,
+                    model_type=holder,
+                    payload={
+                        "model_cfg": {
+                            "__ref__": "shared-prompt",
+                            "__namespace__": "global",
+                        }
+                    },
+                )
+            )
+        assert "is not shared" in exc_info.value.errors[0]

--- a/tests/v2/test_entry_repo_parity.py
+++ b/tests/v2/test_entry_repo_parity.py
@@ -188,7 +188,11 @@ class TestEntryRepositoryParity:
 
 
 class TestFindReferencesGlobalParity:
-    """Story 17.3 / AC15 — `find_references_global` parity across backends."""
+    """Story 17.4 / AC8 — `find_references_global` parity across backends.
+
+    The parameter ``scope`` was dropped — backends enumerate every namespace
+    in the repository and apply the in-memory cross-ns walker per entry.
+    """
 
     def _seed_cross_ns_referrers(self, backend: EntryRepository) -> None:
         """Seed canonical + shorthand cross-ns referrers across two tenants."""
@@ -221,7 +225,6 @@ class TestFindReferencesGlobalParity:
                 payload={"model_cfg": {"__ref__": "global.shared"}},
             )
         )
-        # Out-of-scope referrer (different namespace not in scan scope).
         backend.put(
             make_entry(
                 id="agent-C",
@@ -230,10 +233,6 @@ class TestFindReferencesGlobalParity:
                 payload={"model_cfg": {"__ref__": "global.shared"}},
             )
         )
-        # Same-ns ref (must NOT count — find_references_global excludes
-        # canonical/shorthand markers pointing at the same namespace as the
-        # entry's own namespace? Actually, the walker ALWAYS matches by
-        # target marker shape; the scope filter is applied at the scan level).
         # An unrelated entry that does not reference shared.
         backend.put(
             make_entry(
@@ -244,26 +243,18 @@ class TestFindReferencesGlobalParity:
             )
         )
 
-    def test_returns_referrers_in_scope_namespaces(self, backend: EntryRepository) -> None:
+    def test_returns_referrers_across_all_namespaces(self, backend: EntryRepository) -> None:
         self._seed_cross_ns_referrers(backend)
-        got = backend.find_references_global(
-            "global", "shared", frozenset({"tenant-A", "tenant-B"})
-        )
-        assert {e.id for e in got} == {"agent-A", "agent-B"}
-
-    def test_excludes_out_of_scope_namespaces(self, backend: EntryRepository) -> None:
-        self._seed_cross_ns_referrers(backend)
-        got = backend.find_references_global("global", "shared", frozenset({"tenant-A"}))
-        assert {e.id for e in got} == {"agent-A"}
-
-    def test_empty_scope_returns_empty(self, backend: EntryRepository) -> None:
-        self._seed_cross_ns_referrers(backend)
-        assert backend.find_references_global("global", "shared", frozenset()) == []
+        got = backend.find_references_global("global", "shared")
+        # All three referrers picked up — no scope filter.
+        assert {e.id for e in got} == {"agent-A", "agent-B", "agent-C"}
 
     def test_no_match_returns_empty(self, backend: EntryRepository) -> None:
         self._seed_cross_ns_referrers(backend)
         # Target id that no payload references.
-        got = backend.find_references_global(
-            "global", "does-not-exist", frozenset({"tenant-A", "tenant-B"})
-        )
+        got = backend.find_references_global("global", "does-not-exist")
         assert got == []
+
+    def test_empty_repo_returns_empty(self, backend: EntryRepository) -> None:
+        # Pristine backend with no entries — should not raise, returns [].
+        assert backend.find_references_global("global", "shared") == []

--- a/tests/v2/test_resolver_cross_ns.py
+++ b/tests/v2/test_resolver_cross_ns.py
@@ -1,13 +1,15 @@
-"""Tests for ``akgentic.catalog.resolver.load_model_type`` and constants.
+"""Tests for ``akgentic.catalog.resolver.load_model_type`` and the cross-ns shared-flag gate.
 
-The cross-namespace tests in this file pin ADR-008 §D2 — canonical
-``__namespace__`` sentinel + ``<ns>.<id>`` shorthand parsing, allowlist
-gate, ownership gate, cycle detection across namespaces, and the
-``populate_refs`` keyword threading.
+The cross-namespace tests in this file pin ADR-008 §D2 (updated 2026-05-08)
+— canonical ``__namespace__`` sentinel + ``<ns>.<id>`` shorthand parsing,
+shared-flag gate (target namespace's ``_meta`` carries
+``properties["shared"] == "true"``), ownership gate, cycle detection across
+namespaces, and the ``populate_refs`` ``is_namespace_shared`` keyword.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
@@ -42,8 +44,18 @@ def _model_with_reserved_field(reserved_name: str) -> type[BaseModel]:
     return _Host
 
 
+def _shared_set(*namespaces: str) -> Callable[[str], bool]:
+    """Return an ``is_namespace_shared`` callable accepting any of ``namespaces``."""
+    allowed = set(namespaces)
+
+    def _check(ns: str) -> bool:
+        return ns in allowed
+
+    return _check
+
+
 class TestResolverConstants:
-    """AC6 — REF_KEY / TYPE_KEY have the expected literal values."""
+    """REF_KEY / TYPE_KEY have the expected literal values."""
 
     def test_ref_key_value(self) -> None:
         assert REF_KEY == "__ref__"
@@ -53,7 +65,7 @@ class TestResolverConstants:
 
 
 class TestLoadModelTypeAllowlist:
-    """AC10 — non-allowlisted paths are rejected by ``load_model_type``."""
+    """Non-allowlisted paths are rejected by ``load_model_type``."""
 
     def test_rejects_os_system(self) -> None:
         with pytest.raises(CatalogValidationError) as exc_info:
@@ -71,7 +83,7 @@ class TestLoadModelTypeAllowlist:
 
 
 class TestLoadModelTypeReservedKeys:
-    """AC11 — classes declaring ``__ref__`` or ``__type__`` fields are rejected."""
+    """Classes declaring ``__ref__`` or ``__type__`` fields are rejected."""
 
     def test_ref_key_collision_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         colliding_model = _model_with_reserved_field(REF_KEY)
@@ -103,7 +115,7 @@ class TestLoadModelTypeReservedKeys:
 
 
 class TestLoadModelTypeNonBaseModel:
-    """AC12 — non-BaseModel classes are rejected."""
+    """Non-BaseModel classes are rejected."""
 
     def test_rejects_dataclass(self, monkeypatch: pytest.MonkeyPatch) -> None:
         @dataclass
@@ -120,7 +132,7 @@ class TestLoadModelTypeNonBaseModel:
         assert "is not a Pydantic BaseModel subclass" in exc_info.value.errors[0]
 
     def test_rejects_plain_function(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def some_function() -> None:  # noqa: ANN401 — irrelevant; test fixture
+        def some_function() -> None:
             return None
 
         module_name = register_akgentic_test_module(
@@ -134,7 +146,7 @@ class TestLoadModelTypeNonBaseModel:
 
 
 class TestLoadModelTypeHappyPath:
-    """AC13 — a real akgentic.* BaseModel class resolves by identity."""
+    """A real akgentic.* BaseModel class resolves by identity."""
 
     def test_loads_agent_card(self) -> None:
         from akgentic.core.agent_card import AgentCard
@@ -179,7 +191,12 @@ def coord_module(monkeypatch: pytest.MonkeyPatch) -> str:
 
 
 class TestCrossNamespaceShorthandParsing:
-    """Story 17.3 / AC3 — ``__ref__`` value with ``.`` is split on the FIRST dot."""
+    """Story 17.3 / AC3 — ``__ref__`` value with ``.`` is split on the FIRST dot.
+
+    Preserved verbatim from Story 17.3 — the parsing rules are unchanged
+    by the shared-flag migration. Only the gate name + assertion substring
+    move from ``"is not in the allowlist"`` to ``"is not shared"``.
+    """
 
     def test_single_dot_parses_ns_then_id(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
@@ -195,7 +212,7 @@ class TestCrossNamespaceShorthandParsing:
             {"__ref__": "global.prompt"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "hi"
@@ -214,13 +231,13 @@ class TestCrossNamespaceShorthandParsing:
             {"__ref__": "global.x.y.z"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "compound"
 
     def test_no_dot_is_same_namespace(self, coord_module: str) -> None:
-        """No dot ⇒ same-namespace ref, allowlist not consulted."""
+        """No dot ⇒ same-namespace ref, shared-flag gate not consulted."""
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -230,12 +247,8 @@ class TestCrossNamespaceShorthandParsing:
                 payload={"text": "local"},
             )
         )
-        result = populate_refs(
-            {"__ref__": "local-prompt"},
-            repo,
-            "tenant-A",
-            cross_namespace_refs_allowed=frozenset(),
-        )
+        # No is_namespace_shared callable — same-ns refs work unconditionally.
+        result = populate_refs({"__ref__": "local-prompt"}, repo, "tenant-A")
         assert isinstance(result, _Coord)
         assert result.text == "local"
 
@@ -243,23 +256,24 @@ class TestCrossNamespaceShorthandParsing:
         self,
         coord_module: str,  # noqa: ARG002
     ) -> None:
-        """``"."<id>"`` ⇒ namespace="" — gated by NonEmptyStr / allowlist."""
+        """``"."<id>"`` ⇒ namespace="" — gated by the shared-flag check."""
         repo = FakeEntryRepository()
-        # Empty namespace cannot be in the allowlist (NonEmptyStr is enforced
-        # on Entry.namespace) so the cross-ns gate fires.
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": ".foo"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"global"}),
+                is_namespace_shared=_shared_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not in the allowlist" in msg
+        assert "is not shared" in msg
 
 
 class TestExplicitAndShorthandAgreement:
-    """Story 17.3 / AC4 — explicit + shorthand same → ok; different → reject."""
+    """Story 17.3 / AC4 — explicit + shorthand same → ok; different → reject.
+
+    Preserved verbatim from Story 17.3 — the parsing rules are unchanged.
+    """
 
     def test_agreement_accepted(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
@@ -275,7 +289,7 @@ class TestExplicitAndShorthandAgreement:
             {"__ref__": "global.x", "__namespace__": "global"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
 
@@ -286,7 +300,7 @@ class TestExplicitAndShorthandAgreement:
                 {"__ref__": "A.x", "__namespace__": "B"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"A", "B"}),
+                is_namespace_shared=_shared_set("A", "B"),
             )
         msg = exc_info.value.errors[0]
         assert "shorthand 'ns.id' and explicit __namespace__" in msg
@@ -308,16 +322,17 @@ class TestExplicitAndShorthandAgreement:
             {"__ref__": "bare-id", "__namespace__": "global"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "verbatim"
 
 
 class TestPopulateRefsKwarg:
-    """Story 17.3 / AC6 — ``populate_refs`` accepts the keyword argument."""
+    """``populate_refs`` accepts the ``is_namespace_shared`` keyword argument."""
 
-    def test_kwarg_default_empty(self, coord_module: str) -> None:
+    def test_default_no_kwarg_same_ns(self, coord_module: str) -> None:
+        """No kwarg passed ⇒ same-ns refs work, no behaviour change."""
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -327,41 +342,41 @@ class TestPopulateRefsKwarg:
                 payload={"text": "ok"},
             )
         )
-        # Default arg ⇒ same-ns refs work, no behaviour change.
         result = populate_refs({"__ref__": "local"}, repo, "tenant-A")
         assert isinstance(result, _Coord)
 
 
-class TestCrossNamespaceAllowlistGate:
-    """Story 17.3 / AC8, AC9 — allowlist gate fires before repository lookup."""
+class TestCrossNamespaceSharedFlagGate:
+    """Story 17.4 — shared-flag gate fires before repository lookup."""
 
-    def test_empty_allowlist_rejects_cross_ns(self) -> None:
+    def test_no_shared_callable_rejects_cross_ns(self) -> None:
         repo = FakeEntryRepository()
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "global.x"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset(),
+                is_namespace_shared=None,
             )
         msg = exc_info.value.errors[0]
-        assert "is not allowed (allowlist is empty)" in msg
+        assert "is not shared" in msg
         assert "global.x" in msg
+        assert "'global'" in msg
 
-    def test_non_empty_allowlist_miss_rejects(self) -> None:
+    def test_namespace_not_shared_rejected(self) -> None:
         repo = FakeEntryRepository()
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "other-ns.x"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"global"}),
+                is_namespace_shared=_shared_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not in the allowlist" in msg
-        assert "other-ns.x" in msg
+        assert "is not shared" in msg
+        assert "'other-ns'" in msg
 
-    def test_allowlist_hit_resolves(self, coord_module: str) -> None:
+    def test_shared_namespace_resolves(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -375,26 +390,26 @@ class TestCrossNamespaceAllowlistGate:
             {"__ref__": "global.p"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "shared"
 
     def test_gate_fires_before_repo_lookup(self) -> None:
-        """Denied cross-ns ref raises allowlist error even if target id is missing."""
+        """Denied cross-ns ref raises shared-flag error even if target id is missing."""
         repo = FakeEntryRepository()  # empty repo — no global.does-not-exist
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "global.does-not-exist"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset(),
+                is_namespace_shared=None,
             )
-        # The allowlist message wins; "not found" is never reached.
-        assert "is not allowed (allowlist is empty)" in exc_info.value.errors[0]
+        # The "is not shared" message wins; "not found" is never reached.
+        assert "is not shared" in exc_info.value.errors[0]
 
-    def test_same_ns_unaffected_by_empty_allowlist(self, coord_module: str) -> None:
-        """A same-namespace ref resolves regardless of the (empty) allowlist."""
+    def test_same_ns_unaffected_by_no_shared_callable(self, coord_module: str) -> None:
+        """A same-namespace ref resolves regardless of the shared-flag callable."""
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -408,7 +423,7 @@ class TestCrossNamespaceAllowlistGate:
             {"__ref__": "p"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset(),
+            is_namespace_shared=None,
         )
         assert isinstance(result, _Coord)
 
@@ -432,7 +447,7 @@ class TestCrossNamespaceOwnershipGate:
                 {"__ref__": "global.user-p"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"global"}),
+                is_namespace_shared=_shared_set("global"),
             )
         msg = exc_info.value.errors[0]
         assert "only globally-scoped entries (user_id=None)" in msg
@@ -453,7 +468,7 @@ class TestCrossNamespaceOwnershipGate:
             {"__ref__": "global.global-p"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=_shared_set("global"),
         )
         assert isinstance(result, _Coord)
 
@@ -465,7 +480,11 @@ class _RefHolder(BaseModel):
 
 
 class TestCrossNamespaceCycleDetection:
-    """Story 17.3 / AC11 — 3-hop cross-ns cycle reuses the existing message."""
+    """Story 17.3 / AC11 — 3-hop cross-ns cycle reuses the existing message.
+
+    Preserved verbatim — cycle detection is unchanged by the shared-flag
+    migration.
+    """
 
     def test_three_hop_cross_ns_cycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Register both Coord and RefHolder as akgentic.* model_types.
@@ -498,6 +517,6 @@ class TestCrossNamespaceCycleDetection:
                 {"__ref__": "x"},
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"tenant-A", "global"}),
+                is_namespace_shared=_shared_set("tenant-A", "global"),
             )
         assert "Reference cycle detected" in exc_info.value.errors[0]

--- a/tests/v2/test_resolver_sibling_overrides.py
+++ b/tests/v2/test_resolver_sibling_overrides.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import copy
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -588,12 +589,21 @@ class TestSharedPromptAcrossAgents:
 
 
 class TestCrossNamespaceSiblingOverrides:
-    """Story 17.3 / AC12 — overrides on a cross-ns ref merge in the target's namespace."""
+    """Story 17.4 — overrides on a cross-ns ref merge in the target's namespace."""
+
+    @staticmethod
+    def _shared_set(*namespaces: str) -> Callable[[str], bool]:
+        allowed = set(namespaces)
+
+        def _check(ns: str) -> bool:
+            return ns in allowed
+
+        return _check
 
     def test_override_on_cross_ns_ref_merges(self, monkeypatch: pytest.MonkeyPatch) -> None:
         module_name = register_akgentic_test_module(
             monkeypatch,
-            "tests_fixture_17_3_sibling_target",
+            "tests_fixture_17_4_sibling_target",
             Target=Anything,
         )
         repo = FakeEntryRepository()
@@ -610,7 +620,7 @@ class TestCrossNamespaceSiblingOverrides:
             {"__ref__": "global.shared-prompt", "role": "Manager"},
             repo,
             "tenant-A",
-            cross_namespace_refs_allowed=frozenset({"global"}),
+            is_namespace_shared=self._shared_set("global"),
         )
         assert isinstance(result, Anything)
         dumped = result.model_dump()
@@ -619,13 +629,13 @@ class TestCrossNamespaceSiblingOverrides:
         # Target's other field preserved.
         assert dumped["tone"] == "calm"
 
-    def test_nested_cross_ns_ref_in_override_gated_by_allowlist(
+    def test_nested_cross_ns_ref_in_override_gated_by_shared_flag(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A nested cross-ns ref inside an override value is gated."""
         module_name = register_akgentic_test_module(
             monkeypatch,
-            "tests_fixture_17_3_sibling_nested",
+            "tests_fixture_17_4_sibling_nested",
             Target=Anything,
         )
         repo = FakeEntryRepository()
@@ -638,7 +648,7 @@ class TestCrossNamespaceSiblingOverrides:
                 payload={"x": 1},
             )
         )
-        # The override's nested ref points at a non-allowlisted namespace.
+        # The override's nested ref points at a non-shared namespace.
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {
@@ -647,8 +657,8 @@ class TestCrossNamespaceSiblingOverrides:
                 },
                 repo,
                 "tenant-A",
-                cross_namespace_refs_allowed=frozenset({"global"}),
+                is_namespace_shared=self._shared_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not in the allowlist" in msg
+        assert "is not shared" in msg
         assert "other-ns.x" in msg


### PR DESCRIPTION
## Summary

Story 17.4 — replaces the `cross_namespace_refs_allowed: frozenset[str]` constructor argument shipped by Story 17.3 with a data-driven mechanism: a namespace declares itself cross-namespace-referenceable through its own `_meta` entry's `properties["shared"] == "true"` flag.

This is an architect-sanctioned course correction (Epic 17 Addendum 2026-05-08). The allowlist API ships and is removed in adjacent PRs because no operator has had time to depend on it, and the data-driven shape removes 3-tier infra-wiring duplication (community / department / enterprise no longer thread the same `Settings`-derived `frozenset` through each `wire_*` factory).

### Changes

- `Catalog.__init__` drops the `cross_namespace_refs_allowed` keyword; instead, the catalog owns a per-instance `_shared_flag_cache: dict[str, bool]` populated lazily from `repository.get(ns, "_meta")` and invalidated on any `kind="meta"` create/update/delete.
- `create_app(...)` drops the `cross_namespace_refs_allowed` keyword.
- `populate_refs` / `prepare_for_write` / `resolve` / `validation._check_transient_validation` drop `cross_namespace_refs_allowed` and accept `is_namespace_shared: Callable[[str], bool] | None` instead.
- Resolver rejection substring moves from `"is not in the allowlist"` / `"is not allowed (allowlist is empty)"` to `"is not shared"`.
- `EntryRepository.find_references_global(namespace, target_id)` drops the `scope: frozenset[str]` argument; YAML / Mongo / Postgres backends enumerate every namespace internally.
- `Catalog.delete` runs the global-scope referrer scan only when the deleted entry's namespace is shared (`_meta.properties["shared"] == "true"`); otherwise byte-identical to the pre-17.3 baseline.
- `NamespaceMeta` docstring documents `"shared"` as the single catalog-reserved key in `properties`.
- Tests rewritten (`test_resolver_allowlist.py` → `test_resolver_cross_ns.py` via `git mv`); new `test_catalog_shared_flag_cache.py` covers cache hit, invalidation through create/update/delete, per-instance isolation, and exact-string semantics.

Closes #164

Relates to Epic 17 / ADR-008 §D2 (updated 2026-05-08).

### Architecture / ADR doc updates

The architecture-shard edits (`_bmad-output/akgentic-catalog/architecture/03..07.md`) and the ADR-08 §D2 banner + body rewrite live on the **root-repo working tree** per CLAUDE.md Golden Rule 4 (cross-repo doc-edit boundary) and are NOT committed in this submodule branch. They land in a separate root-repo docs PR.

### Quality gates

- `pytest packages/akgentic-catalog/tests/`: 874 passed, 23 skipped
- `ruff check` + `ruff format --check`: clean
- `mypy --strict`: no issues found
- Coverage: ≥ 80% maintained on every modified file
- CI: green on commit 04770d7
