### PR TITLE
Story 17.5: Extend export with external_refs section

### DIFF
--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -50,7 +50,11 @@ from akgentic.catalog.resolver import (
     validate_delete,
 )
 from akgentic.catalog.resolver import resolve as _resolve
-from akgentic.catalog.serialization import dump_namespace, load_namespace
+from akgentic.catalog.serialization import (
+    _iter_cross_ns_targets,
+    dump_namespace_v2,
+    load_namespace,
+)
 from akgentic.catalog.validation import NamespaceValidationReport, validate_entries
 from akgentic.team.models import TeamCard
 
@@ -416,19 +420,37 @@ class Catalog:
     # --- Namespace bundle export / import -------------------------------------
 
     def export_namespace_yaml(self, namespace: str) -> str:
-        """Return ``namespace`` serialised as a single-bundle YAML document.
+        """Return ``namespace`` serialised as a v2 bundle YAML document (Story 17.5).
 
-        Delegates to :func:`akgentic.catalog.serialization.dump_namespace` after
-        a single ``list_by_namespace`` call against the repository. An empty
-        namespace surfaces the bundle-must-declare-entry error from
-        ``dump_namespace`` unchanged; the router maps it to HTTP 409.
+        The v2 bundle wire format is a two-section mapping at the document
+        root: ``entries:`` (every persisted entry in ``namespace``) +
+        ``external_refs:`` (every cross-namespace target reachable from
+        ``entries``, fetched from each target's source namespace and
+        deduplicated). Targets in non-shared namespaces (per ADR-008 §D2 as
+        updated 2026-05-08 — a namespace's ``_meta`` entry must carry
+        ``properties["shared"] == "true"``) are silently omitted from
+        ``external_refs:``; missing targets are silently omitted as well.
+
+        Implementation:
+
+        1. ``entries = list_by_namespace(namespace)`` — single repository call
+           for the namespace's own entries.
+        2. ``external_refs = _collect_external_refs(entries)`` — transitively
+           reaches every cross-ns target (with cycle protection), filters
+           out non-shared and missing targets, sorts by ``(namespace, kind,
+           id)`` for stable diffs.
+        3. ``return dump_namespace_v2(entries, external_refs)``.
+
+        An empty namespace surfaces the bundle-must-declare-entry error
+        from :func:`dump_namespace_v2` unchanged; the router maps it to
+        HTTP 409.
 
         Args:
             namespace: The namespace to export.
 
         Returns:
-            YAML string following the bundle format (document-level
-            ``namespace`` + ``user_id`` + ``entries`` map).
+            YAML string following the v2 bundle format (root mapping with
+            ``entries:`` + ``external_refs:`` lists).
 
         Raises:
             CatalogValidationError: If ``namespace`` has no entries, or if
@@ -437,7 +459,92 @@ class Catalog:
                 because the Catalog service enforces ownership on write).
         """
         entries = self._repository.list_by_namespace(namespace)
-        return dump_namespace(entries)
+        external_refs = self._collect_external_refs(entries)
+        return dump_namespace_v2(entries, external_refs)
+
+    def _collect_external_refs(self, entries: _list[Entry]) -> _list[Entry]:
+        """Return the deduplicated, shared-flag-filtered, transitively-reached cross-ns targets.
+
+        Worklist algorithm (Story 17.5 Task 2):
+
+        1. Seed the worklist with every cross-ns target reachable from
+           ``entries[*].payload`` via :func:`_iter_cross_ns_targets`,
+           skipping pairs whose namespace is the bundle's own namespace
+           (AC7 — same-namespace short-circuit even when the marker carried
+           an explicit ``__namespace__`` matching the bundle's namespace).
+        2. Maintain a ``visited`` set of ``(namespace, id)`` pairs already
+           processed (cycle protection — same shape as the resolver's
+           cycle set).
+        3. For each pair popped from the worklist:
+           - Skip if already in ``visited``.
+           - Skip if the target namespace is not shared (AC5 — silent
+             omission per ADR-008 §D2).
+           - Try ``repository.get(target_ns, target_id)``; on
+             ``EntryNotFoundError`` semantics (``None``), skip silently
+             (AC6).
+           - Append to the result list and mark visited.
+           - Walk the target's payload via ``_iter_cross_ns_targets``;
+             enqueue every produced pair whose target namespace is NOT the
+             bundle's namespace AND NOT the target entry's own namespace
+             (AC9 — same-namespace refs inside a cross-ns target's payload
+             do NOT widen the section).
+        4. Sort the result by ``(namespace, kind, id)`` ascending (AC4).
+
+        Returns an empty list when ``entries`` is empty or carries no
+        cross-ns refs. The ``visited`` set IS used to short-circuit
+        re-processing — repeated pops of the same pair never re-fetch the
+        repository (cycle protection).
+
+        Args:
+            entries: The persisted entries of the bundle's namespace
+                (uniform-namespace invariant assumed — same as
+                :func:`dump_namespace`).
+
+        Returns:
+            The deduplicated, sorted list of cross-namespace target
+            entries reachable from ``entries``. An empty list when no
+            shared cross-ns targets are reachable.
+        """
+        if not entries:
+            return []
+
+        bundle_namespace = entries[0].namespace
+        worklist: _list[tuple[str, str]] = []
+        for entry in entries:
+            for target_ns, target_id in _iter_cross_ns_targets(entry.payload):
+                if target_ns != bundle_namespace:
+                    worklist.append((target_ns, target_id))
+
+        visited: set[tuple[str, str]] = set()
+        collected: _list[Entry] = []
+
+        while worklist:
+            target_ns, target_id = worklist.pop(0)
+            key = (target_ns, target_id)
+            if key in visited:
+                continue
+            visited.add(key)
+            if not self._is_namespace_shared(target_ns):
+                continue
+            target_entry = self._repository.get(target_ns, target_id)
+            if target_entry is None:
+                continue
+            collected.append(target_entry)
+            for nested_ns, nested_id in _iter_cross_ns_targets(target_entry.payload):
+                # AC9: same-ns refs inside a cross-ns target's payload do NOT
+                # widen external_refs (the local refs belong to the target's
+                # own namespace; the frontend renders the target as opaque).
+                if nested_ns == target_ns:
+                    continue
+                # AC7: cross-ns refs that resolve back to the bundle's own
+                # namespace are not external refs.
+                if nested_ns == bundle_namespace:
+                    continue
+                worklist.append((nested_ns, nested_id))
+
+        # AC4 — sort by (namespace, kind, id) for stable diffs.
+        collected.sort(key=lambda e: (e.namespace, e.kind, e.id))
+        return collected
 
     def import_namespace_yaml(self, yaml_text: str) -> _list[Entry]:
         """Import a bundle YAML document as an atomic namespace replacement.

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -31,7 +31,22 @@ from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.repositories.yaml import _BlockScalarDumper
 
-__all__ = ["dump_namespace", "load_namespace"]
+# Local copies of the resolver-layer ref-marker sentinel keys, kept here so
+# the serialization module remains independent of resolver imports (resolver
+# in turn does NOT import serialization, preserving a clean acyclic shape).
+# These values are the single-source-of-truth strings ``"__ref__"`` /
+# ``"__namespace__"`` defined at module load time in ``catalog/resolver.py``.
+_REF_KEY: str = "__ref__"
+_NAMESPACE_KEY: str = "__namespace__"
+_TYPE_KEY: str = "__type__"
+_RESERVED_REF_KEYS: frozenset[str] = frozenset({_REF_KEY, _NAMESPACE_KEY, _TYPE_KEY})
+
+__all__ = [
+    "_iter_cross_ns_targets",
+    "dump_namespace",
+    "dump_namespace_v2",
+    "load_namespace",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -237,26 +252,310 @@ def _entry_to_map(entry: Entry) -> dict[str, Any]:
     }
 
 
+# --- dump_namespace_v2 (Story 17.5) -----------------------------------------
+
+
+def dump_namespace_v2(entries: list[Entry], external_refs: list[Entry]) -> str:
+    """Serialise a namespace + cross-ns targets to the v2 bundle YAML.
+
+    The v2 bundle wire format is a two-section mapping at the document root:
+
+    * ``entries:`` — a **list** of full per-entry maps (one item per persisted
+      entry in the namespace), in the same kind / id order produced by
+      :func:`dump_namespace` (team → meta → agent → prompt → tool → model;
+      sorted by ``id`` within each kind). The visual section-header comments
+      from :func:`dump_namespace` are preserved inside this block.
+    * ``external_refs:`` — a **list** of full per-entry maps from other
+      namespaces, sorted by ``(namespace, kind, id)`` ascending. The frontend
+      uses these to render readonly cards for cross-namespace targets without
+      additional round-trips.
+
+    Each list item carries the full ``Entry`` shape — ``id``, ``namespace``,
+    ``user_id``, ``kind``, ``model_type``, ``parent_namespace``,
+    ``parent_id``, ``description``, ``payload``. Lists are used (rather than
+    a dict keyed by id) because ``external_refs`` items live in foreign
+    namespaces and a dict-keyed shape would collapse same-id entries from
+    different namespaces. Both lists use the same shape for symmetry.
+
+    Args:
+        entries: The non-empty namespace-bounded entry list (same uniform-
+            owner / uniform-namespace invariants as :func:`dump_namespace`).
+        external_refs: The deduplicated, sorted list of cross-namespace target
+            entries reachable from ``entries`` (sourced from each target's
+            own namespace via the catalog service). May be empty.
+
+    Returns:
+        A YAML document string emitting the two-section mapping with the
+        same ``_BlockScalarDumper`` configuration as :func:`dump_namespace`,
+        post-processed to add section headers inside the ``entries:`` block.
+
+    Raises:
+        CatalogValidationError: When ``entries`` is empty (same message as
+            :func:`dump_namespace`), or when ``entries`` violates the
+            uniform-owner / uniform-namespace invariants.
+    """
+    if not entries:
+        raise CatalogValidationError(
+            ["bundle must declare at least one entry, including a `kind=team` entry"]
+        )
+
+    errors: list[str] = []
+    errors.extend(_check_uniform_owner(entries))
+    errors.extend(_check_uniform_namespace(entries))
+    if errors:
+        raise CatalogValidationError(errors)
+
+    sorted_entries = _sort_entries_for_emit(entries)
+    # AC4 — sort externals lexicographically on (namespace, kind, id), NOT
+    # by ``_KIND_EMIT_ORDER``. Lexicographic kind order keeps the diff
+    # stable under future kind additions; the consumption-graph ordering
+    # of ``entries:`` is a display projection that does not extend to
+    # foreign-namespace entries.
+    sorted_external = sorted(external_refs, key=lambda e: (e.namespace, e.kind, e.id))
+
+    doc: dict[str, Any] = {
+        "entries": [_full_entry_to_map(e) for e in sorted_entries],
+        "external_refs": [_full_entry_to_map(e) for e in sorted_external],
+    }
+    raw = yaml.dump(
+        doc,
+        Dumper=_BlockScalarDumper,
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    return _format_bundle_v2_sections(raw)
+
+
+def _full_entry_to_map(entry: Entry) -> dict[str, Any]:
+    """Return a per-entry YAML map carrying every persisted ``Entry`` field.
+
+    Used by :func:`dump_namespace_v2` for both ``entries:`` and
+    ``external_refs:`` items. Each item is self-contained — it carries its
+    own ``id`` / ``namespace`` / ``user_id`` rather than relying on the
+    document-level inheritance used by the legacy :func:`dump_namespace`
+    shape.
+    """
+    return {
+        "id": entry.id,
+        "namespace": entry.namespace,
+        "user_id": entry.user_id,
+        "kind": entry.kind,
+        "model_type": entry.model_type,
+        "parent_namespace": entry.parent_namespace,
+        "parent_id": entry.parent_id,
+        "description": entry.description,
+        "payload": entry.payload,
+    }
+
+
+# Regex matching the start of a list item under ``entries:`` in the v2 dump
+# emitted by PyYAML with ``default_flow_style=False``: 2 spaces, dash, space,
+# ``id:``. Items in ``external_refs:`` are formatted identically; the
+# post-processor distinguishes the two blocks by walking from the
+# ``entries:`` line to the ``external_refs:`` line.
+_V2_ITEM_START_RE = re.compile(r"^- id: ")
+# In v2 dumps each list item begins at column 0 (PyYAML emits ``- ...`` at
+# the document-relative indent of its enclosing key, which for ``entries:``
+# at the root is column 0). The ``id`` field is the first key of the item,
+# so the very first line of every item starts with ``- id: ``.
+_V2_ITEM_KIND_RE = re.compile(r"^  kind: ([a-z]+)$")
+
+
+def _format_bundle_v2_sections(yaml_text: str) -> str:
+    """Post-process v2 bundle YAML to insert section headers inside ``entries:``.
+
+    Walks the document, locates the ``entries:`` block, and for each list
+    item under it (a line beginning with ``- id: ``) inserts a kind-section
+    header (from ``_KIND_HEADERS``) when the kind transitions, plus blank-
+    line separators between items. The ``external_refs:`` block (and any
+    other top-level block) is left untouched — section headers belong to
+    the namespace's own entries, not to foreign-namespace targets.
+    """
+    lines = yaml_text.rstrip("\n").split("\n")
+    entries_idx = _find_top_level_key_line(lines, "entries:")
+    external_idx = _find_top_level_key_line(lines, "external_refs:")
+    if entries_idx is None:
+        # Defensive: dump_namespace_v2 always produces an entries: block.
+        return yaml_text  # pragma: no cover
+
+    end_idx = external_idx if external_idx is not None else len(lines)
+    head = lines[: entries_idx + 1]
+    body = lines[entries_idx + 1 : end_idx]
+    tail = lines[end_idx:]
+
+    formatted_body = _format_v2_entries_block(body)
+    return "\n".join(head + formatted_body + tail) + "\n"
+
+
+def _find_top_level_key_line(lines: list[str], key_line: str) -> int | None:
+    """Return the index of the first line equal to ``key_line`` at column 0."""
+    for i, line in enumerate(lines):
+        if line == key_line:
+            return i
+    return None
+
+
+def _format_v2_entries_block(body: list[str]) -> list[str]:
+    """Insert kind-section headers and blank-line separators in the entries body.
+
+    ``body`` is the slice of YAML lines between ``entries:`` and the next
+    top-level key (``external_refs:`` or end of document). Items begin with
+    a line matching ``_V2_ITEM_START_RE`` and continue until the next item
+    or the end of the slice.
+    """
+    output: list[str] = []
+    last_kind: str | None = None
+    for i, line in enumerate(body):
+        if _V2_ITEM_START_RE.match(line):
+            kind = _peek_v2_kind(body, i)
+            if kind != last_kind:
+                output.append("")
+                output.append(_KIND_HEADERS[kind])
+                last_kind = kind
+            else:
+                output.append("")
+        output.append(line)
+    return output
+
+
+def _peek_v2_kind(lines: list[str], i: int) -> str:
+    """Return the kind value from the v2 list item starting at index ``i``.
+
+    Each v2 item carries a ``kind:`` field on its own line at indent 2 (the
+    item's interior indent). The header line is two-space indent + ``kind:
+    <value>``.
+    """
+    for j in range(i + 1, len(lines)):
+        m = _V2_ITEM_KIND_RE.match(lines[j])
+        if m:
+            return m.group(1)
+    raise AssertionError("unreachable: every v2 item must declare `kind:`")
+
+
+# --- Cross-namespace ref walker (Story 17.5 Task 1) -------------------------
+
+
+def _iter_cross_ns_targets(payload: Any) -> list[tuple[str, str]]:
+    """Return every ``(target_namespace, target_id)`` reachable through cross-ns ref markers.
+
+    Walks the payload tree recursively and collects every dict node carrying
+    a ``__ref__`` entry that resolves to a cross-namespace target. The
+    walker recognises the same two cross-ns shapes as the resolver:
+
+    * **Canonical** — a sibling ``__namespace__`` key on the ref marker.
+    * **Shorthand** — a ``<ns>.<id>`` form in the ``__ref__`` value (split
+      on the first dot only, matching :func:`_resolve_target_namespace` in
+      the resolver).
+
+    Same-namespace markers (no ``__namespace__``, no dot in ``__ref__``)
+    are excluded — they do not belong in ``external_refs:``.
+
+    The walker is **parse-only**:
+
+    * No call to :func:`populate_refs`.
+    * No Pydantic validation.
+    * No repository access.
+    * No allowlist or shared-flag check (the shared-flag gate fires later,
+      when the catalog service decides whether to fetch the target).
+
+    Sibling-override sub-payloads (architecture/03 — non-reserved keys
+    alongside ``__ref__`` / ``__namespace__`` / ``__type__``) are walked
+    recursively, so a cross-ns ref marker that ALSO carries an override
+    sub-payload containing another cross-ns ref yields both targets.
+
+    Args:
+        payload: An ``Entry.payload`` tree — arbitrary nested ``dict`` /
+            ``list`` of JSON-able primitives.
+
+    Returns:
+        A flat list of ``(target_namespace, target_id)`` tuples in
+        depth-first traversal order. Duplicates are NOT removed at this
+        layer (the caller — :meth:`Catalog._collect_external_refs` — owns
+        deduplication so the worklist + visited-set algorithm operates on
+        the raw walker output).
+    """
+    results: list[tuple[str, str]] = []
+    _walk_for_cross_ns(payload, results)
+    return results
+
+
+def _walk_for_cross_ns(node: Any, out: list[tuple[str, str]]) -> None:
+    """Recursive helper for :func:`_iter_cross_ns_targets`."""
+    if isinstance(node, dict):
+        if _REF_KEY in node:
+            pair = _classify_cross_ns_marker(node)
+            if pair is not None:
+                out.append(pair)
+            # Walk sibling-override values (keys other than the reserved set)
+            # — they may themselves carry nested cross-ns refs. We do NOT
+            # recurse into the reserved keys themselves (``__namespace__`` is
+            # a string; ``__type__`` is a string; ``__ref__`` is a string or
+            # the shorthand we already classified).
+            for key, value in node.items():
+                if key not in _RESERVED_REF_KEYS:
+                    _walk_for_cross_ns(value, out)
+            return
+        for value in node.values():
+            _walk_for_cross_ns(value, out)
+        return
+    if isinstance(node, list):
+        for item in node:
+            _walk_for_cross_ns(item, out)
+
+
+def _classify_cross_ns_marker(node: dict[str, Any]) -> tuple[str, str] | None:
+    """Return ``(target_namespace, target_id)`` for a cross-ns ref marker, else ``None``.
+
+    The classification mirrors the resolver's
+    :func:`_resolve_target_namespace`:
+
+    * If ``__ref__`` is a string containing a dot, the first-dot split
+      yields ``(namespace, id)`` — this is the shorthand form.
+    * Else if ``__namespace__`` is set explicitly, the pair is
+      ``(__namespace__, __ref__)``.
+    * Otherwise the marker is same-namespace and ``None`` is returned.
+    """
+    raw_ref = node.get(_REF_KEY)
+    if isinstance(raw_ref, str) and "." in raw_ref:
+        ns, rid = raw_ref.split(".", 1)
+        return ns, rid
+    explicit_ns = node.get(_NAMESPACE_KEY)
+    if isinstance(explicit_ns, str) and isinstance(raw_ref, str):
+        return explicit_ns, raw_ref
+    return None
+
+
 # --- load_namespace ---------------------------------------------------------
 
 
 def load_namespace(yaml_text: str) -> list[Entry]:
     """Parse a bundle YAML document and return the list of reconstructed entries.
 
-    The parser is structurally strict: the root must be a ``dict`` with
-    ``namespace`` (non-empty ``str``), ``user_id`` (``str | None``), and
-    ``entries`` (non-empty ``dict``). Any missing or wrong-typed key accumulates
-    into a single ``CatalogValidationError`` — the error list is NOT
-    short-circuited after the first failure so frontends can render every
-    issue in one pass.
+    Two wire shapes are accepted:
 
-    Each ``(entry_id, entry_map)`` pair becomes an ``Entry`` whose ``id`` is
-    the outer key, and whose ``namespace`` and ``user_id`` come from the
-    document context. The six per-entry keys (``kind``, ``model_type``,
-    ``parent_namespace``, ``parent_id``, ``description``, ``payload``) are
-    consumed verbatim. Any Pydantic ``ValidationError`` raised by ``Entry``
-    construction is wrapped in ``CatalogValidationError`` with the substring
-    ``"entry '<id>' is invalid"`` so the offending id surfaces in UI toasts.
+    * **v2 (Story 17.5)** — root is a ``dict`` with at least an ``entries``
+      key whose value is a ``list`` (full per-entry maps, each carrying its
+      own ``id`` / ``namespace`` / ``user_id``); an optional
+      ``external_refs`` key carries cross-namespace targets and is **ignored
+      on import** (those entries belong to other namespaces and are not
+      part of THIS namespace's atomic-replace contents).
+
+    * **Legacy (Story 16.2 — pre-17.5)** — root is a ``dict`` with
+      ``namespace`` (non-empty ``str``), ``user_id`` (``str | None``), and
+      ``entries`` whose value is a ``dict`` keyed by id; ``namespace`` and
+      ``user_id`` are inherited document-wide.
+
+    Shape detection is unambiguous because the legacy ``entries`` is always
+    a ``dict`` and the v2 ``entries`` is always a ``list``. When the root
+    contains an ``external_refs`` key, the v2 shape is selected even if
+    ``entries`` is missing (so a bundle with an empty namespace cannot
+    masquerade as legacy). The v2 path validates each entry's map shape
+    individually; the legacy path uses ``_validate_root_shape`` as before.
+
+    Any Pydantic ``ValidationError`` raised by ``Entry`` construction is
+    wrapped in ``CatalogValidationError`` with the substring ``"entry
+    '<id>' is invalid"`` so the offending id surfaces in UI toasts.
 
     The function is parse-only: it does NOT call ``prepare_for_write``, does
     NOT touch a repository, and does NOT persist anything. Callers that want
@@ -266,14 +565,110 @@ def load_namespace(yaml_text: str) -> list[Entry]:
         yaml_text: The full bundle YAML document as a string.
 
     Returns:
-        The list of parsed ``Entry`` instances in dict-iteration order
-        (PyYAML yields keys in document order).
+        The list of parsed ``Entry`` instances in document order. For a v2
+        bundle, only the ``entries:`` items are returned — ``external_refs:``
+        items are silently dropped (they belong to other namespaces).
 
     Raises:
         CatalogValidationError: On malformed YAML, structural failures,
-            empty entries dict, or per-entry construction failures.
+            empty entries collection, or per-entry construction failures.
     """
     doc = _parse_yaml(yaml_text)
+    if not isinstance(doc, dict):
+        raise CatalogValidationError([f"bundle root must be a mapping, got {type(doc).__name__}"])
+    if _is_v2_bundle_shape(doc):
+        return _load_v2_entries(doc)
+    return _load_legacy_entries(doc)
+
+
+def _is_v2_bundle_shape(doc: dict[str, Any]) -> bool:
+    """Return ``True`` when ``doc`` is a v2 bundle (Story 17.5 wire shape).
+
+    The discriminator is unambiguous:
+
+    * The legacy shape's ``entries`` is always a ``dict`` (``namespace`` /
+      ``user_id`` siblings sit alongside it).
+    * The v2 shape's ``entries`` is always a ``list``; the document also
+      may carry an ``external_refs`` list.
+
+    Cases handled:
+
+    * ``entries`` present and is a ``list`` ⇒ v2.
+    * ``external_refs`` present (regardless of ``entries`` shape) ⇒ v2.
+    * Otherwise ⇒ legacy (the legacy validator will report missing /
+      wrong-typed keys as today).
+    """
+    entries = doc.get("entries")
+    if isinstance(entries, list):
+        return True
+    if "external_refs" in doc:
+        return True
+    return False
+
+
+def _load_v2_entries(doc: dict[str, Any]) -> list[Entry]:
+    """Parse the v2 bundle shape into a list of ``Entry`` instances.
+
+    ``doc["entries"]`` MUST be a ``list``. ``external_refs`` is ignored —
+    those items belong to other namespaces and are not part of this
+    namespace's atomic-replace contents. Each entry item carries its own
+    ``id`` / ``namespace`` / ``user_id`` so the function does not need to
+    inherit document-level fields.
+    """
+    entries_value = doc.get("entries")
+    if not isinstance(entries_value, list):
+        # External_refs-only document with no entries — surface as an empty
+        # bundle, same shape as the legacy empty-entries error so callers
+        # can rely on the substring.
+        raise CatalogValidationError(
+            ["bundle must declare at least one entry, including a `kind=team` entry"]
+        )
+    if not entries_value:
+        raise CatalogValidationError(
+            ["bundle must declare at least one entry, including a `kind=team` entry"]
+        )
+
+    return [_build_v2_entry(item) for item in entries_value]
+
+
+def _build_v2_entry(item: Any) -> Entry:
+    """Build a single ``Entry`` from a v2 list-item map.
+
+    The v2 item carries every ``Entry`` field directly — ``id`` /
+    ``namespace`` / ``user_id`` are NOT inherited from a document-level
+    context (they sit on each item, which is what makes ``external_refs:``
+    items self-contained when they live in foreign namespaces).
+    """
+    if not isinstance(item, dict):
+        raise CatalogValidationError(
+            [f"v2 bundle entry is invalid: expected a mapping, got {type(item).__name__}"]
+        )
+    entry_id = item.get("id", "<missing>")
+    try:
+        return Entry.model_validate(
+            {
+                "id": item.get("id"),
+                "namespace": item.get("namespace"),
+                "user_id": item.get("user_id"),
+                "kind": item.get("kind"),
+                "model_type": item.get("model_type"),
+                "parent_namespace": item.get("parent_namespace"),
+                "parent_id": item.get("parent_id"),
+                "description": item.get("description", ""),
+                "payload": item.get("payload", {}),
+            }
+        )
+    except ValidationError as exc:
+        raise CatalogValidationError([f"entry '{entry_id}' is invalid: {exc}"]) from exc
+
+
+def _load_legacy_entries(doc: dict[str, Any]) -> list[Entry]:
+    """Parse the legacy (Story 16.2) bundle shape into a list of ``Entry`` instances.
+
+    The legacy shape is a root ``dict`` carrying ``namespace`` /
+    ``user_id`` siblings and an ``entries`` dict keyed by id. Structural
+    failures accumulate into a single ``CatalogValidationError``.
+    """
     structural_errors = _validate_root_shape(doc)
     if structural_errors:
         raise CatalogValidationError(structural_errors)

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -576,6 +576,7 @@ class TestNamespaceExport:
     """GET /catalog/namespace/{namespace}/export — AC23, AC25."""
 
     def test_export_happy_path(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """Story 17.5 v2 shape: root has ``entries:`` (list) + ``external_refs:`` (list)."""
         import yaml
 
         client, catalog = api_client
@@ -585,14 +586,180 @@ class TestNamespaceExport:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/yaml")
         doc = yaml.safe_load(response.text)
-        assert list(doc.keys()) == ["namespace", "user_id", "entries"]
-        assert doc["namespace"] == "ns-exp"
-        assert set(doc["entries"].keys()) == {"team", "a-1"}
+        # v2 shape: top-level keys in order are entries, external_refs.
+        assert list(doc.keys()) == ["entries", "external_refs"]
+        assert isinstance(doc["entries"], list)
+        assert isinstance(doc["external_refs"], list)
+        assert {e["id"] for e in doc["entries"]} == {"team", "a-1"}
+        # No cross-ns refs were seeded — external_refs is the canonical empty list.
+        assert doc["external_refs"] == []
+        # Per-entry shape carries id, namespace, user_id directly.
+        team_item = next(e for e in doc["entries"] if e["id"] == "team")
+        assert team_item["namespace"] == "ns-exp"
+        assert team_item["user_id"] == "alice"
 
     def test_export_empty_namespace_409(self, api_client: tuple[TestClient, Catalog]) -> None:
         client, _ = api_client
         response = client.get("/catalog/namespace/nope/export")
         assert response.status_code == 409
+
+
+class TestNamespaceExportImportV2:
+    """Story 17.5 — HTTP-level coverage of the new v2 wire shape on both endpoints."""
+
+    def test_export_carries_external_refs_for_cross_ns_targets(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """v2 ``GET /export`` carries ``external_refs:`` resolved from shared namespaces."""
+        import yaml
+
+        from akgentic.catalog.models.entry import Entry as _Entry
+
+        from .conftest import make_meta_entry
+
+        client, catalog = api_client
+        # Seed shared global with one model target.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            _Entry(
+                id="m1",
+                kind="model",
+                namespace="global",
+                user_id=None,
+                model_type="akgentic.llm.config.ModelConfig",
+                payload={"provider": "openai"},
+            )
+        )
+        # Seed tenant with one agent that references global.m1 — bypass
+        # populate_refs (the agent's payload uses a free-form key the
+        # AgentCard model would reject) by writing through the repository
+        # directly. We only exercise the export-side projection here.
+        _seed_team(catalog, "tenant-V2", user_id=None)
+        # Use an agent payload that AgentCard accepts; stash the ref in a
+        # tolerated optional field. AgentCard's metadata field is dict[str, Any].
+        catalog.create(
+            _Entry(
+                id="a-1",
+                kind="agent",
+                namespace="tenant-V2",
+                user_id=None,
+                model_type=_AGENT_TYPE,
+                payload={
+                    "role": "r",
+                    "description": "",
+                    "skills": [],
+                    "agent_class": "akgentic.core.agent.Akgent",
+                    "config": {"name": "a-1", "role": "r"},
+                    "routes_to": [],
+                    "metadata": {"shared_ref": {"__ref__": "global.m1"}},
+                },
+            )
+        )
+        response = client.get("/catalog/namespace/tenant-V2/export")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/yaml")
+        doc = yaml.safe_load(response.text)
+        # v2 shape: entries (list) + external_refs (list).
+        assert list(doc.keys()) == ["entries", "external_refs"]
+        assert {e["id"] for e in doc["entries"]} == {"team", "a-1"}
+        ext_keys = {(e["namespace"], e["id"]) for e in doc["external_refs"]}
+        assert ext_keys == {("global", "m1")}
+
+    def test_import_accepts_v2_shape(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """``POST /import`` accepts the v2 mapping shape."""
+        from akgentic.catalog.models.entry import Entry as _Entry
+        from akgentic.catalog.serialization import dump_namespace_v2
+
+        client, _ = api_client
+        team_entry = _Entry(
+            id="team",
+            kind="team",
+            namespace="ns-v2-imp",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        agent_entry = _Entry(
+            id="a",
+            kind="agent",
+            namespace="ns-v2-imp",
+            user_id="alice",
+            model_type=_AGENT_TYPE,
+            payload=_agent_payload("a"),
+        )
+        yaml_text = dump_namespace_v2([team_entry, agent_entry], [])
+        response = client.post(
+            "/catalog/namespace/import",
+            content=yaml_text.encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert {e["id"] for e in data} == {"team", "a"}
+
+    def test_import_accepts_legacy_shape(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """``POST /import`` accepts the legacy flat-list shape — backward compat (AC11)."""
+        import yaml as _yaml
+
+        client, _ = api_client
+        doc = {
+            "namespace": "ns-legacy-imp-http",
+            "user_id": "alice",
+            "entries": {
+                "team": {
+                    "kind": "team",
+                    "model_type": _TEAM_TYPE,
+                    "parent_namespace": None,
+                    "parent_id": None,
+                    "description": "",
+                    "payload": _team_payload(),
+                },
+                "a": {
+                    "kind": "agent",
+                    "model_type": _AGENT_TYPE,
+                    "parent_namespace": None,
+                    "parent_id": None,
+                    "description": "",
+                    "payload": _agent_payload("a"),
+                },
+            },
+        }
+        yaml_text = _yaml.safe_dump(doc, sort_keys=False)
+        response = client.post(
+            "/catalog/namespace/import",
+            content=yaml_text.encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert {e["id"] for e in data} == {"team", "a"}
+
+    def test_export_then_import_v2_round_trip(self, api_client: tuple[TestClient, Catalog]) -> None:
+        """Round-trip: export → import the resulting v2 YAML into a different namespace."""
+        import yaml
+
+        client, catalog = api_client
+        _seed_team(catalog, "rt-src", user_id="alice")
+        _seed_agent(catalog, "rt-src", id="a-rt", user_id="alice")
+
+        export_resp = client.get("/catalog/namespace/rt-src/export")
+        assert export_resp.status_code == 200
+        v2_text = export_resp.text
+        # Rewrite per-entry namespace src → dst.
+        v2_for_dst = v2_text.replace("namespace: rt-src", "namespace: rt-dst")
+
+        import_resp = client.post(
+            "/catalog/namespace/import",
+            content=v2_for_dst.encode("utf-8"),
+            headers={"Content-Type": "application/yaml"},
+        )
+        assert import_resp.status_code == 201
+        # Verify dst-ns now carries the same ids.
+        re_export = client.get("/catalog/namespace/rt-dst/export")
+        assert re_export.status_code == 200
+        doc = yaml.safe_load(re_export.text)
+        assert {e["id"] for e in doc["entries"]} == {"team", "a-rt"}
 
 
 class TestNamespaceImport:

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -16,7 +16,11 @@ from pydantic import BaseModel
 from akgentic.catalog.catalog import Catalog
 from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
-from akgentic.catalog.serialization import dump_namespace, load_namespace
+from akgentic.catalog.serialization import (
+    dump_namespace,
+    dump_namespace_v2,
+    load_namespace,
+)
 
 from .conftest import (
     CatalogFactory,
@@ -132,15 +136,18 @@ class TestExportNamespaceYaml:
             catalog.export_namespace_yaml("nope")
 
     def test_export_round_trip_idempotent(self, catalog_factory: CatalogFactory) -> None:
+        """Story 17.5: export → re-export is byte-identical for the v2 wire shape."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "ns-rt")
         _seed_agent(catalog, "ns-rt", "a")
         _seed_agent(catalog, "ns-rt", "b")
         yaml_text = catalog.export_namespace_yaml("ns-rt")
-        parsed = load_namespace(yaml_text)
-        # dump → load → dump yields the same yaml.
-        again = dump_namespace(parsed)
+        again = catalog.export_namespace_yaml("ns-rt")
+        # Two consecutive exports against unchanged state ⇒ byte-identical YAML.
         assert again == yaml_text
+        # And the v2 shape parses to entries (load_namespace handles both shapes).
+        parsed = load_namespace(yaml_text)
+        assert {e.id for e in parsed} == {"team", "a", "b"}
 
 
 # --- Import -----------------------------------------------------------------
@@ -528,7 +535,7 @@ class TestImportBundleCrossNs:
                 namespace="global",
                 user_id=None,
                 model_type=leaf_type,
-                payload={"provider": "shared"},
+                payload={"provider": "openai"},
             )
         )
         bundle = [
@@ -627,3 +634,715 @@ class TestImportBundleCrossNs:
         msg = " | ".join(exc_info.value.errors)
         assert "not found in namespace" in msg
         assert "global" in msg
+
+
+# --- Story 17.5 — Export external_refs ------------------------------------
+
+
+class _OpenLeafModel(BaseModel):
+    """Permissive leaf payload model — accepts arbitrary ref-style sub-payloads.
+
+    Used by Story 17.5 export-side tests where the test seeds cross-ns
+    targets whose payloads themselves carry refs (transitive reachability,
+    cycle protection). The ``ConfigDict(extra='allow')`` accepts the
+    populated/resolved sub-payload values that ``populate_refs`` produces
+    at validation time, plus arbitrary leaf fields the tests stash.
+    """
+
+    model_config = {"extra": "allow"}
+    provider: str = "openai"
+
+
+class _OpenAgentModel(BaseModel):
+    """Permissive agent payload model — accepts arbitrary ref-style sub-payloads.
+
+    Mirrors :class:`_OpenLeafModel` for entries seeded as ``kind="agent"``.
+    Story 17.5's tests stash cross-ns ref markers under arbitrary keys
+    (``model_cfg``, ``list``, ``ref``, …) so the model must accept any
+    field at validation time without rejecting unknown keys.
+    """
+
+    model_config = {"extra": "allow"}
+    provider: str = "openai"
+
+
+def _register_open_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    """Register the permissive agent/leaf payload models; return (agent_type, leaf_type) FQCNs."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_17_5_open",
+        _OpenAgentModel=_OpenAgentModel,
+        _OpenLeafModel=_OpenLeafModel,
+    )
+    return f"{module_name}._OpenAgentModel", f"{module_name}._OpenLeafModel"
+
+
+def _seed_shared_namespace_with_targets(
+    catalog: Catalog,
+    namespace: str,
+    user_id: str | None,
+    target_ids: list[str],
+    leaf_type: str | None = None,
+) -> str:
+    """Seed a shared namespace (team + meta with shared=true) and N model-kind targets.
+
+    Returns the leaf-type FQCN used for the seeded targets so callers can
+    pass it back when constructing referring agents. If ``leaf_type`` is
+    ``None``, the test stub ``_LeafPayloadModel`` registered by
+    :func:`_register_agent_models` is assumed to already be importable in
+    the current process — callers MUST pass a registered FQCN explicitly.
+    """
+    assert leaf_type is not None, "callers must pass an already-registered leaf_type FQCN"
+    _seed_team(catalog, namespace, user_id=user_id)
+    catalog.create(make_meta_entry(namespace, shared=True, user_id=user_id))
+    for tid in target_ids:
+        catalog.create(
+            Entry(
+                id=tid,
+                kind="model",
+                namespace=namespace,
+                user_id=user_id,
+                model_type=leaf_type,
+                payload={"provider": "openai", "temperature": 0.0},
+            )
+        )
+    return leaf_type
+
+
+def _seed_referrer_agent(
+    catalog: Catalog,
+    namespace: str,
+    agent_id: str,
+    payload: dict[str, Any],
+    user_id: str | None,
+    agent_type: str,
+) -> Entry:
+    """Seed a single agent in ``namespace`` whose payload carries cross-ns refs.
+
+    ``agent_type`` is the FQCN registered for the permissive
+    ``_OpenAgentModel`` via :func:`_register_open_models` so the test's
+    payload accepts any field shape (refs, lists, nested overrides).
+    """
+    return catalog.create(
+        Entry(
+            id=agent_id,
+            kind="agent",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=agent_type,
+            payload=payload,
+        )
+    )
+
+
+class TestExportExternalRefs:
+    """Story 17.5 ACs 3, 5, 6, 7, 8, 9 — ``external_refs:`` content semantics.
+
+    Tests directly exercise the catalog service's repository to seed
+    cross-ns ref scenarios that ``populate_refs`` would otherwise reject —
+    the export endpoint is a display projection, NOT a validator, so the
+    tests focus on what export emits given persisted state, not on whether
+    that state was reachable through the create pipeline.
+    """
+
+    def test_no_cross_ns_refs_yields_empty_external_refs(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """A namespace with no cross-ns refs exports ``external_refs: []``."""
+        import yaml
+
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-clean", user_id="alice")
+        _seed_agent(catalog, "tenant-clean", "a", user_id="alice")
+        text = catalog.export_namespace_yaml("tenant-clean")
+        doc = yaml.safe_load(text)
+        assert doc["external_refs"] == []
+
+    def test_one_cross_ns_ref_yields_one_external(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One agent with one cross-ns ref ⇒ one ``external_refs:`` entry."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=["m1"], leaf_type=leaf_type
+        )
+        _seed_team(catalog, "tenant-A", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-A",
+            "a",
+            payload={"model_cfg": {"__ref__": "m1", "__namespace__": "global"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-A")
+        doc = yaml.safe_load(text)
+        ext = doc["external_refs"]
+        assert len(ext) == 1
+        assert ext[0]["namespace"] == "global"
+        assert ext[0]["id"] == "m1"
+        assert ext[0]["kind"] == "model"
+
+    def test_multiple_refs_to_same_target_dedup_to_one(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC3 dedup: multiple refs from different entries to ``(global, m1)`` collapse to one."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=["m1"], leaf_type=leaf_type
+        )
+        _seed_team(catalog, "tenant-D", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-D",
+            "a",
+            payload={"model_cfg": {"__ref__": "global.m1"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+        _seed_referrer_agent(
+            catalog,
+            "tenant-D",
+            "b",
+            payload={"model_cfg": {"__ref__": "global.m1"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-D")
+        doc = yaml.safe_load(text)
+        assert len(doc["external_refs"]) == 1
+        assert doc["external_refs"][0]["id"] == "m1"
+
+    def test_external_refs_sorted_namespace_kind_id(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC4 sort key: ``external_refs:`` sorted by (namespace, kind, id) ascending."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "alpha", user_id=None, target_ids=["m-a", "m-b"], leaf_type=leaf_type
+        )
+        _seed_shared_namespace_with_targets(
+            catalog, "zulu", user_id=None, target_ids=["m-z"], leaf_type=leaf_type
+        )
+        _seed_team(catalog, "tenant-S", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-S",
+            "agent",
+            payload={
+                "list": [
+                    {"__ref__": "zulu.m-z"},
+                    {"__ref__": "alpha.m-b"},
+                    {"__ref__": "alpha.m-a"},
+                ]
+            },
+            user_id=None,
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-S")
+        doc = yaml.safe_load(text)
+        keys = [(e["namespace"], e["kind"], e["id"]) for e in doc["external_refs"]]
+        # alpha sorts before zulu; within alpha, "m-a" < "m-b".
+        assert keys == [
+            ("alpha", "model", "m-a"),
+            ("alpha", "model", "m-b"),
+            ("zulu", "model", "m-z"),
+        ]
+
+    def test_non_shared_target_silently_omitted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC5: refs into a non-shared namespace are dropped from ``external_refs:``.
+
+        Mixes one shared target and one non-shared target — only the shared
+        one appears. The non-shared agent is staged via ``_repository.put``
+        directly (bypassing ``populate_refs``) to simulate the data-drift
+        scenario where a referrer was persisted before the target's
+        namespace was flipped to non-shared.
+        """
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        # Shared global with a target.
+        _seed_shared_namespace_with_targets(
+            catalog,
+            "global",
+            user_id=None,
+            target_ids=["shared-target"],
+            leaf_type=leaf_type,
+        )
+        # Non-shared "legacy-global" with a target — meta declares shared=false.
+        _seed_team(catalog, "legacy-global", user_id=None)
+        catalog.create(make_meta_entry("legacy-global", shared=False))
+        catalog.create(
+            Entry(
+                id="legacy-target",
+                kind="model",
+                namespace="legacy-global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        # Tenant team + agent with both refs (use repository.put so the
+        # non-shared ref doesn't trip populate_refs).
+        _seed_team(catalog, "tenant-NS", user_id=None)
+        repo.put(
+            Entry(
+                id="a",
+                kind="agent",
+                namespace="tenant-NS",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "list": [
+                        {"__ref__": "global.shared-target"},
+                        {"__ref__": "legacy-global.legacy-target"},
+                    ]
+                },
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-NS")
+        doc = yaml.safe_load(text)
+        ext_keys = {(e["namespace"], e["id"]) for e in doc["external_refs"]}
+        # Only the shared one survives.
+        assert ext_keys == {("global", "shared-target")}
+
+    def test_missing_target_silently_omitted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC6: a ref to a non-existent id in a shared namespace ⇒ silently omitted on export."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=["real"], leaf_type=leaf_type
+        )
+        _seed_team(catalog, "tenant-M", user_id=None)
+        # Use repo.put to bypass populate_refs — simulates a delete-guard
+        # bypass (target was deleted out from under the referrer).
+        repo.put(
+            Entry(
+                id="agent-ghost-ref",
+                kind="agent",
+                namespace="tenant-M",
+                user_id=None,
+                model_type=agent_type,
+                payload={"extra_ref": {"__ref__": "global.ghost"}},
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-M")
+        doc = yaml.safe_load(text)
+        # Ghost is silently omitted — no entry for (global, ghost).
+        assert doc["external_refs"] == []
+
+    def test_same_namespace_ref_not_in_external_refs(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC7: same-namespace refs do not appear in ``external_refs:``."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-LR", user_id="alice")
+        # Pre-create a sibling target in the same namespace.
+        catalog.create(
+            Entry(
+                id="sibling",
+                kind="model",
+                namespace="tenant-LR",
+                user_id="alice",
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        _seed_referrer_agent(
+            catalog,
+            "tenant-LR",
+            "a",
+            payload={"model_cfg": {"__ref__": "sibling"}},
+            user_id="alice",
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-LR")
+        doc = yaml.safe_load(text)
+        assert doc["external_refs"] == []
+
+    def test_explicit_namespace_matching_bundle_treated_as_same_namespace(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC7 second clause: ``__namespace__`` matching bundle's namespace ⇒ not external."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "tenant-X", user_id="alice")
+        catalog.create(
+            Entry(
+                id="sibling",
+                kind="model",
+                namespace="tenant-X",
+                user_id="alice",
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        # Use repo.put because cross-ns markers pointing at the same namespace
+        # would normally be flagged by populate_refs.
+        repo.put(
+            Entry(
+                id="agent",
+                kind="agent",
+                namespace="tenant-X",
+                user_id="alice",
+                model_type=agent_type,
+                payload={"ref": {"__ref__": "sibling", "__namespace__": "tenant-X"}},
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-X")
+        doc = yaml.safe_load(text)
+        assert doc["external_refs"] == []
+
+    def test_transitive_reachability_two_hops(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC8: cross-ns target's payload carrying a cross-ns ref is followed transitively."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=[], leaf_type=leaf_type
+        )
+        _seed_shared_namespace_with_targets(
+            catalog, "default", user_id=None, target_ids=[], leaf_type=leaf_type
+        )
+        # ``default.prompt-y`` is a leaf with no cross-ns refs.
+        catalog.create(
+            Entry(
+                id="prompt-y",
+                kind="model",
+                namespace="default",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        # ``global.agent-x`` references ``default.prompt-y`` — staged via
+        # repo.put so cross-ns ownership rules don't reject it.
+        repo.put(
+            Entry(
+                id="agent-x",
+                kind="agent",
+                namespace="global",
+                user_id=None,
+                model_type=agent_type,
+                payload={"model_cfg": {"__ref__": "default.prompt-y"}},
+            )
+        )
+        # Tenant references ``global.agent-x``.
+        _seed_team(catalog, "tenant-T", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-T",
+            "agent",
+            payload={"model_cfg": {"__ref__": "global.agent-x"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-T")
+        doc = yaml.safe_load(text)
+        ext_keys = {(e["namespace"], e["id"]) for e in doc["external_refs"]}
+        assert ext_keys == {("global", "agent-x"), ("default", "prompt-y")}
+
+    def test_cycle_in_cross_ns_refs_terminates(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC8 cycle clause: ``tenant → global.x → default.y → global.x`` terminates."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=[], leaf_type=leaf_type
+        )
+        _seed_shared_namespace_with_targets(
+            catalog, "default", user_id=None, target_ids=[], leaf_type=leaf_type
+        )
+        # default.y points back at global.x — a cycle through cross-ns refs.
+        repo.put(
+            Entry(
+                id="y",
+                kind="model",
+                namespace="default",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"back_ref": {"__ref__": "global.x"}},
+            )
+        )
+        # global.x references default.y.
+        repo.put(
+            Entry(
+                id="x",
+                kind="model",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"fwd_ref": {"__ref__": "default.y"}},
+            )
+        )
+        _seed_team(catalog, "tenant-C", user_id=None)
+        # Use repo.put so the cycle in the persisted state doesn't trip
+        # populate_refs at create time — the export path is a display
+        # projection that must tolerate cyclic state.
+        repo.put(
+            Entry(
+                id="agent",
+                kind="agent",
+                namespace="tenant-C",
+                user_id=None,
+                model_type=agent_type,
+                payload={"model_cfg": {"__ref__": "global.x"}},
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-C")
+        doc = yaml.safe_load(text)
+        ext_keys = {(e["namespace"], e["id"]) for e in doc["external_refs"]}
+        # Both targets appear exactly once — cycle terminated.
+        assert ext_keys == {("global", "x"), ("default", "y")}
+        # And the dedup invariant: each target appears exactly once.
+        ids = [(e["namespace"], e["id"]) for e in doc["external_refs"]]
+        assert len(ids) == len(set(ids))
+
+    def test_same_ns_ref_inside_cross_ns_target_does_not_widen(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC9: a same-ns ref inside a cross-ns target does NOT widen ``external_refs:``."""
+        import yaml
+
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, repo = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=[], leaf_type=leaf_type
+        )
+        # Local same-ns ref inside global.
+        catalog.create(
+            Entry(
+                id="prompt-z",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "openai"},
+            )
+        )
+        # global.agent-x's payload carries a same-ns ref to prompt-z.
+        repo.put(
+            Entry(
+                id="agent-x",
+                kind="agent",
+                namespace="global",
+                user_id=None,
+                model_type=agent_type,
+                payload={"model_cfg": {"__ref__": "prompt-z"}},
+            )
+        )
+        # Tenant references global.agent-x.
+        _seed_team(catalog, "tenant-W", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-W",
+            "agent",
+            payload={"model_cfg": {"__ref__": "global.agent-x"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-W")
+        doc = yaml.safe_load(text)
+        ext_keys = {(e["namespace"], e["id"]) for e in doc["external_refs"]}
+        # Only agent-x, NOT prompt-z. Per AC9 the local ref inside the
+        # cross-ns target does NOT widen external_refs.
+        assert ext_keys == {("global", "agent-x")}
+
+
+# --- Story 17.5 — Import backward-compat ----------------------------------
+
+
+class TestImportBackwardCompat:
+    """Story 17.5 AC10, AC11 — both wire shapes accepted on import."""
+
+    def test_import_v2_bundle_round_trip(self, catalog_factory: CatalogFactory) -> None:
+        """A v2-shape bundle from ``export_namespace_yaml`` round-trips through import."""
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "ns-rt2", user_id="alice")
+        _seed_agent(catalog, "ns-rt2", "a", user_id="alice")
+        yaml_text = catalog.export_namespace_yaml("ns-rt2")
+        # Rewrite to a fresh destination to avoid colliding with current state.
+        new_text = yaml_text.replace("ns-rt2", "ns-rt2-dst")
+        catalog.import_namespace_yaml(new_text)
+        ids = {e.id for e in repo.list_by_namespace("ns-rt2-dst")}
+        assert ids == {"team", "a"}
+
+    def test_import_legacy_flat_list_bundle(self, catalog_factory: CatalogFactory) -> None:
+        """A pre-17.5 legacy bundle (dict-keyed entries) imports cleanly."""
+        catalog, repo = catalog_factory()
+        legacy_text = (
+            "namespace: ns-legacy-imp\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_team_payload()!r}\n"
+            "  a:\n"
+            "    kind: agent\n"
+            "    model_type: akgentic.core.agent_card.AgentCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_agent_payload('a')!r}\n"
+        )
+        catalog.import_namespace_yaml(legacy_text)
+        ids = {e.id for e in repo.list_by_namespace("ns-legacy-imp")}
+        assert ids == {"team", "a"}
+
+    def test_v2_external_refs_ignored_even_when_invalid(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """AC10: ``external_refs:`` items would-fail-validation are still ignored on import."""
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "ns-imp-ext", user_id="alice")
+        # Build a v2 bundle with a valid entries: list and a malformed
+        # external_refs: item (missing required fields). Import must
+        # ignore it entirely.
+        entries = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-imp-ext-dst",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        ]
+        # Build by serialising entries:, then surgically inject a malformed
+        # external_refs: section into the YAML text.
+        valid_yaml = dump_namespace_v2(entries, [])
+        # Replace the empty external_refs: [] with a malformed list.
+        broken = valid_yaml.replace(
+            "external_refs: []",
+            "external_refs:\n- {id: bad, namespace: foreign}\n",
+        )
+        # Import succeeds — external_refs is ignored.
+        catalog.import_namespace_yaml(broken)
+        ids = {e.id for e in repo.list_by_namespace("ns-imp-ext-dst")}
+        assert ids == {"team"}
+
+    def test_bare_list_root_rejected_with_existing_error(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """AC11 second clause: a bare list at the YAML root is rejected with the existing error."""
+        catalog, _ = catalog_factory()
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.import_namespace_yaml("- a\n- b\n")
+        assert any("mapping" in m for m in exc_info.value.errors)
+
+
+# --- Story 17.5 — Round-trip integrity ------------------------------------
+
+
+class TestRoundTripBundle:
+    """Story 17.5 AC12 — ``export → import → export`` is byte-identical on ``entries:``."""
+
+    def test_export_import_export_byte_identical_entries(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Round-trip through ``dst-ns`` preserves the ``entries:`` block byte-for-byte."""
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        # Shared global with a target.
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=["shared-m"], leaf_type=leaf_type
+        )
+        # Source namespace src-ns.
+        _seed_team(catalog, "src-ns", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "src-ns",
+            "agent",
+            payload={"model_cfg": {"__ref__": "global.shared-m"}},
+            user_id=None,
+            agent_type=agent_type,
+        )
+
+        # 1) Export src-ns → bundle A.
+        bundle_a = catalog.export_namespace_yaml("src-ns")
+
+        # 2) Rewrite bundle A's namespace to dst-ns (each per-entry
+        # ``namespace: src-ns`` line) and import — atomic replace into the
+        # empty dst-ns.
+        bundle_a_for_dst = bundle_a.replace("namespace: src-ns", "namespace: dst-ns")
+        catalog.import_namespace_yaml(bundle_a_for_dst)
+
+        # 3) Re-export dst-ns → bundle B.
+        bundle_b = catalog.export_namespace_yaml("dst-ns")
+
+        # The entries: block of bundle B (after the same namespace rewrite of
+        # bundle A) must be byte-identical. Compare the entries: blocks
+        # directly via slicing on the section markers.
+        a_entries = _extract_section(bundle_a_for_dst, "entries:", "external_refs:")
+        b_entries = _extract_section(bundle_b, "entries:", "external_refs:")
+        assert a_entries == b_entries
+
+    def test_external_refs_byte_identical_when_repo_unchanged(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two consecutive exports of the same namespace produce byte-identical YAML."""
+        agent_type, leaf_type = _register_open_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        _seed_shared_namespace_with_targets(
+            catalog, "global", user_id=None, target_ids=["m1", "m2"], leaf_type=leaf_type
+        )
+        _seed_team(catalog, "tenant-X", user_id=None)
+        _seed_referrer_agent(
+            catalog,
+            "tenant-X",
+            "agent",
+            payload={
+                "list": [
+                    {"__ref__": "global.m1"},
+                    {"__ref__": "global.m2"},
+                ],
+            },
+            user_id=None,
+            agent_type=agent_type,
+        )
+        first = catalog.export_namespace_yaml("tenant-X")
+        second = catalog.export_namespace_yaml("tenant-X")
+        assert first == second
+
+
+def _extract_section(yaml_text: str, start_key: str, end_key: str) -> str:
+    """Slice the substring of ``yaml_text`` between two top-level keys.
+
+    Used by round-trip tests to compare the ``entries:`` block byte-for-byte
+    while ignoring the ``external_refs:`` block (which depends on global
+    namespace state and may not be relevant to the assertion).
+    """
+    start = yaml_text.index(start_key)
+    end = yaml_text.index(end_key, start)
+    return yaml_text[start:end]

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -138,16 +138,18 @@ class TestExportVerb:
     """AC3-AC6 + AC23 — export verb shape, stdout fidelity, error paths."""
 
     def test_export_stdout_is_parseable_bundle(self, runner: CliRunner, catalog_root: Path) -> None:
+        """Story 17.5 v2 shape: root has ``entries:`` (list) + ``external_refs:`` (list)."""
         result = runner.invoke(
             cli_main.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
         )
         assert result.exit_code == 0, result.stderr
         payload = yaml.safe_load(result.stdout)
-        assert set(payload.keys()) == {"namespace", "user_id", "entries"}
-        assert payload["namespace"] == "ns-a"
-        assert "team-a" in payload["entries"]
-        assert "tool-a" in payload["entries"]
-        assert "agent-a" in payload["entries"]
+        assert set(payload.keys()) == {"entries", "external_refs"}
+        assert isinstance(payload["entries"], list)
+        ids = {e["id"] for e in payload["entries"]}
+        assert {"team-a", "tool-a", "agent-a"} <= ids
+        # Each entry carries its own namespace; uniform within the bundle.
+        assert {e["namespace"] for e in payload["entries"]} == {"ns-a"}
 
     def test_export_missing_namespace_is_usage_error(
         self, runner: CliRunner, catalog_root: Path
@@ -178,7 +180,7 @@ class TestExportVerb:
         assert "validation error:" in result.stderr
 
     def test_export_format_flag_ignored(self, runner: CliRunner, catalog_root: Path) -> None:
-        # --format is a no-op on export; bundle is always YAML bytes.
+        # --format is a no-op on export; bundle is always YAML bytes (v2 shape).
         result_yaml = runner.invoke(
             cli_main.app,
             _base_args(catalog_root) + ["--format", "json", "export", "--namespace", "ns-a"],
@@ -186,7 +188,8 @@ class TestExportVerb:
         assert result_yaml.exit_code == 0
         # Output must still parse as YAML (the bundle format).
         payload = yaml.safe_load(result_yaml.stdout)
-        assert payload["namespace"] == "ns-a"
+        # v2 shape — list of self-contained entries.
+        assert {e["namespace"] for e in payload["entries"]} == {"ns-a"}
 
 
 # --------------------------------------------------------------------------- #
@@ -200,14 +203,15 @@ class TestImportPersistence:
     def test_round_trip_mutation(
         self, runner: CliRunner, catalog_root: Path, tmp_path: Path
     ) -> None:
-        # AC17 — export → edit → import → re-export → verify.
+        # AC17 — export → edit → import → re-export → verify (v2 shape).
         export = runner.invoke(
             cli_main.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
         )
         assert export.exit_code == 0
         bundle = yaml.safe_load(export.stdout)
-        assert bundle["namespace"] == "ns-a"
-        bundle["entries"]["team-a"]["description"] = "edited description"
+        # v2 shape — entries is a list of self-contained items.
+        team_item = next(e for e in bundle["entries"] if e["id"] == "team-a")
+        team_item["description"] = "edited description"
         bundle_path = tmp_path / "bundle.yaml"
         bundle_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
 
@@ -222,10 +226,13 @@ class TestImportPersistence:
         )
         assert re_export.exit_code == 0
         re_bundle = yaml.safe_load(re_export.stdout)
-        assert re_bundle["entries"]["team-a"]["description"] == "edited description"
-        # Other entries untouched — byte-equivalent dumps.
+        re_team = next(e for e in re_bundle["entries"] if e["id"] == "team-a")
+        assert re_team["description"] == "edited description"
+        # Other entries untouched — byte-equivalent items by id.
+        re_by_id = {e["id"]: e for e in re_bundle["entries"]}
+        orig_by_id = {e["id"]: e for e in bundle["entries"]}
         for k in ("tool-a", "agent-a"):
-            assert re_bundle["entries"][k] == bundle["entries"][k]
+            assert re_by_id[k] == orig_by_id[k]
 
     def test_atomic_failure_leaves_namespace_untouched(
         self, runner: CliRunner, catalog_root: Path, tmp_path: Path
@@ -237,9 +244,10 @@ class TestImportPersistence:
         assert before.exit_code == 0
         pre_bundle_text = before.stdout
 
-        # Break the bundle: point agent-a.linked.__ref__ at a missing id.
+        # Break the bundle: point agent-a.linked.__ref__ at a missing id (v2 shape).
         bundle = yaml.safe_load(pre_bundle_text)
-        bundle["entries"]["agent-a"]["payload"]["linked"] = {"__ref__": "does-not-exist"}
+        agent_item = next(e for e in bundle["entries"] if e["id"] == "agent-a")
+        agent_item["payload"]["linked"] = {"__ref__": "does-not-exist"}
         broken_path = tmp_path / "broken.yaml"
         broken_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
 
@@ -293,7 +301,8 @@ class TestImportDryRun:
             cli_main.app, _base_args(catalog_root) + ["export", "--namespace", "ns-a"]
         )
         bundle = yaml.safe_load(export.stdout)
-        bundle["entries"]["agent-a"]["payload"]["linked"] = {"__ref__": "does-not-exist"}
+        agent_item = next(e for e in bundle["entries"] if e["id"] == "agent-a")
+        agent_item["payload"]["linked"] = {"__ref__": "does-not-exist"}
         broken_path = tmp_path / "broken.yaml"
         broken_path.write_text(yaml.safe_dump(bundle, sort_keys=False))
 

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -11,7 +11,9 @@ from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.serialization import (
     _KIND_HEADERS,
+    _iter_cross_ns_targets,
     dump_namespace,
+    dump_namespace_v2,
     load_namespace,
 )
 
@@ -258,11 +260,14 @@ class TestLoadNamespace:
             "bundle must declare at least one entry, including a `kind=team` entry"
         ]
 
-    def test_rejects_entries_as_list(self) -> None:
+    def test_rejects_empty_v2_entries_list(self) -> None:
+        """Story 17.5: ``entries: []`` selects the v2 shape, then errors as empty bundle."""
         text = "namespace: ns-1\nuser_id: alice\nentries: []\n"
         with pytest.raises(CatalogValidationError) as exc_info:
             load_namespace(text)
-        assert any("entries" in e and "mapping" in e for e in exc_info.value.errors)
+        assert exc_info.value.errors == [
+            "bundle must declare at least one entry, including a `kind=team` entry"
+        ]
 
     def test_rejects_namespace_empty(self) -> None:
         text = "namespace: ''\nuser_id: alice\nentries:\n  team: {kind: team}\n"
@@ -495,3 +500,281 @@ class TestMetaEmitOrderAndRoundTrip:
         doc = yaml.safe_load(text)
         # Outer keys are emitted in (kind emit order, id) — team @ 0, meta @ 1, agent @ 2.
         assert list(doc["entries"].keys()) == ["team", "_meta", "a1"]
+
+
+# --- Story 17.5 — dump_namespace_v2 (entries: + external_refs:) ----------
+
+
+class TestDumpNamespaceV2:
+    """Story 17.5 AC1, AC2, AC4 — v2 wire shape with ``entries:`` + ``external_refs:``."""
+
+    def test_root_has_entries_and_external_refs_in_order(self) -> None:
+        """Document root has exactly two keys, ``entries`` first then ``external_refs``."""
+        text = dump_namespace_v2([_team(), _agent("a")], [])
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == ["entries", "external_refs"]
+        assert isinstance(doc["entries"], list)
+        assert isinstance(doc["external_refs"], list)
+
+    def test_external_refs_always_present_when_empty(self) -> None:
+        """``external_refs:`` is emitted as ``[]`` when no cross-ns targets exist."""
+        text = dump_namespace_v2([_team()], [])
+        doc = yaml.safe_load(text)
+        assert doc["external_refs"] == []
+        assert "external_refs:" in text
+
+    def test_each_entry_carries_id_namespace_user_id(self) -> None:
+        """v2 list items are self-contained — id/namespace/user_id sit on each item."""
+        text = dump_namespace_v2(
+            [_team(namespace="ns-1", user_id="alice"), _agent("a", namespace="ns-1")],
+            [],
+        )
+        doc = yaml.safe_load(text)
+        team_item = next(e for e in doc["entries"] if e["id"] == "team")
+        assert team_item["namespace"] == "ns-1"
+        assert team_item["user_id"] == "alice"
+        assert team_item["kind"] == "team"
+
+    def test_external_refs_sorted_by_namespace_kind_id(self) -> None:
+        """``external_refs:`` items sort by ``(namespace, kind, id)`` ascending."""
+        # Three foreign entries with mixed (namespace, kind, id) tuples.
+        externals = [
+            _prompt("z-prompt", namespace="alpha", user_id=None),
+            _model("a-model", namespace="alpha", user_id=None),
+            _agent("a-agent", namespace="zulu", user_id=None),
+        ]
+        text = dump_namespace_v2([_team()], externals)
+        doc = yaml.safe_load(text)
+        items = doc["external_refs"]
+        keys = [(e["namespace"], e["kind"], e["id"]) for e in items]
+        # alpha sorts before zulu; within alpha, model < prompt by string order.
+        assert keys == [
+            ("alpha", "model", "a-model"),
+            ("alpha", "prompt", "z-prompt"),
+            ("zulu", "agent", "a-agent"),
+        ]
+
+    def test_entries_block_has_section_headers(self) -> None:
+        """The legacy section-header comments (Teams / Agents / …) survive in v2 ``entries:``."""
+        text = dump_namespace_v2([_team(), _agent("a"), _prompt("p")], [])
+        # All three section headers appear inside the entries: block.
+        assert _KIND_HEADERS["team"] in text
+        assert _KIND_HEADERS["agent"] in text
+        assert _KIND_HEADERS["prompt"] in text
+        # The headers appear BEFORE external_refs:.
+        external_pos = text.index("external_refs:")
+        assert text.index(_KIND_HEADERS["team"]) < external_pos
+        assert text.index(_KIND_HEADERS["agent"]) < external_pos
+        assert text.index(_KIND_HEADERS["prompt"]) < external_pos
+
+    def test_external_refs_block_has_no_section_headers(self) -> None:
+        """Section-header comments are reserved for ``entries:`` only."""
+        external = _prompt("p1", namespace="global", user_id=None)
+        text = dump_namespace_v2([_team()], [external])
+        external_pos = text.index("external_refs:")
+        external_block = text[external_pos:]
+        # No kind-section headers under external_refs:.
+        for header in _KIND_HEADERS.values():
+            assert header not in external_block
+
+    def test_rejects_empty_entries(self) -> None:
+        """``entries: []`` raises with the legacy empty-bundle message."""
+        with pytest.raises(CatalogValidationError) as exc_info:
+            dump_namespace_v2([], [])
+        assert exc_info.value.errors == [
+            "bundle must declare at least one entry, including a `kind=team` entry"
+        ]
+
+    def test_rejects_mismatched_namespace(self) -> None:
+        """Uniform-namespace invariant on ``entries`` is enforced (same as ``dump_namespace``)."""
+        entries = [_team(namespace="ns-1"), _agent("a", namespace="ns-2")]
+        with pytest.raises(CatalogValidationError) as exc_info:
+            dump_namespace_v2(entries, [])
+        assert any("namespace" in e for e in exc_info.value.errors)
+
+    def test_two_consecutive_v2_dumps_byte_identical(self) -> None:
+        """Repeat dumps with the same inputs produce byte-identical output."""
+        entries = [_team(), _agent("a"), _agent("b")]
+        externals = [_prompt("p1", namespace="global", user_id=None)]
+        first = dump_namespace_v2(entries, externals)
+        second = dump_namespace_v2(entries, externals)
+        assert first == second
+
+
+# --- Story 17.5 — load_namespace shape detection ---------------------------
+
+
+class TestLoadNamespaceShapeDetection:
+    """Story 17.5 AC10, AC11 — both shapes accepted on import; new ignores ``external_refs:``."""
+
+    def test_v2_bundle_round_trip(self) -> None:
+        """``load_namespace(dump_namespace_v2(entries, []))`` returns the same entries."""
+        entries = [_team(), _agent("a"), _agent("b")]
+        text = dump_namespace_v2(entries, [])
+        recovered = load_namespace(text)
+        sort_key = lambda e: (e.kind, e.id)  # noqa: E731
+        assert [e.model_dump() for e in sorted(recovered, key=sort_key)] == [
+            e.model_dump() for e in sorted(entries, key=sort_key)
+        ]
+
+    def test_v2_external_refs_silently_dropped_on_load(self) -> None:
+        """Items inside ``external_refs:`` are NOT returned by ``load_namespace``."""
+        entries = [_team(), _agent("a")]
+        external = _prompt("foreign", namespace="global", user_id=None)
+        text = dump_namespace_v2(entries, [external])
+        recovered = load_namespace(text)
+        # Only the namespace's own entries surface — the foreign prompt is ignored.
+        assert {e.id for e in recovered} == {"team", "a"}
+        # And every recovered entry's namespace is the bundle's own namespace.
+        assert {e.namespace for e in recovered} == {"ns-1"}
+
+    def test_legacy_bundle_round_trip_unchanged(self) -> None:
+        """Pre-17.5 flat-list bundles still load — backward compat for on-disk fixtures."""
+        # Construct the legacy YAML by hand to simulate an old fixture.
+        legacy_text = (
+            "namespace: ns-legacy\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload: {name: team}\n"
+            "  agent-a:\n"
+            "    kind: agent\n"
+            "    model_type: akgentic.core.agent_card.AgentCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload: {role: r}\n"
+        )
+        recovered = load_namespace(legacy_text)
+        assert {e.id for e in recovered} == {"team", "agent-a"}
+        assert {e.namespace for e in recovered} == {"ns-legacy"}
+        assert {e.user_id for e in recovered} == {"alice"}
+
+    def test_external_refs_only_document_with_entries_list_loads_v2(self) -> None:
+        """A v2 bundle with only ``entries: [...]`` (no namespace/user_id at root) parses."""
+        entries = [_team(namespace="ns-vx"), _agent("a", namespace="ns-vx")]
+        text = dump_namespace_v2(entries, [])
+        # The v2 dump omits document-level namespace/user_id by design.
+        doc = yaml.safe_load(text)
+        assert "namespace" not in doc
+        assert "user_id" not in doc
+        # And it loads cleanly.
+        recovered = load_namespace(text)
+        assert {e.id for e in recovered} == {"team", "a"}
+
+    def test_legacy_bundle_with_entries_dict_keeps_legacy_path(self) -> None:
+        """Ambiguous-looking root: ``entries`` is a dict ⇒ legacy path is selected."""
+        text = (
+            "namespace: ns-l\n"
+            "user_id: null\n"
+            "entries:\n"
+            "  team: {kind: team, model_type: akgentic.team.models.TeamCard, payload: {}}\n"
+        )
+        recovered = load_namespace(text)
+        assert len(recovered) == 1
+        assert recovered[0].id == "team"
+        assert recovered[0].namespace == "ns-l"
+
+    def test_root_not_mapping_rejected_for_both_shapes(self) -> None:
+        """A bare list at the root is rejected with the existing error message."""
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_namespace("- a\n- b\n")
+        assert any("mapping" in e for e in exc_info.value.errors)
+
+    def test_v2_per_item_validation_wraps_pydantic_error(self) -> None:
+        """A v2 list item missing required fields raises ``entry '<id>' is invalid``."""
+        text = (
+            "entries:\n"
+            "  - id: bad\n"
+            "    namespace: ns-1\n"
+            "    kind: agent\n"  # missing model_type
+            "    payload: {}\n"
+            "external_refs: []\n"
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_namespace(text)
+        assert any("entry 'bad' is invalid" in e for e in exc_info.value.errors)
+
+
+# --- Story 17.5 — _iter_cross_ns_targets walker ----------------------------
+
+
+class TestIterCrossNsTargets:
+    """Story 17.5 AC13 — the cross-ns walker recognises both ref-marker shapes."""
+
+    def test_canonical_marker_is_collected(self) -> None:
+        """``{__ref__: x, __namespace__: ns}`` yields ``(ns, x)``."""
+        payload = {"prompt": {"__ref__": "x", "__namespace__": "global"}}
+        assert _iter_cross_ns_targets(payload) == [("global", "x")]
+
+    def test_shorthand_marker_is_collected(self) -> None:
+        """``{__ref__: ns.x}`` yields ``(ns, x)`` via first-dot split."""
+        payload = {"prompt": {"__ref__": "global.x"}}
+        assert _iter_cross_ns_targets(payload) == [("global", "x")]
+
+    def test_same_namespace_marker_is_omitted(self) -> None:
+        """``{__ref__: x}`` (no dot, no ``__namespace__``) yields nothing."""
+        payload = {"prompt": {"__ref__": "x"}}
+        assert _iter_cross_ns_targets(payload) == []
+
+    def test_first_dot_split_for_shorthand_with_dotted_id(self) -> None:
+        """Shorthand splits on the FIRST dot — ids may continue to contain dots."""
+        payload = {"ref": {"__ref__": "ns.id.with.dots"}}
+        assert _iter_cross_ns_targets(payload) == [("ns", "id.with.dots")]
+
+    def test_walker_recurses_into_lists(self) -> None:
+        """List items are visited."""
+        payload = {
+            "tools": [
+                {"__ref__": "global.t1"},
+                {"__ref__": "default.t2"},
+            ]
+        }
+        result = _iter_cross_ns_targets(payload)
+        assert ("global", "t1") in result
+        assert ("default", "t2") in result
+
+    def test_walker_recurses_into_sibling_overrides(self) -> None:
+        """Sibling-override sub-payloads on a ref marker are walked for nested cross-ns refs."""
+        # The marker itself targets (global, agent-x); its override carries
+        # another cross-ns ref to (default, prompt-y) — both must be yielded.
+        payload = {
+            "agent": {
+                "__ref__": "global.agent-x",
+                "params": {"prompt": {"__ref__": "default.prompt-y"}},
+            }
+        }
+        result = _iter_cross_ns_targets(payload)
+        assert ("global", "agent-x") in result
+        assert ("default", "prompt-y") in result
+
+    def test_dedup_is_caller_responsibility(self) -> None:
+        """The walker emits duplicates; dedup happens in ``_collect_external_refs``."""
+        payload = {
+            "a": {"__ref__": "global.x"},
+            "b": {"__ref__": "global.x"},
+        }
+        result = _iter_cross_ns_targets(payload)
+        assert result.count(("global", "x")) == 2
+
+    def test_walker_is_parse_only_no_repository_access(self) -> None:
+        """The walker accepts an arbitrary payload tree — no Pydantic, no repo lookups."""
+        # An exotic but legal payload tree — primitives, nested dicts/lists.
+        payload = {
+            "level1": {
+                "level2": [
+                    1,
+                    "string",
+                    None,
+                    {"__ref__": "global.deep"},
+                ]
+            }
+        }
+        # Does not raise.
+        result = _iter_cross_ns_targets(payload)
+        assert result == [("global", "deep")]


### PR DESCRIPTION
## Summary

Story 17.5 — Extend `GET /catalog/namespace/{namespace}/export` with an `external_refs:` section that surfaces cross-namespace targets reachable from the namespace's entries.

The bundle YAML wire format on export changes from a flat list under `entries:` into a two-section mapping at the document root:

- `entries:` — every persisted entry in the namespace (same content as today, list shape).
- `external_refs:` — every cross-namespace target reachable from `entries:`, fetched from each target's source namespace, deduplicated, and sorted by `(namespace, kind, id)`. Targets in non-shared namespaces (per the data-driven shared-flag introduced in story 17.4) are silently omitted; missing targets are silently omitted as well.

Import accepts both shapes for backward compatibility:

- The new mapping shape (`external_refs:` is ignored on import — those entries belong to other namespaces).
- The legacy flat-list shape (`{namespace, user_id, entries: <dict-keyed-by-id>}`) — every existing on-disk fixture and CI bundle continues to load through `import_namespace_yaml` without re-encoding.

Detection is unambiguous because the legacy `entries` is always a `dict` and the new `entries` is always a `list`. The router-level handler is unchanged — the upstream `load_namespace` function transparently supports both shapes through shape detection.

## Implementation

- `serialization.py`: new `dump_namespace_v2`, `_iter_cross_ns_targets` (parse-only walker with sibling-override recursion), v2-vs-legacy detection in `load_namespace`. Legacy `dump_namespace` is unchanged.
- `catalog.py`: new `Catalog._collect_external_refs` (worklist + visited-set algorithm with cycle protection, shared-flag filtering, silent omission of missing targets). `Catalog.export_namespace_yaml` now computes external refs and calls `dump_namespace_v2`.

Round-trip integrity is preserved: export → import → re-export of the same namespace produces a byte-identical `entries:` block on the second export; two consecutive exports against unchanged repository state produce byte-identical YAML for `external_refs:` as well.

Cross-ns reachability is transitive with cycle protection. The walker recognises both ref-marker shapes (canonical `__namespace__` and the `<ns>.<id>` shorthand), recurses into sibling-override sub-payloads, and is parse-only — no `populate_refs`, no Pydantic validation, no repository access. The shared-flag check fires later when fetching the target.

## Tests

- `test_serialization.py`: added `TestDumpNamespaceV2`, `TestLoadNamespaceShapeDetection`, `TestIterCrossNsTargets`.
- `test_catalog_namespace_bundle.py`: added `TestExportExternalRefs`, `TestImportBackwardCompat`, `TestRoundTripBundle` (with `_OpenAgentModel` / `_OpenLeafModel` permissive payload fixtures).
- `test_api_router.py`: added `TestNamespaceExportImportV2` covering HTTP-level export/import for both shapes plus round-trip.
- `test_cli_bundle.py`: existing CLI tests updated to consume the v2 list-of-items shape.

`pytest packages/akgentic-catalog/tests/`: 936 passed, 23 skipped (backend-absent skips). `ruff check`, `ruff format --check`, `mypy --strict`: all clean.

## Branch stack

This branch is stacked on `feat/164-shared-flag-meta` (story 17.4). The PR base is `feat/164-shared-flag-meta`, not `master`.

## Code review

Reviewed by Rex on 2026-05-08 — no HIGH or MEDIUM issues found. Three LOW informational notes, none blocking. Story status moved to `done`.

Closes #166
