### PR TITLE
feat: simplify export bundle to dict-keyed shape with header projection (story 17.6)

### DIFF
--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -41,18 +41,29 @@ from pydantic import BaseModel
 
 from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+from akgentic.catalog.models.namespace_meta import NamespaceMeta
 from akgentic.catalog.models.queries import EntryQuery
 from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.resolver import (
     NAMESPACE_KEY,
     REF_KEY,
+    TYPE_KEY,
     prepare_for_write,
     validate_delete,
 )
 from akgentic.catalog.resolver import resolve as _resolve
-from akgentic.catalog.serialization import dump_namespace, load_namespace
+from akgentic.catalog.serialization import BundleHeader, dump_namespace, load_namespace
 from akgentic.catalog.validation import NamespaceValidationReport, validate_entries
 from akgentic.team.models import TeamCard
+
+# The namespace-meta `model_type` allowlist key — pinned at module load time
+# so the meta-upsert path (Catalog.import_namespace_yaml) can construct a
+# `_meta` Entry without redeclaring the FQCN string. ADR-008 §D1.
+_NAMESPACE_META_TYPE: Final[str] = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+# Reserved ref-marker keys (subset of `_RESERVED_REF_KEYS` from the resolver)
+# used by the cross-ns walker to skip recursion into reserved sub-fields.
+_RESERVED_REF_KEYS: Final[frozenset[str]] = frozenset({REF_KEY, TYPE_KEY, NAMESPACE_KEY})
 
 __all__ = ["UNSET_NAMESPACE", "Catalog"]
 
@@ -418,17 +429,46 @@ class Catalog:
     def export_namespace_yaml(self, namespace: str) -> str:
         """Return ``namespace`` serialised as a single-bundle YAML document.
 
-        Delegates to :func:`akgentic.catalog.serialization.dump_namespace` after
-        a single ``list_by_namespace`` call against the repository. An empty
-        namespace surfaces the bundle-must-declare-entry error from
-        ``dump_namespace`` unchanged; the router maps it to HTTP 409.
+        Story 17.6 — the bundle carries six top-level keys (in declaration
+        order): ``namespace``, ``user_id``, ``name``, ``description``,
+        ``properties``, ``entries``. The ``name`` / ``description`` /
+        ``properties`` trio is projected from the namespace's ``_meta`` entry
+        when present, with team-payload fallback otherwise (per ADR-008 §D1
+        and Story 17.6 AC2). The ``_meta`` entry itself is hoisted to the
+        header — it does NOT appear in ``entries:``. ``entries:`` is a
+        YAML mapping (dict-keyed-by-id for local entries, dict-keyed-by-
+        ``<ns>.<id>`` for cross-namespace external entries; external entries
+        are sorted within per-kind sections marked ``External ref, readonly``).
+
+        Pipeline:
+
+        1. ``entries = list_by_namespace(namespace)`` — single repository call.
+        2. ``meta_entry, local_entries = _partition_meta(entries)`` —
+           separate the canonical ``_meta`` entry from regular catalog
+           entries; the ``_meta`` entry is hoisted to header fields.
+        3. Compute ``name`` / ``description`` / ``properties`` from
+           ``meta_entry.payload`` when present; fall back to
+           ``(team.payload.get("name", ""), team.description, {})`` when
+           absent (per AC2). When ``meta_entry.payload.name`` is empty, fall
+           back to the team for ``name`` only (description and properties
+           still come from the meta entry).
+        4. ``external_refs = self._collect_external_refs(local_entries)`` —
+           transitive cross-ns target collection (carried over from Story
+           17.5; algorithm unchanged). Local entries (not the meta entry)
+           are passed in so the meta payload's properties dict does not
+           introduce spurious cross-ns walks.
+        5. Return ``dump_namespace(local_entries, name=name,
+           description=description, properties=properties,
+           external_refs=external_refs)``.
+
+        An empty namespace surfaces the bundle-must-declare-entry error
+        from ``dump_namespace`` unchanged; the router maps it to HTTP 409.
 
         Args:
             namespace: The namespace to export.
 
         Returns:
-            YAML string following the bundle format (document-level
-            ``namespace`` + ``user_id`` + ``entries`` map).
+            YAML string following the Story 17.6 bundle format.
 
         Raises:
             CatalogValidationError: If ``namespace`` has no entries, or if
@@ -437,23 +477,174 @@ class Catalog:
                 because the Catalog service enforces ownership on write).
         """
         entries = self._repository.list_by_namespace(namespace)
-        return dump_namespace(entries)
+        meta_entry, local_entries = _partition_meta(entries)
+        name, description, properties = self._project_header(meta_entry, local_entries)
+        external_refs = self._collect_external_refs(local_entries)
+        return dump_namespace(
+            local_entries,
+            name=name,
+            description=description,
+            properties=properties,
+            external_refs=external_refs,
+        )
+
+    def _project_header(
+        self,
+        meta_entry: Entry | None,
+        local_entries: _list[Entry],
+    ) -> tuple[str, str, dict[str, str]]:
+        """Project ``name`` / ``description`` / ``properties`` for the bundle header.
+
+        When ``meta_entry`` is present, read from its payload. When the
+        meta's ``payload.name`` is empty / missing, fall back to the team
+        entry's payload-name for the ``name`` field only — description and
+        properties still come from the meta entry (mirrors the existing
+        ``list_namespaces`` graceful-degradation rule for empty meta names).
+
+        When ``meta_entry`` is absent, fall back fully to the team:
+        ``(team.payload.get("name", ""), team.description, {})``. When the
+        team entry is also absent (defensive — should not happen in practice
+        because the catalog service enforces a team-bootstrap invariant),
+        return empty defaults.
+
+        Args:
+            meta_entry: The namespace's ``_meta`` entry, or ``None``.
+            local_entries: The non-meta entries of the namespace; the team
+                entry is located inside this list.
+
+        Returns:
+            ``(name, description, properties)`` triple — the header
+            projection ready to pass to :func:`dump_namespace`.
+        """
+        team_entry = next((e for e in local_entries if e.kind == "team"), None)
+        team_name = ""
+        team_description = ""
+        if team_entry is not None:
+            team_payload = team_entry.payload if isinstance(team_entry.payload, dict) else {}
+            raw_name = team_payload.get("name", "")
+            team_name = raw_name if isinstance(raw_name, str) else ""
+            team_description = team_entry.description
+
+        if meta_entry is None:
+            return team_name, team_description, {}
+
+        payload = meta_entry.payload if isinstance(meta_entry.payload, dict) else {}
+        meta_name = payload.get("name", "")
+        meta_description = payload.get("description", "")
+        meta_properties_raw = payload.get("properties", {})
+        if not isinstance(meta_name, str):
+            meta_name = ""
+        if not isinstance(meta_description, str):
+            meta_description = ""
+        meta_properties: dict[str, str] = {}
+        if isinstance(meta_properties_raw, dict):
+            meta_properties = {
+                str(k): str(v) for k, v in meta_properties_raw.items() if isinstance(k, str)
+            }
+        # Empty-meta-name graceful degradation — team-fallback for name only.
+        name = meta_name if meta_name else team_name
+        return name, meta_description, meta_properties
+
+    def _collect_external_refs(self, entries: _list[Entry]) -> _list[Entry]:
+        """Return the deduplicated, shared-flag-filtered, transitively-reached cross-ns targets.
+
+        Worklist algorithm carried over from Story 17.5 (unchanged):
+
+        1. Seed the worklist with every cross-ns target reachable from
+           ``entries[*].payload`` via :func:`_iter_cross_ns_targets`,
+           skipping pairs whose namespace is the bundle's own namespace
+           (same-namespace short-circuit even when the marker carried an
+           explicit ``__namespace__`` matching the bundle's namespace).
+        2. Maintain a ``visited`` set of ``(namespace, id)`` pairs already
+           processed (cycle protection — same shape as the resolver's
+           cycle set).
+        3. For each pair popped from the worklist:
+           - Skip if already in ``visited``.
+           - Skip if the target namespace is not shared (silent omission per
+             ADR-008 §D2).
+           - Try ``repository.get(target_ns, target_id)``; on
+             ``EntryNotFoundError`` semantics (``None``), skip silently.
+           - Append to the result list and mark visited.
+           - Walk the target's payload via ``_iter_cross_ns_targets``;
+             enqueue every produced pair whose target namespace is NOT the
+             bundle's namespace AND NOT the target entry's own namespace
+             (same-namespace refs inside a cross-ns target's payload do NOT
+             widen the section).
+        4. Sort the result by ``(namespace, kind, id)`` ascending.
+
+        Returns an empty list when ``entries`` is empty or carries no
+        cross-ns refs. The ``visited`` set IS used to short-circuit
+        re-processing — repeated pops of the same pair never re-fetch the
+        repository (cycle protection).
+        """
+        if not entries:
+            return []
+
+        bundle_namespace = entries[0].namespace
+        worklist: _list[tuple[str, str]] = []
+        for entry in entries:
+            for target_ns, target_id in _iter_cross_ns_targets(entry.payload):
+                if target_ns != bundle_namespace:
+                    worklist.append((target_ns, target_id))
+
+        visited: set[tuple[str, str]] = set()
+        collected: _list[Entry] = []
+
+        while worklist:
+            target_ns, target_id = worklist.pop(0)
+            key = (target_ns, target_id)
+            if key in visited:
+                continue
+            visited.add(key)
+            if not self._is_namespace_shared(target_ns):
+                continue
+            target_entry = self._repository.get(target_ns, target_id)
+            if target_entry is None:
+                continue
+            collected.append(target_entry)
+            for nested_ns, nested_id in _iter_cross_ns_targets(target_entry.payload):
+                # Same-ns refs inside a cross-ns target's payload do NOT
+                # widen the external section (the local refs belong to the
+                # target's own namespace; the frontend renders the target
+                # as opaque).
+                if nested_ns == target_ns:
+                    continue
+                # Cross-ns refs that resolve back to the bundle's own
+                # namespace are not external refs.
+                if nested_ns == bundle_namespace:
+                    continue
+                worklist.append((nested_ns, nested_id))
+
+        # Sort by (namespace, kind, id) for stable diffs.
+        collected.sort(key=lambda e: (e.namespace, e.kind, e.id))
+        return collected
 
     def import_namespace_yaml(self, yaml_text: str) -> _list[Entry]:
         """Import a bundle YAML document as an atomic namespace replacement.
 
-        Five-step pipeline, every pre-write step raising on failure:
+        Story 17.6 — six-step pipeline, every pre-write step raising on failure:
 
-        1. ``parsed = load_namespace(yaml_text)`` — structural validation.
+        1. ``parsed, header = load_namespace(yaml_text)`` — structural
+           validation. Composite-keyed external entries (cross-namespace
+           targets) are SKIPPED by ``load_namespace`` — they belong to other
+           namespaces and are not part of this namespace's atomic-replace
+           contents.
         2. Run ``prepare_for_write`` on each parsed entry. Any failure aborts
            the import with no repository writes.
         3. Bundle invariants: exactly one team entry, uniform user_id within
            the bundle (reuses the ``_check_ownership`` shape).
-        4. Cross-entry ref check: every ``__ref__`` marker target MUST be an
-           id present in the bundle.
+        4. Cross-entry ref check: every same-namespace ``__ref__`` marker
+           target MUST be an id present in the bundle.
         5. Atomic replace: compute the id difference against the current
-           namespace state, delete non-team entries then team, then put team
-           first and non-team sorted by id.
+           namespace state, delete stale non-team entries then stale team,
+           then put team first and non-team sorted by id.
+        6. Header upsert: when ``header.present`` is True, upsert the
+           namespace's ``_meta`` entry with the bundle's header fields. The
+           upsert is part of the atomic sequence — it runs after the entries
+           replace and uses the same overlay repository so any bundle-side
+           ref-resolution invariants remain consistent. Pre-17.5 bundles
+           (no header at all) skip the meta upsert and leave the existing
+           ``_meta`` entry (if any) untouched.
 
         ``CatalogValidationError`` from any step propagates unchanged; the
         atomic-failure contract guarantees the repository stays untouched
@@ -464,13 +655,16 @@ class Catalog:
 
         Returns:
             The prepared entries in the order they were persisted — team
-            first, then non-team sorted by ``id``.
+            first, then non-team sorted by ``id``. The hoisted ``_meta``
+            entry (if upserted) is NOT in this list — it is an atomic side-
+            effect of the bundle import, not a bundle entry.
 
         Raises:
             CatalogValidationError: On any validation-phase failure (parse,
-                prepare-for-write, bundle invariants, dangling refs).
+                prepare-for-write, bundle invariants, dangling refs, meta
+                upsert validation).
         """
-        parsed = load_namespace(yaml_text)
+        parsed, header = load_namespace(yaml_text)
         # Bundle-internal refs (e.g., an agent payload referring to a sibling
         # model id in the same bundle) must resolve during prepare_for_write,
         # even when those sibling entries are not yet in the repository. Stage
@@ -489,8 +683,86 @@ class Catalog:
         self._check_bundle_refs(prepared)
         namespace = prepared[0].namespace
         ordered = self._order_bundle_for_put(prepared)
-        self._apply_atomic_swap(namespace, ordered)
+        # Header upsert is part of the atomic sequence; validate the
+        # meta-entry payload up-front so a header-shape failure aborts the
+        # import BEFORE any repository writes (atomic-failure contract).
+        meta_to_upsert: Entry | None = None
+        if header.present:
+            meta_to_upsert = self._build_meta_entry_for_upsert(namespace, prepared, header)
+        # AC11 / AC12 — pre-17.5 bundles (no header trio) leave the existing
+        # `_meta` entry untouched. Pass `preserve_meta=True` so the atomic
+        # swap does NOT sweep an existing `_meta` out from under a legacy
+        # bundle. When the bundle DOES carry a header, the meta upsert
+        # immediately re-creates `_meta` after the swap, so the swap may
+        # safely delete the prior meta.
+        preserve_meta = not header.present
+        self._apply_atomic_swap(namespace, ordered, preserve_meta=preserve_meta)
+        if meta_to_upsert is not None:
+            self._upsert_meta_entry(meta_to_upsert)
         return ordered
+
+    def _build_meta_entry_for_upsert(
+        self,
+        namespace: str,
+        prepared: _list[Entry],
+        header: BundleHeader,
+    ) -> Entry:
+        """Build the ``_meta`` entry to upsert from the bundle's header fields.
+
+        Constructs (but does NOT persist) the ``_meta`` entry; validates the
+        ``NamespaceMeta`` payload immediately so a header-shape failure
+        aborts the import BEFORE any repository writes are committed
+        (atomic-failure contract). The payload is constructed via
+        ``NamespaceMeta(...).model_dump()`` so a future schema change to
+        ``NamespaceMeta`` automatically flows through.
+
+        Args:
+            namespace: The bundle's namespace (already pinned by uniform-
+                namespace invariant on the prepared entries).
+            prepared: The prepared bundle entries; consulted to inherit the
+                ``user_id`` from the team entry so the meta entry's
+                ownership matches the rest of the namespace.
+            header: The :class:`BundleHeader` projected by ``load_namespace``.
+
+        Returns:
+            The constructed ``_meta`` entry ready for upsert.
+
+        Raises:
+            CatalogValidationError: When ``header`` does not yield a valid
+                ``NamespaceMeta`` payload (e.g. empty name).
+        """
+        team_entry = next((e for e in prepared if e.kind == "team"), None)
+        user_id = team_entry.user_id if team_entry is not None else None
+        try:
+            meta_payload = NamespaceMeta(
+                name=header.name,
+                description=header.description,
+                properties=dict(header.properties),
+            ).model_dump()
+        except ValueError as exc:
+            raise CatalogValidationError([f"bundle header is invalid: {exc}"]) from exc
+        return Entry(
+            id="_meta",
+            kind="meta",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_NAMESPACE_META_TYPE,
+            payload=meta_payload,
+        )
+
+    def _upsert_meta_entry(self, meta_entry: Entry) -> None:
+        """Upsert ``meta_entry`` via :meth:`update` if exists else :meth:`create`.
+
+        Goes through the standard write pipeline so ``prepare_for_write`` /
+        ownership / shared-flag-cache invalidation all fire normally. The
+        meta-singleton check inside :meth:`create` is satisfied by the
+        canonical id ``"_meta"`` — at most one meta entry per namespace.
+        """
+        existing = self._repository.get(meta_entry.namespace, meta_entry.id)
+        if existing is None:
+            self.create(meta_entry)
+        else:
+            self.update(meta_entry)
 
     # --- Namespace validation -------------------------------------------------
 
@@ -541,7 +813,7 @@ class Catalog:
         ``populate_refs``.
         """
         try:
-            entries = load_namespace(yaml_text)
+            entries, _header = load_namespace(yaml_text)
         except CatalogValidationError as exc:
             return NamespaceValidationReport(
                 namespace=None,
@@ -628,7 +900,13 @@ class Catalog:
         non_team = sorted((e for e in prepared if e.kind != "team"), key=lambda e: e.id)
         return team + non_team
 
-    def _apply_atomic_swap(self, namespace: str, ordered: _list[Entry]) -> None:
+    def _apply_atomic_swap(
+        self,
+        namespace: str,
+        ordered: _list[Entry],
+        *,
+        preserve_meta: bool = False,
+    ) -> None:
         """Replace ``namespace`` state with ``ordered`` in two passes.
 
         Delete non-team entries from the current namespace that are not in
@@ -637,10 +915,27 @@ class Catalog:
         Delete ordering preserves the bootstrap invariant across the swap;
         put ordering satisfies :meth:`Catalog.create`'s bootstrap gate in
         the "net-new team + sub-entries" path.
+
+        Story 17.6 — when ``preserve_meta`` is True, an existing `_meta`
+        entry in the namespace is excluded from the stale-sweep regardless
+        of whether the bundle declares one. This is the legacy / pre-17.5
+        bundle path: the bundle carries no top-level header trio, so the
+        meta upsert is skipped, and the existing meta entry must be left
+        untouched (AC11).
+
+        Args:
+            namespace: The namespace whose state is being replaced.
+            ordered: The bundle's prepared entries (team first, then sorted
+                non-team).
+            preserve_meta: When True, exclude the canonical ``_meta`` entry
+                (id="_meta", kind="meta") from the stale-sweep. Default
+                False — the standard atomic-replace behaviour.
         """
         current = self._repository.list_by_namespace(namespace)
         bundle_ids = {e.id for e in ordered}
         stale = [e for e in current if e.id not in bundle_ids]
+        if preserve_meta:
+            stale = [e for e in stale if not (e.id == "_meta" and e.kind == "meta")]
         stale_non_team = [e for e in stale if e.kind != "team"]
         stale_team = [e for e in stale if e.kind == "team"]
         for e in stale_non_team:
@@ -921,6 +1216,112 @@ def _is_cross_ns_marker(node: dict[str, Any]) -> bool:
         return True
     raw_ref = node.get(REF_KEY)
     return isinstance(raw_ref, str) and "." in raw_ref
+
+
+def _partition_meta(entries: builtins.list[Entry]) -> tuple[Entry | None, builtins.list[Entry]]:
+    """Split ``entries`` into ``(meta_entry_or_None, [non_meta_entries])``.
+
+    The meta entry is identified by the canonical predicate
+    ``e.id == "_meta" and e.kind == "meta"`` — both checks together so an
+    accidental ``id="_meta"`` non-meta entry (or a hand-rolled
+    ``kind="meta"`` entry under a non-canonical id) is excluded from the
+    hoist. The meta-singleton invariant is enforced separately by
+    :meth:`Catalog._check_meta_singleton`; this helper is a structural split
+    only and does not validate cardinality.
+    """
+    meta_entry: Entry | None = None
+    non_meta: builtins.list[Entry] = []
+    for entry in entries:
+        if entry.id == "_meta" and entry.kind == "meta":
+            meta_entry = entry
+        else:
+            non_meta.append(entry)
+    return meta_entry, non_meta
+
+
+def _iter_cross_ns_targets(payload: Any) -> builtins.list[tuple[str, str]]:
+    """Return every ``(target_namespace, target_id)`` reachable through cross-ns ref markers.
+
+    Walks the payload tree recursively and collects every dict node carrying
+    a ``__ref__`` entry that resolves to a cross-namespace target. The
+    walker recognises the same two cross-ns shapes as the resolver:
+
+    * **Canonical** — a sibling ``__namespace__`` key on the ref marker.
+    * **Shorthand** — a ``<ns>.<id>`` form in the ``__ref__`` value (split
+      on the first dot only, matching the resolver's
+      ``_resolve_target_namespace``).
+
+    Same-namespace markers (no ``__namespace__``, no dot in ``__ref__``) are
+    excluded — they do not belong in the external section.
+
+    The walker is parse-only:
+
+    * No call to ``populate_refs``.
+    * No Pydantic validation.
+    * No repository access.
+    * No allowlist or shared-flag check (the shared-flag gate fires later,
+      when :meth:`Catalog._collect_external_refs` decides whether to fetch
+      the target).
+
+    Sibling-override sub-payloads (architecture/03 — non-reserved keys
+    alongside ``__ref__`` / ``__namespace__`` / ``__type__``) are walked
+    recursively, so a cross-ns ref marker that ALSO carries an override
+    sub-payload containing another cross-ns ref yields both targets.
+
+    Args:
+        payload: An ``Entry.payload`` tree — arbitrary nested ``dict`` /
+            ``list`` of JSON-able primitives.
+
+    Returns:
+        A flat list of ``(target_namespace, target_id)`` tuples in
+        depth-first traversal order. Duplicates are NOT removed at this
+        layer (the caller — :meth:`Catalog._collect_external_refs` — owns
+        deduplication so the worklist + visited-set algorithm operates on
+        the raw walker output).
+    """
+    results: builtins.list[tuple[str, str]] = []
+    _walk_for_cross_ns(payload, results)
+    return results
+
+
+def _walk_for_cross_ns(node: Any, out: builtins.list[tuple[str, str]]) -> None:
+    """Recursive helper for :func:`_iter_cross_ns_targets`."""
+    if isinstance(node, dict):
+        if REF_KEY in node:
+            pair = _classify_cross_ns_marker(node)
+            if pair is not None:
+                out.append(pair)
+            for key, value in node.items():
+                if key not in _RESERVED_REF_KEYS:
+                    _walk_for_cross_ns(value, out)
+            return
+        for value in node.values():
+            _walk_for_cross_ns(value, out)
+        return
+    if isinstance(node, list):
+        for item in node:
+            _walk_for_cross_ns(item, out)
+
+
+def _classify_cross_ns_marker(node: dict[str, Any]) -> tuple[str, str] | None:
+    """Return ``(target_namespace, target_id)`` for a cross-ns ref marker, else ``None``.
+
+    The classification mirrors the resolver's ``_resolve_target_namespace``:
+
+    * If ``__ref__`` is a string containing a dot, the first-dot split
+      yields ``(namespace, id)`` — this is the shorthand form.
+    * Else if ``__namespace__`` is set explicitly, the pair is
+      ``(__namespace__, __ref__)``.
+    * Otherwise the marker is same-namespace and ``None`` is returned.
+    """
+    raw_ref = node.get(REF_KEY)
+    if isinstance(raw_ref, str) and "." in raw_ref:
+        ns, rid = raw_ref.split(".", 1)
+        return ns, rid
+    explicit_ns = node.get(NAMESPACE_KEY)
+    if isinstance(explicit_ns, str) and isinstance(raw_ref, str):
+        return explicit_ns, raw_ref
+    return None
 
 
 def _iter_ref_targets(node: Any) -> list[str]:

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -2,11 +2,22 @@
 
 This module owns the single-bundle YAML format defined in architecture shard 09:
 an entire user or enterprise namespace serialised as one self-contained YAML
-document with document-level ``namespace`` + ``user_id`` and per-entry fields
-nested under ``entries.<id>``. The module exposes two pure functions:
+document with document-level ``namespace`` + ``user_id`` (and optional header
+projection — ``name`` / ``description`` / ``properties`` — hoisted from the
+namespace's ``_meta`` entry) plus per-entry fields nested under ``entries.<id>``.
 
-* :func:`dump_namespace` — serialise ``list[Entry]`` to YAML ``str``.
-* :func:`load_namespace` — parse YAML ``str`` into ``list[Entry]``.
+Story 17.6 — the wire format is the pre-17.5 dict-keyed shape extended with:
+
+* Top-level ``name`` / ``description`` / ``properties`` (header projection).
+* Per-kind external sections inside ``entries:`` keyed by composite ``<ns>.<id>``
+  for cross-namespace targets (collected upstream by
+  :meth:`Catalog._collect_external_refs`).
+
+The module exposes two pure functions:
+
+* :func:`dump_namespace` — serialise ``list[Entry]`` (+ optional header +
+  optional external refs) to YAML ``str``.
+* :func:`load_namespace` — parse YAML ``str`` into ``(list[Entry], BundleHeader)``.
 
 The module is repository-agnostic: neither function performs repository I/O,
 runs ``prepare_for_write``, or mutates any catalog state. The service-level
@@ -14,7 +25,7 @@ runs ``prepare_for_write``, or mutates any catalog state. The service-level
 repository boundary; this module owns only the wire format.
 
 ``load_namespace`` is deliberately kept pure (no ``prepare_for_write``) so
-Story 16.3's ``validate_namespace_yaml`` can reuse it in-process for dry-run
+``Catalog.validate_namespace_yaml`` can reuse it in-process for dry-run
 validation of proposed bundles.
 """
 
@@ -22,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass, field
 from typing import Any
 
 import yaml
@@ -31,16 +43,36 @@ from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.repositories.yaml import _BlockScalarDumper
 
-__all__ = ["dump_namespace", "load_namespace"]
+__all__ = ["BundleHeader", "dump_namespace", "load_namespace"]
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BundleHeader:
+    """Parsed top-level header fields for an export bundle.
+
+    ``present`` is ``True`` iff at least one of ``name`` / ``description`` /
+    ``properties`` was explicitly set in the source YAML. Pre-17.5 bundles
+    (no header fields at all) parse to ``BundleHeader(present=False, ...)``
+    so the import handler can skip the meta-upsert step (AC11 / AC12).
+    """
+
+    name: str = ""
+    description: str = ""
+    properties: dict[str, str] = field(default_factory=dict)
+    present: bool = False
+
 
 # Kind emit order for bundle serialisation: team → meta → agent → prompt → tool → model.
 # Reading a bundle top-down then mirrors the consumption graph: teams consume
 # agents; agents consume prompts, tools, and models. ``meta`` follows ``team``
 # because both describe the namespace as a whole (ADR-008 §D1). ``EntryKind``
 # is a closed ``Literal`` of exactly these six values, so indexing by ``e.kind``
-# is safe without a fallback.
+# is safe without a fallback. Story 17.6: the meta entry is hoisted to the
+# header and never appears in ``entries:`` for bundles produced by this
+# function, but the kind is retained in the table for the defensive case
+# where a caller passes a meta entry through ``dump_namespace`` directly.
 _KIND_EMIT_ORDER: dict[str, int] = {
     "team": 0,
     "meta": 1,
@@ -50,14 +82,17 @@ _KIND_EMIT_ORDER: dict[str, int] = {
     "model": 5,
 }
 
-# Section-header comment strings for each kind, aligned to an 80-character visual
-# width (Python string length) and bracketed with ``####`` markers at both ends so
-# the section break is loudly visible in an editor. The character ─ is U+2500 (1
-# Python char, 3 UTF-8 bytes). Pinned as frozen strings keyed by lowercase kind
-# name — deliberately NOT computed from kind.capitalize() so a future EntryKind
-# rename cannot silently shift header text. Shape: two-space indent + ``#### ``
-# + ``─── `` + capitalized plural name + space + ``─`` fill up to column 75 +
-# `` ####`` trailer → 80 columns total.
+# Story 17.6: external sections emit AFTER all local sections, in pre-17.5
+# kind order (team → agent → prompt → tool → model). Meta is intentionally
+# NOT in this ordering — meta entries are namespace-level metadata and never
+# appear as cross-ns targets.
+_EXTERNAL_KIND_ORDER: list[str] = ["team", "agent", "prompt", "tool", "model"]
+
+# Section-header comment strings for each local kind, aligned to an 80-character
+# visual width and bracketed with ``####`` markers. The character ─ is U+2500
+# (1 Python char, 3 UTF-8 bytes). Pinned as frozen strings keyed by lowercase
+# kind name — deliberately NOT computed from kind.capitalize() so a future
+# EntryKind rename cannot silently shift header text.
 _KIND_HEADERS: dict[str, str] = {
     "team": "  #### ─── Teams ".ljust(75, "─") + " ####",
     "meta": "  #### ─── Meta ".ljust(75, "─") + " ####",
@@ -67,26 +102,60 @@ _KIND_HEADERS: dict[str, str] = {
     "model": "  #### ─── Models ".ljust(75, "─") + " ####",
 }
 
+# Story 17.6 — section headers for external (cross-ns, readonly) entries.
+# One per kind that may appear in an external section.
+_EXTERNAL_KIND_HEADERS: dict[str, str] = {
+    "team": "  #### ─── Teams (External ref, readonly) ".ljust(75, "─") + " ####",
+    "agent": "  #### ─── Agents (External ref, readonly) ".ljust(75, "─") + " ####",
+    "prompt": "  #### ─── Prompts (External ref, readonly) ".ljust(75, "─") + " ####",
+    "tool": "  #### ─── Tools (External ref, readonly) ".ljust(75, "─") + " ####",
+    "model": "  #### ─── Models (External ref, readonly) ".ljust(75, "─") + " ####",
+}
+
 # Regex patterns used by the post-processor.
-# Matches a top-level entry key: exactly 2 spaces + identifier + colon (nothing else).
-_ENTRY_KEY_RE = re.compile(r"^  [A-Za-z0-9_\-]+:$")
+# Matches a top-level entry key: exactly 2 spaces + identifier (allowing dots
+# and underscores so composite ``<ns>.<id>`` keys are recognised) + colon.
+_ENTRY_KEY_RE = re.compile(r"^  [A-Za-z0-9_\-.]+:$")
 # Matches the kind line of an entry: 4 spaces + "kind: " + kind value.
 _KIND_LINE_RE = re.compile(r"^    kind: ([a-z]+)$")
+# Sentinel inserted as a comment line before composite-keyed sections so the
+# post-processor knows where to plant the External-ref headers without having
+# to reverse-engineer the dict-iteration order. Stripped on read by
+# ``yaml.safe_load`` (it is a comment).
+_EXTERNAL_SECTION_MARKER = "  # __EXTERNAL_SECTION__:{kind}"
+_EXTERNAL_SECTION_RE = re.compile(r"^  # __EXTERNAL_SECTION__:([a-z]+)$")
 
 
 # --- dump_namespace ---------------------------------------------------------
 
 
-def dump_namespace(entries: list[Entry]) -> str:
+def dump_namespace(
+    entries: list[Entry],
+    *,
+    name: str = "",
+    description: str = "",
+    properties: dict[str, str] | None = None,
+    external_refs: list[Entry] | None = None,
+) -> str:
     """Serialise a uniform-namespace list of entries to bundle YAML.
 
-    The output document has exactly three root keys in this order:
-    ``namespace``, ``user_id``, ``entries``. Each value under ``entries``
-    is keyed by the entry id and maps to six per-entry fields in declaration
-    order: ``kind``, ``model_type``, ``parent_namespace``, ``parent_id``,
-    ``description``, ``payload``. The ``id``, ``namespace`` and ``user_id``
-    fields are NOT duplicated inside the per-entry maps — they are implied
-    by the document context and the outer key.
+    The output document carries up to six top-level keys in declaration order:
+    ``namespace``, ``user_id``, ``name``, ``description``, ``properties``,
+    ``entries``. The header trio (``name`` / ``description`` / ``properties``)
+    is emitted ONLY when at least one of the four optional parameters is set
+    (i.e. ``name`` is non-empty, ``description`` is non-empty, ``properties``
+    is non-empty, or ``external_refs`` is non-empty). When all four parameters
+    are at their default values, the function emits the pre-17.5 wire shape
+    verbatim (three top-level keys: ``namespace``, ``user_id``, ``entries``)
+    so legacy callers see no behaviour change.
+
+    Each value under ``entries`` is keyed either by the entry id (local) or
+    by the composite ``<entry.namespace>.<entry.id>`` (external). Local values
+    map to six per-entry fields in declaration order: ``kind``, ``model_type``,
+    ``parent_namespace``, ``parent_id``, ``description``, ``payload``. The
+    ``id``, ``namespace`` and ``user_id`` fields are NOT duplicated inside
+    the per-entry maps — they are implied by the document context and the
+    outer key.
 
     Ownership invariant: every entry in ``entries`` MUST share the same
     ``user_id`` (including the ``None`` case for enterprise bundles).
@@ -99,22 +168,25 @@ def dump_namespace(entries: list[Entry]) -> str:
     re-resolve, re-validate, or re-reconcile; stored payloads are already
     intent-preserving.
 
-    Entries are emitted in a stable order grouped by kind in consumption
-    order — ``team`` → ``meta`` → ``agent`` → ``prompt`` → ``tool`` →
-    ``model`` — and within each kind sorted by ``id`` (lexicographic,
-    unicode codepoint order). Reading a bundle top-down then matches the
-    dependency tree: teams describe the namespace, meta annotates it; then
-    agents consume prompts, tools, and models.
-
-    The rendered document includes a comment-header line per non-empty kind
-    group and blank-line separation between entries; both are stripped by
-    ``yaml.safe_load`` on the import path, so round-tripping is unaffected.
+    Local entries are emitted in a stable order grouped by kind in
+    consumption order — ``team`` → ``meta`` → ``agent`` → ``prompt`` →
+    ``tool`` → ``model`` — and within each kind sorted by ``id``
+    (lexicographic). External sections emit AFTER all local kinds, in pre-17.5
+    kind order (team → agent → prompt → tool → model — no meta), each
+    section sorted by ``(namespace, id)`` ascending.
 
     Args:
         entries: Non-empty list of ``Entry`` instances sharing a single
-            namespace and user_id. The list MUST include at least one
-            entry — at import time a team entry is required, and
-            ``dump_namespace`` fails fast on the empty-list case.
+            namespace and user_id.
+        name: Optional namespace display name (header projection from
+            ``_meta.payload`` with team-payload fallback). Default ``""``
+            suppresses the header.
+        description: Optional namespace description. Default ``""``.
+        properties: Optional namespace properties mapping. Default ``None``
+            is treated as empty.
+        external_refs: Optional list of cross-namespace target entries. When
+            non-empty, emit per-kind external sections inside ``entries:``
+            using composite ``<ns>.<id>`` keys.
 
     Returns:
         A YAML document string produced via ``yaml.dump`` with
@@ -138,12 +210,25 @@ def dump_namespace(entries: list[Entry]) -> str:
     if errors:
         raise CatalogValidationError(errors)
 
+    properties = properties if properties is not None else {}
+    external_refs = external_refs if external_refs is not None else []
+    has_header = bool(name) or bool(description) or bool(properties) or bool(external_refs)
+
     sorted_entries = _sort_entries_for_emit(entries)
+    entries_map: dict[str, Any] = {e.id: _entry_to_map(e) for e in sorted_entries}
+    if external_refs:
+        _append_external_sections(entries_map, external_refs)
+
     doc: dict[str, Any] = {
         "namespace": entries[0].namespace,
         "user_id": entries[0].user_id,
-        "entries": {e.id: _entry_to_map(e) for e in sorted_entries},
     }
+    if has_header:
+        doc["name"] = name
+        doc["description"] = description
+        doc["properties"] = properties
+    doc["entries"] = entries_map
+
     raw = yaml.dump(
         doc,
         Dumper=_BlockScalarDumper,
@@ -152,6 +237,34 @@ def dump_namespace(entries: list[Entry]) -> str:
         default_flow_style=False,
     )
     return _format_bundle_sections(raw)
+
+
+def _append_external_sections(entries_map: dict[str, Any], external_refs: list[Entry]) -> None:
+    """Append composite-keyed external sections to ``entries_map``.
+
+    Inserts a sentinel comment marker before each kind transition so the
+    post-processor can plant the matching ``External-ref, readonly`` header.
+    Empty kinds (no external entry of that kind) emit no marker and no
+    header at all, per AC5.
+    """
+    for kind in _EXTERNAL_KIND_ORDER:
+        kind_entries = sorted(
+            (e for e in external_refs if e.kind == kind),
+            key=lambda e: (e.namespace, e.id),
+        )
+        if not kind_entries:
+            continue
+        # Sentinel key — must NOT contain characters that PyYAML would need
+        # to quote (no ``:``, no ``.``, no leading dash). Underscores + ASCII
+        # letters keep PyYAML in the bare-string emit path so the post-
+        # processor's regex match is stable. The colon-free shape is
+        # intentional: a YAML key containing ``:`` is forced into quoted form
+        # by PyYAML, which would break the post-processor's prefix match.
+        marker_key = f"__external_marker_{kind}"
+        entries_map[marker_key] = None
+        for e in kind_entries:
+            composite_key = f"{e.namespace}.{e.id}"
+            entries_map[composite_key] = _entry_to_map(e)
 
 
 def _peek_kind(lines: list[str], i: int) -> str:
@@ -167,29 +280,78 @@ def _format_bundle_sections(yaml_text: str) -> str:
     """Post-process a raw PyYAML bundle string to add section headers and spacing.
 
     Inserts a kind-section comment header (from ``_KIND_HEADERS``) and a blank
-    line at each kind transition inside the ``entries:`` block. Consecutive entries
-    within the same kind are separated by exactly one blank line. The header line
-    for a kind is preceded by one blank line (visual gap after the previous section
-    or after the ``entries:`` key). No blank line is added after the last entry.
+    line at each kind transition inside the ``entries:`` block. Consecutive
+    entries within the same kind are separated by exactly one blank line. The
+    header line for a kind is preceded by one blank line (visual gap after the
+    previous section or after the ``entries:`` key). External sections (planted
+    via the sentinel marker) replace the marker line with the
+    External-ref-suffixed header.
 
     The document ends with exactly one trailing newline.
     """
     lines = yaml_text.rstrip("\n").split("\n")
     output: list[str] = []
     last_kind: str | None = None
+    in_external = False
+    pending_external_header: str | None = None
     for i, line in enumerate(lines):
+        # External-section sentinel — a YAML ``__external_marker__:<kind>: null``
+        # pair planted by ``_append_external_sections``. Replace with the
+        # External-ref-suffixed header; suppress the local header for the
+        # entry that follows (its kind already matches the section).
+        marker_kind = _try_parse_external_marker_yaml(line)
+        if marker_kind is not None:
+            output.append("")
+            output.append(_EXTERNAL_KIND_HEADERS[marker_kind])
+            in_external = True
+            pending_external_header = marker_kind
+            last_kind = marker_kind  # the next entry key matches this kind
+            continue
         if _ENTRY_KEY_RE.match(line):
             kind = _peek_kind(lines, i)
-            if kind != last_kind:
+            if pending_external_header is not None:
+                # First entry under a freshly-emitted external section header.
+                # The header already wrote the blank-above; still need a blank
+                # line between the header and the entry key to honour AC5
+                # ("every section header is surrounded by a blank line above
+                # and a blank line below").
                 output.append("")
-                output.append(_KIND_HEADERS[kind])
+                pending_external_header = None
+            elif kind != last_kind:
+                # Kind transition within local sections — emit a fresh local
+                # header. External sections never reach this branch (the
+                # marker pre-set ``last_kind`` to the external kind).
+                output.append("")
+                if not in_external:
+                    output.append(_KIND_HEADERS[kind])
                 last_kind = kind
             else:
+                # Same-kind continuation — blank line between consecutive
+                # entries in the same section (local OR external).
                 output.append("")
             output.append(line)
         else:
             output.append(line)
     return "\n".join(output) + "\n"
+
+
+def _try_parse_external_marker_yaml(line: str) -> str | None:
+    """If ``line`` is the YAML form of an external-section sentinel, return its kind.
+
+    The sentinel is inserted as ``__external_marker_<kind>`` keyed at indent 2
+    with a ``None`` value. PyYAML emits ``  __external_marker_<kind>: null``.
+    The kind suffix is one of the closed ``EntryKind`` values that may appear
+    in an external section: team / agent / prompt / tool / model.
+    """
+    prefix = "  __external_marker_"
+    if not line.startswith(prefix):
+        return None
+    rest = line[len(prefix) :]
+    if rest.endswith(": null"):
+        return rest[: -len(": null")]
+    if rest.endswith(":"):
+        return rest[:-1]
+    return None
 
 
 def _check_uniform_owner(entries: list[Entry]) -> list[str]:
@@ -213,15 +375,7 @@ def _check_uniform_namespace(entries: list[Entry]) -> list[str]:
 
 
 def _sort_entries_for_emit(entries: list[Entry]) -> list[Entry]:
-    """Return a new list sorted by (kind emit order, id).
-
-    Kind order follows ``_KIND_EMIT_ORDER`` — ``team`` → ``meta`` →
-    ``agent`` → ``prompt`` → ``tool`` → ``model`` — the consumption graph
-    with the namespace-meta entry sandwiched between team and agents.
-    Within each kind, entries are sorted by ``id`` (lexicographic).
-    ``EntryKind`` is a closed ``Literal`` of exactly these six values, so
-    direct indexing (no ``.get`` fallback) is safe.
-    """
+    """Return a new list sorted by (kind emit order, id)."""
     return sorted(entries, key=lambda e: (_KIND_EMIT_ORDER[e.kind], e.id))
 
 
@@ -240,38 +394,50 @@ def _entry_to_map(entry: Entry) -> dict[str, Any]:
 # --- load_namespace ---------------------------------------------------------
 
 
-def load_namespace(yaml_text: str) -> list[Entry]:
-    """Parse a bundle YAML document and return the list of reconstructed entries.
+def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
+    """Parse a bundle YAML document and return ``(entries, header)``.
 
-    The parser is structurally strict: the root must be a ``dict`` with
-    ``namespace`` (non-empty ``str``), ``user_id`` (``str | None``), and
-    ``entries`` (non-empty ``dict``). Any missing or wrong-typed key accumulates
-    into a single ``CatalogValidationError`` — the error list is NOT
-    short-circuited after the first failure so frontends can render every
-    issue in one pass.
+    Story 17.6 — the parser is structurally strict: the root must be a
+    ``dict`` with ``namespace`` (non-empty ``str``), ``user_id`` (``str | None``),
+    and ``entries`` (non-empty ``dict``). Optional top-level fields ``name``
+    (``str``), ``description`` (``str``), and ``properties`` (``dict[str, str]``)
+    are projected into the returned :class:`BundleHeader`. Any missing or
+    wrong-typed required key accumulates into a single
+    ``CatalogValidationError`` — the error list is NOT short-circuited after
+    the first failure so frontends can render every issue in one pass.
 
-    Each ``(entry_id, entry_map)`` pair becomes an ``Entry`` whose ``id`` is
-    the outer key, and whose ``namespace`` and ``user_id`` come from the
-    document context. The six per-entry keys (``kind``, ``model_type``,
-    ``parent_namespace``, ``parent_id``, ``description``, ``payload``) are
-    consumed verbatim. Any Pydantic ``ValidationError`` raised by ``Entry``
-    construction is wrapped in ``CatalogValidationError`` with the substring
-    ``"entry '<id>' is invalid"`` so the offending id surfaces in UI toasts.
+    Each ``(entry_key, entry_map)`` pair under ``entries:`` is split on the
+    FIRST ``.`` to decide local vs. external:
+
+    * Key contains no ``.`` → local entry. The handler constructs an ``Entry``
+      with ``id=key``, ``namespace=<doc namespace>``, ``user_id=<doc user_id>``.
+    * Key contains at least one ``.`` → external entry (cross-namespace
+      target). The handler **SKIPS** it entirely (the import path treats
+      external entries as readonly display projection — they belong to other
+      namespaces and are not part of this namespace's atomic-replace contents).
+
+    A bundle whose ``entries:`` block is a YAML list (the rejected Story 17.5
+    wire shape) raises ``CatalogValidationError`` with an explicit message —
+    the field-shape is unambiguous, so an explicit error is preferable to
+    silent degradation.
 
     The function is parse-only: it does NOT call ``prepare_for_write``, does
-    NOT touch a repository, and does NOT persist anything. Callers that want
-    to persist parsed entries must feed them through the ``Catalog`` service.
+    NOT touch a repository, and does NOT persist anything.
 
     Args:
         yaml_text: The full bundle YAML document as a string.
 
     Returns:
-        The list of parsed ``Entry`` instances in dict-iteration order
-        (PyYAML yields keys in document order).
+        ``(entries, header)`` — the list of parsed local ``Entry`` instances
+        in dict-iteration order (PyYAML yields keys in document order), plus
+        the :class:`BundleHeader` projection of the optional top-level
+        header trio (``present=False`` when none of the three header fields
+        appears in the source).
 
     Raises:
         CatalogValidationError: On malformed YAML, structural failures,
-            empty entries dict, or per-entry construction failures.
+            empty / no-local-entries collection, or per-entry construction
+            failures.
     """
     doc = _parse_yaml(yaml_text)
     structural_errors = _validate_root_shape(doc)
@@ -286,10 +452,55 @@ def load_namespace(yaml_text: str) -> list[Entry]:
 
     namespace: str = doc["namespace"]
     user_id: str | None = doc["user_id"]
-    return [
-        _build_entry(entry_id, entry_map, namespace, user_id)
-        for entry_id, entry_map in entries_map.items()
-    ]
+    header = _project_header(doc)
+    entries: list[Entry] = []
+    for entry_key, entry_map in entries_map.items():
+        if "." in entry_key:
+            # External entry — skip on import per AC10.
+            continue
+        entries.append(_build_entry(entry_key, entry_map, namespace, user_id))
+
+    if not entries:
+        raise CatalogValidationError(
+            ["bundle must declare at least one entry, including a `kind=team` entry"]
+        )
+
+    return entries, header
+
+
+def _project_header(doc: dict[str, Any]) -> BundleHeader:
+    """Project the optional ``name`` / ``description`` / ``properties`` fields.
+
+    ``present=True`` iff at least one of the three header fields is explicitly
+    present in the document (regardless of value). This signal lets the
+    import handler distinguish a pre-17.5 bundle (no header at all → skip
+    meta upsert) from a 17.6 bundle whose header carries empty strings (still
+    upsert meta, possibly with the team-fallback values that the export path
+    synthesised).
+    """
+    name_present = "name" in doc
+    desc_present = "description" in doc
+    props_present = "properties" in doc
+    name_val = doc.get("name", "")
+    desc_val = doc.get("description", "")
+    props_val = doc.get("properties", {})
+    if not isinstance(name_val, str):
+        name_val = ""
+    if not isinstance(desc_val, str):
+        desc_val = ""
+    if not isinstance(props_val, dict):
+        props_val = {}
+    # Coerce property values to strings if any leaked through; this is a
+    # display projection so strict typing is enforced upstream by NamespaceMeta.
+    properties: dict[str, str] = {
+        str(k): str(v) for k, v in props_val.items() if isinstance(k, str)
+    }
+    return BundleHeader(
+        name=name_val,
+        description=desc_val,
+        properties=properties,
+        present=name_present or desc_present or props_present,
+    )
 
 
 def _parse_yaml(yaml_text: str) -> Any:
@@ -321,6 +532,15 @@ def _validate_root_shape(doc: Any) -> list[str]:
 
     if "entries" not in doc:
         errors.append("bundle root missing required key 'entries'")
+    elif isinstance(doc["entries"], list):
+        # Story 17.6 — the rejected 17.5 wire shape (``entries:`` as a list)
+        # is structurally unambiguous; raise an explicit error rather than
+        # silently producing an empty bundle (per AC12 — "any unambiguous
+        # behaviour is acceptable; silently producing wrong results is NOT").
+        errors.append(
+            "bundle 'entries' must be a mapping (the Story 17.5 list-of-items "
+            "shape is rejected — re-export to the dict-keyed shape)"
+        )
     elif not isinstance(doc["entries"], dict):
         errors.append(f"bundle 'entries' must be a mapping, got {type(doc['entries']).__name__}")
     return errors

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -118,12 +118,6 @@ _EXTERNAL_KIND_HEADERS: dict[str, str] = {
 _ENTRY_KEY_RE = re.compile(r"^  [A-Za-z0-9_\-.]+:$")
 # Matches the kind line of an entry: 4 spaces + "kind: " + kind value.
 _KIND_LINE_RE = re.compile(r"^    kind: ([a-z]+)$")
-# Sentinel inserted as a comment line before composite-keyed sections so the
-# post-processor knows where to plant the External-ref headers without having
-# to reverse-engineer the dict-iteration order. Stripped on read by
-# ``yaml.safe_load`` (it is a comment).
-_EXTERNAL_SECTION_MARKER = "  # __EXTERNAL_SECTION__:{kind}"
-_EXTERNAL_SECTION_RE = re.compile(r"^  # __EXTERNAL_SECTION__:([a-z]+)$")
 
 
 # --- dump_namespace ---------------------------------------------------------

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -585,7 +585,17 @@ class TestNamespaceExport:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/yaml")
         doc = yaml.safe_load(response.text)
-        assert list(doc.keys()) == ["namespace", "user_id", "entries"]
+        # Story 17.6 — six top-level keys in declaration order. The header
+        # trio (name/description/properties) is auto-synthesised from the
+        # team-payload fallback when no _meta entry exists in the namespace.
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "entries",
+        ]
         assert doc["namespace"] == "ns-exp"
         assert set(doc["entries"].keys()) == {"team", "a-1"}
 

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 from akgentic.catalog.catalog import Catalog
 from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
-from akgentic.catalog.serialization import dump_namespace, load_namespace
+from akgentic.catalog.serialization import dump_namespace
 
 from .conftest import (
     CatalogFactory,
@@ -132,15 +132,16 @@ class TestExportNamespaceYaml:
             catalog.export_namespace_yaml("nope")
 
     def test_export_round_trip_idempotent(self, catalog_factory: CatalogFactory) -> None:
+        """Two consecutive exports of an unchanged namespace produce byte-identical YAML."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "ns-rt")
         _seed_agent(catalog, "ns-rt", "a")
         _seed_agent(catalog, "ns-rt", "b")
-        yaml_text = catalog.export_namespace_yaml("ns-rt")
-        parsed = load_namespace(yaml_text)
-        # dump → load → dump yields the same yaml.
-        again = dump_namespace(parsed)
-        assert again == yaml_text
+        yaml_text_a = catalog.export_namespace_yaml("ns-rt")
+        yaml_text_b = catalog.export_namespace_yaml("ns-rt")
+        # Story 17.6 round-trip pin: deterministic ordering yields byte-identical
+        # re-export, including the header trio synthesized via team-fallback.
+        assert yaml_text_a == yaml_text_b
 
 
 # --- Import -----------------------------------------------------------------
@@ -159,9 +160,14 @@ class TestImportNamespaceYaml:
         # Rewrite to a different destination namespace.
         new_text = yaml_text.replace("ns-src", "ns-dst")
         result = catalog.import_namespace_yaml(new_text)
+        # The returned list reflects the bundle entries (team + a). Story 17.6
+        # AC11: the meta upsert is an atomic side-effect, NOT a bundle entry.
         assert {e.id for e in result} == {"team", "a"}
         fetched = repo.list_by_namespace("ns-dst")
-        assert {e.id for e in fetched} == {"team", "a"}
+        # Persisted state includes the auto-upserted `_meta` entry — the export
+        # synthesized header fields via team-fallback (no source meta), and the
+        # import path upserts a `_meta` from those fields atomically (AC11).
+        assert {e.id for e in fetched} == {"team", "a", "_meta"}
 
     def test_import_atomic_replace(self, catalog_factory: CatalogFactory) -> None:
         catalog, repo = catalog_factory()
@@ -627,3 +633,644 @@ class TestImportBundleCrossNs:
         msg = " | ".join(exc_info.value.errors)
         assert "not found in namespace" in msg
         assert "global" in msg
+
+
+# --- Story 17.6 — header projection on export ------------------------------
+
+
+def _seed_meta(
+    catalog: Catalog,
+    namespace: str,
+    *,
+    name: str = "Tenant",
+    description: str = "primary tenant",
+    properties: dict[str, str] | None = None,
+    user_id: str | None = "alice",
+) -> Entry:
+    """Create a `_meta` entry in ``namespace`` and return it."""
+    return catalog.create(
+        Entry(
+            id="_meta",
+            kind="meta",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_NAMESPACE_META_TYPE_BUNDLE,
+            payload={
+                "name": name,
+                "description": description,
+                "properties": properties if properties is not None else {},
+            },
+        )
+    )
+
+
+class TestHeaderProjection:
+    """Story 17.6 AC2 — `_meta` is hoisted to top-level header fields on export.
+
+    Behaviours pinned:
+    * Meta-present → header reads from meta.payload (name / description /
+      properties pass through verbatim).
+    * Meta-absent → header falls back to (team.payload['name'],
+      team.description, {}).
+    * Meta-with-empty-name → name falls back to team for `name` ONLY;
+      description and properties still come from the meta entry.
+    * Properties dict propagates verbatim; empty mapping emits as `{}`.
+    * The hoisted meta entry NEVER appears in `entries:`.
+    """
+
+    def test_meta_present_header_reads_from_meta(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-A")
+        _seed_meta(
+            catalog,
+            "tenant-A",
+            name="Agent Team",
+            description="Manager-led team",
+            properties={"shared": "true", "tier": "gold"},
+        )
+        text = catalog.export_namespace_yaml("tenant-A")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        # AC1 — six top-level keys in declaration order.
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "entries",
+        ]
+        assert doc["name"] == "Agent Team"
+        assert doc["description"] == "Manager-led team"
+        assert doc["properties"] == {"shared": "true", "tier": "gold"}
+        # AC2 — the meta entry is NEVER in `entries:` for bundles produced
+        # by Catalog.export_namespace_yaml.
+        assert "_meta" not in doc["entries"]
+
+    def test_meta_absent_falls_back_to_team(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-B")
+        _seed_agent(catalog, "tenant-B", "a")
+        text = catalog.export_namespace_yaml("tenant-B")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        # team payload['name'] = 'team' (from _team_payload); team.description = '' (default).
+        assert doc["name"] == "team"
+        assert doc["description"] == ""
+        assert doc["properties"] == {}
+
+    def test_meta_with_empty_name_falls_back_to_team_for_name_only(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """AC2 — empty meta name → fall back to team for name; keep meta description/properties."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-C")
+        # Hand-build a meta entry whose payload.name is empty (NamespaceMeta
+        # forbids that at validation time; bypass via the resolver-allowlist
+        # by writing the model_type that points at NamespaceMeta but with a
+        # raw payload that the validator would reject in normal CRUD. We do
+        # NOT go through Catalog.create here — that would re-validate.
+        # Instead, write directly to the repo to seed the empty-name case.)
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="tenant-C",
+                user_id="alice",
+                model_type=_NAMESPACE_META_TYPE_BUNDLE,
+                payload={
+                    "name": "",
+                    "description": "tenant description",
+                    "properties": {"shared": "true"},
+                },
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-C")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        # name falls back to team payload's name.
+        assert doc["name"] == "team"
+        # description and properties still come from the meta entry.
+        assert doc["description"] == "tenant description"
+        assert doc["properties"] == {"shared": "true"}
+
+    def test_shared_property_round_trips(self, catalog_factory: CatalogFactory) -> None:
+        """AC2 — `properties.shared='true'` propagates verbatim to top-level properties."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-D")
+        _seed_meta(
+            catalog,
+            "tenant-D",
+            name="Shared Tenant",
+            properties={"shared": "true"},
+        )
+        text = catalog.export_namespace_yaml("tenant-D")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert doc["properties"] == {"shared": "true"}
+
+
+# --- Story 17.6 — header upsert on import ----------------------------------
+
+
+class TestImportHeaderUpsert:
+    """Story 17.6 AC11 — meta is upserted from header fields atomically with entries."""
+
+    def _build_bundle_with_header(
+        self,
+        namespace: str = "tenant-X",
+        user_id: str | None = "alice",
+        name: str = "Tenant X",
+        description: str = "imported tenant",
+        properties: dict[str, str] | None = None,
+    ) -> str:
+        """Build a Story 17.6 bundle string with the header trio populated."""
+        team = Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        return dump_namespace(
+            [team],
+            name=name,
+            description=description,
+            properties=properties if properties is not None else {},
+        )
+
+    def test_import_creates_meta_when_absent(self, catalog_factory: CatalogFactory) -> None:
+        """Bundle has header → meta is CREATED when none existed."""
+        catalog, repo = catalog_factory()
+        yaml_text = self._build_bundle_with_header(
+            namespace="tenant-X",
+            name="X-name",
+            description="X-desc",
+            properties={"shared": "true"},
+        )
+        catalog.import_namespace_yaml(yaml_text)
+        meta = repo.get("tenant-X", "_meta")
+        assert meta is not None
+        assert meta.payload["name"] == "X-name"
+        assert meta.payload["description"] == "X-desc"
+        assert meta.payload["properties"] == {"shared": "true"}
+
+    def test_import_updates_meta_when_present(self, catalog_factory: CatalogFactory) -> None:
+        """Bundle has header → existing meta is UPDATED in place."""
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "tenant-Y")
+        _seed_meta(
+            catalog,
+            "tenant-Y",
+            name="OLD",
+            description="OLD-desc",
+            properties={"existing": "val"},
+        )
+        yaml_text = self._build_bundle_with_header(
+            namespace="tenant-Y",
+            name="NEW",
+            description="NEW-desc",
+            properties={"shared": "true"},
+        )
+        catalog.import_namespace_yaml(yaml_text)
+        meta = repo.get("tenant-Y", "_meta")
+        assert meta is not None
+        assert meta.payload["name"] == "NEW"
+        assert meta.payload["description"] == "NEW-desc"
+        assert meta.payload["properties"] == {"shared": "true"}
+
+    def test_import_legacy_bundle_skips_meta_upsert(self, catalog_factory: CatalogFactory) -> None:
+        """AC11 / AC12 — pre-17.5 bundle (no header trio) leaves existing _meta untouched."""
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "tenant-Z")
+        _seed_meta(
+            catalog,
+            "tenant-Z",
+            name="UNCHANGED",
+            description="should not move",
+            properties={"keep": "me"},
+        )
+        # Build a pre-17.5-shape bundle by hand (no top-level header keys).
+        legacy_text = (
+            "namespace: tenant-Z\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_team_payload()!r}\n"
+        )
+        catalog.import_namespace_yaml(legacy_text)
+        meta = repo.get("tenant-Z", "_meta")
+        assert meta is not None
+        assert meta.payload["name"] == "UNCHANGED"
+        assert meta.payload["description"] == "should not move"
+        assert meta.payload["properties"] == {"keep": "me"}
+
+    def test_import_no_meta_no_header_leaves_meta_absent(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Pre-17.5 bundle into an empty namespace creates no _meta entry."""
+        catalog, repo = catalog_factory()
+        legacy_text = (
+            "namespace: tenant-W\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_team_payload()!r}\n"
+        )
+        catalog.import_namespace_yaml(legacy_text)
+        # No _meta because the bundle had no header AND no _meta in entries:.
+        ids = {e.id for e in repo.list_by_namespace("tenant-W")}
+        assert ids == {"team"}
+
+    def test_import_with_explicit_meta_in_entries_wins(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """AC11 defensive — an explicit `_meta` in entries: wins over the (absent) header.
+
+        Pre-17.5 / hand-edited bundle path: the bundle has no header trio
+        but explicitly declares a _meta entry under entries:. The handler
+        treats _meta as a normal local-entry create — the meta-singleton
+        gate in Catalog.create allows exactly one _meta per namespace, so
+        the import succeeds.
+        """
+        catalog, repo = catalog_factory()
+        bundle = [
+            Entry(
+                id="team",
+                kind="team",
+                namespace="tenant-V",
+                user_id="alice",
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            ),
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="tenant-V",
+                user_id="alice",
+                model_type=_NAMESPACE_META_TYPE_BUNDLE,
+                payload={
+                    "name": "explicit-meta",
+                    "description": "from entries",
+                    "properties": {},
+                },
+            ),
+        ]
+        # No header kwargs → bundle has no top-level header → meta upsert skipped;
+        # the meta entry comes from `entries:` instead.
+        yaml_text = dump_namespace(bundle)
+        catalog.import_namespace_yaml(yaml_text)
+        meta = repo.get("tenant-V", "_meta")
+        assert meta is not None
+        assert meta.payload["name"] == "explicit-meta"
+
+
+# --- Story 17.6 — export with external refs --------------------------------
+
+
+class TestExportExternalRefs:
+    """Story 17.6 reshape of Story 17.5's behaviour pins.
+
+    Behaviours pinned (carry over from Story 17.5):
+    * Cross-ns targets in shared namespaces appear in external sections.
+    * Cross-ns targets in non-shared namespaces are silently omitted.
+    * Cross-ns targets that are missing are silently omitted.
+    * Same-namespace short-circuit (cross-ns marker pointing at the bundle's
+      own namespace is not external).
+    * Transitive reachability with cycle protection.
+    * No widening — same-namespace refs inside an external target's payload
+      do NOT widen the section.
+
+    Wire shape (NEW for Story 17.6):
+    * External entries appear UNDER `entries:` with composite `<ns>.<id>` keys.
+    * Per-kind external sections, marked `External ref, readonly`.
+    * No top-level `external_refs:` field.
+    """
+
+    def test_external_target_in_shared_namespace_appears(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_type, leaf_type = _register_agent_models(monkeypatch)
+        catalog, _repo = catalog_factory()
+        # Seed a shared global namespace + a target.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="shared-model",
+                kind="model",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "shared", "temperature": 0.0},
+            )
+        )
+        # Seed tenant with a ref to global.shared-model. Use the
+        # _AgentPayloadModel shape (provider/temperature/model_cfg) so
+        # prepare_for_write succeeds — the cross-ns walker reads `model_cfg`
+        # as a dict and finds the marker.
+        _seed_team(catalog, "tenant-S", user_id=None)
+        _seed_agent(
+            catalog,
+            "tenant-S",
+            "agent-1",
+            user_id=None,
+            payload={
+                "provider": "openai",
+                "temperature": 0.0,
+                "model_cfg": {"__ref__": "global.shared-model"},
+            },
+            model_type=agent_type,
+        )
+        text = catalog.export_namespace_yaml("tenant-S")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert "global.shared-model" in doc["entries"]
+        # No top-level external_refs key.
+        assert "external_refs" not in doc
+
+    def test_external_target_non_shared_silently_omitted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_type, leaf_type = _register_agent_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        # Seed global with a target but NO shared-flag.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(
+            Entry(
+                id="hidden-model",
+                kind="model",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "hidden", "temperature": 0.0},
+            )
+        )
+        # We cannot create a tenant entry with a cross-ns ref to a
+        # non-shared target through Catalog.create (the shared-flag gate
+        # rejects). Bypass by writing directly to the repo.
+        _seed_team(catalog, "tenant-N", user_id=None)
+        catalog._repository.put(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-N",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "model_cfg": {"__ref__": "global.hidden-model"},
+                },
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-N")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        # The non-shared target is silently omitted (no external section emitted).
+        assert "global.hidden-model" not in doc["entries"]
+
+    def test_external_target_missing_silently_omitted(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_type, _leaf = _register_agent_models(monkeypatch)
+        catalog, _ = catalog_factory()
+        # Mark global shared but seed no target id.
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        # Bypass the catalog gate by writing the bad ref directly.
+        _seed_team(catalog, "tenant-M", user_id=None)
+        catalog._repository.put(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-M",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "model_cfg": {"__ref__": "global.does-not-exist"},
+                },
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-M")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert "global.does-not-exist" not in doc["entries"]
+
+
+# --- Story 17.6 — round-trip with external sections + snapshot --------------
+
+
+class TestRoundTripBundle:
+    """Story 17.6 AC20 / AC21 — round-trip + snapshot regression.
+
+    AC20 — export → save → import → re-export. Local-entries content
+    byte-identical (sans non-deterministic blank-line rules — assert
+    structural equality via yaml.safe_load).
+
+    AC21 — Snapshot fixture asserts the literal YAML structure (parsed)
+    of a representative export.
+    """
+
+    def test_round_trip_preserves_local_entries(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        catalog, _repo = catalog_factory()
+        _seed_team(catalog, "tenant-RT", user_id="alice")
+        _seed_meta(
+            catalog,
+            "tenant-RT",
+            name="Roundtrip Tenant",
+            description="rt",
+            properties={"shared": "true"},
+        )
+        _seed_agent(catalog, "tenant-RT", "a-1", user_id="alice")
+
+        yaml_a = catalog.export_namespace_yaml("tenant-RT")
+        # Import into a fresh dst-ns (rewrite the namespace string).
+        yaml_a_dst = yaml_a.replace("tenant-RT", "dst-ns")
+        catalog.import_namespace_yaml(yaml_a_dst)
+        yaml_b = catalog.export_namespace_yaml("dst-ns")
+
+        import yaml as _yaml
+
+        parsed_a = _yaml.safe_load(yaml_a_dst)
+        parsed_b = _yaml.safe_load(yaml_b)
+        # Entries dict equality (key-order-independent).
+        assert parsed_a["entries"] == parsed_b["entries"]
+        # Header trio survives the round-trip via meta upsert.
+        assert parsed_a["name"] == parsed_b["name"]
+        assert parsed_a["description"] == parsed_b["description"]
+        assert parsed_a["properties"] == parsed_b["properties"]
+
+    def test_pre_175_bundle_imports_cleanly(self, catalog_factory: CatalogFactory) -> None:
+        """AC12 — a hand-written legacy pre-17.5 bundle imports without errors."""
+        catalog, repo = catalog_factory()
+        legacy_text = (
+            "namespace: tenant-LEG\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_team_payload()!r}\n"
+        )
+        catalog.import_namespace_yaml(legacy_text)
+        ids = {e.id for e in repo.list_by_namespace("tenant-LEG")}
+        # No header trio → no meta upsert; only the team is created.
+        assert ids == {"team"}
+
+    def test_byte_identical_export_no_writes(self, catalog_factory: CatalogFactory) -> None:
+        """AC20 strict byte-identical contract."""
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "ns-bi")
+        _seed_meta(catalog, "ns-bi", name="X", properties={"shared": "true"})
+        _seed_agent(catalog, "ns-bi", "a")
+        text_a = catalog.export_namespace_yaml("ns-bi")
+        text_b = catalog.export_namespace_yaml("ns-bi")
+        assert text_a == text_b
+
+
+class TestSnapshotShape:
+    """Story 17.6 AC21 — structural snapshot of the canonical wire format."""
+
+    def test_canonical_export_structure(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_type, leaf_type = _register_agent_models(monkeypatch)
+        catalog, _repo = catalog_factory()
+        # Build a representative namespace:
+        # - 3 local kinds: team + agent + prompt (and meta hoisted to header).
+        # - 2 external kinds: model + tool (in shared global namespace).
+        _seed_team(catalog, "global", user_id=None)
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="m1",
+                kind="model",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "openai", "temperature": 0.0},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="t1",
+                kind="tool",
+                namespace="global",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "shared", "temperature": 0.0},
+            )
+        )
+
+        _seed_team(catalog, "tenant-Snap", user_id=None)
+        _seed_meta(
+            catalog,
+            "tenant-Snap",
+            name="Snap Tenant",
+            description="snap",
+            properties={"shared": "false"},
+            user_id=None,
+        )
+        catalog.create(
+            Entry(
+                id="prompt-1",
+                kind="prompt",
+                namespace="tenant-Snap",
+                user_id=None,
+                model_type=leaf_type,
+                payload={"provider": "p", "temperature": 0.0},
+            )
+        )
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-Snap",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "provider": "openai",
+                    "temperature": 0.0,
+                    "model_cfg": {"__ref__": "global.m1"},
+                },
+            )
+        )
+        # Second agent referencing the tool — keeps payloads valid against
+        # the test fixture's _AgentPayloadModel (provider/temperature/model_cfg).
+        catalog.create(
+            Entry(
+                id="agent-2",
+                kind="agent",
+                namespace="tenant-Snap",
+                user_id=None,
+                model_type=agent_type,
+                payload={
+                    "provider": "openai",
+                    "temperature": 0.0,
+                    "model_cfg": {"__ref__": "global.t1"},
+                },
+            )
+        )
+
+        text = catalog.export_namespace_yaml("tenant-Snap")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+
+        # Snapshot — top-level keys in order.
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "entries",
+        ]
+
+        # Snapshot — local kinds present (team + agent + prompt). No `_meta`.
+        local_keys = [k for k in doc["entries"] if "." not in k]
+        assert "team" in local_keys
+        assert "agent-1" in local_keys
+        assert "prompt-1" in local_keys
+        assert "_meta" not in local_keys
+
+        # Snapshot — external kinds present with composite keys.
+        composite_keys = [k for k in doc["entries"] if "." in k]
+        assert "global.m1" in composite_keys
+        assert "global.t1" in composite_keys
+
+        # Section header order: local Teams → local Agents → local Prompts →
+        # external Tools (External ref) → external Models (External ref).
+        from akgentic.catalog.serialization import (
+            _EXTERNAL_KIND_HEADERS,
+            _KIND_HEADERS,
+        )
+
+        teams_pos = text.index(_KIND_HEADERS["team"])
+        agents_pos = text.index(_KIND_HEADERS["agent"])
+        prompts_pos = text.index(_KIND_HEADERS["prompt"])
+        ext_tools_pos = text.index(_EXTERNAL_KIND_HEADERS["tool"])
+        ext_models_pos = text.index(_EXTERNAL_KIND_HEADERS["model"])
+        assert teams_pos < agents_pos < prompts_pos < ext_tools_pos < ext_models_pos

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -143,7 +143,15 @@ class TestExportVerb:
         )
         assert result.exit_code == 0, result.stderr
         payload = yaml.safe_load(result.stdout)
-        assert set(payload.keys()) == {"namespace", "user_id", "entries"}
+        # Story 17.6 — six top-level keys including the header trio.
+        assert set(payload.keys()) == {
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "entries",
+        }
         assert payload["namespace"] == "ns-a"
         assert "team-a" in payload["entries"]
         assert "tool-a" in payload["entries"]

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``akgentic.catalog.serialization`` (Story 16.2)."""
+"""Unit tests for ``akgentic.catalog.serialization`` (Stories 16.2 / 17.6)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,9 @@ import yaml
 from akgentic.catalog.models.entry import Entry
 from akgentic.catalog.models.errors import CatalogValidationError
 from akgentic.catalog.serialization import (
+    _EXTERNAL_KIND_HEADERS,
     _KIND_HEADERS,
+    BundleHeader,
     dump_namespace,
     load_namespace,
 )
@@ -20,6 +22,7 @@ _AGENT_TYPE = "akgentic.core.agent_card.AgentCard"
 _PROMPT_TYPE = "akgentic.llm.prompts.PromptTemplate"
 _TOOL_TYPE = "akgentic.tool.tool_card.ToolCard"
 _MODEL_TYPE = "akgentic.llm.model_config.ModelConfig"
+_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 
 
 def _team(namespace: str = "ns-1", user_id: str | None = "alice") -> Entry:
@@ -94,22 +97,51 @@ def _model(
     )
 
 
-# --- dump_namespace ---------------------------------------------------------
+def _meta(
+    namespace: str = "ns-1",
+    user_id: str | None = "alice",
+    entry_id: str = "_meta",
+    name: str = "Tenant",
+    description: str = "primary tenant",
+    properties: dict[str, str] | None = None,
+) -> Entry:
+    return Entry(
+        id=entry_id,
+        kind="meta",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=_META_TYPE,
+        description="namespace meta",
+        payload={
+            "name": name,
+            "description": description,
+            "properties": properties if properties is not None else {},
+        },
+    )
+
+
+# --- dump_namespace (pre-17.5 shape via default kwargs) ---------------------
 
 
 class TestDumpNamespace:
+    """Restored pre-17.5 dict-keyed shape — emitted when no header / external_refs are passed."""
+
     def test_round_trip(self) -> None:
         entries = [_team(), _agent("b"), _agent("a"), _agent("c")]
         text = dump_namespace(entries)
-        parsed = load_namespace(text)
+        parsed_entries, header = load_namespace(text)
         # dump reorders (team first, non-team sorted); round-trip input-order is
         # the dumped order. Compare after reordering the input to match.
         expected_order = [_team(), _agent("a"), _agent("b"), _agent("c")]
-        assert [e.model_dump() for e in parsed] == [e.model_dump() for e in expected_order]
+        assert [e.model_dump() for e in parsed_entries] == [e.model_dump() for e in expected_order]
+        # Pre-17.5 callers pass no header → header NOT emitted → parsed header
+        # has present=False.
+        assert header.present is False
 
-    def test_root_keys_and_order(self) -> None:
+    def test_root_keys_legacy_no_header(self) -> None:
         text = dump_namespace([_team(), _agent("a")])
         doc = yaml.safe_load(text)
+        # Pre-17.5 wire shape — three top-level keys, no header trio.
         assert list(doc.keys()) == ["namespace", "user_id", "entries"]
         assert doc["namespace"] == "ns-1"
         assert doc["user_id"] == "alice"
@@ -118,7 +150,6 @@ class TestDumpNamespace:
         text = dump_namespace([_team(user_id=None), _agent("a", user_id=None)])
         doc = yaml.safe_load(text)
         assert doc["user_id"] is None
-        # YAML null, not the literal string "null".
         assert "user_id: null" in text
 
     def test_entry_keys_and_order(self) -> None:
@@ -146,40 +177,15 @@ class TestDumpNamespace:
 
     def test_emit_order_groups_by_kind_then_id(self) -> None:
         """Entries emit in kind order (team, agent, prompt, tool, model) then id."""
-        prompt_a = Entry(
-            id="prompt_a",
-            kind="prompt",
-            namespace="ns-1",
-            user_id="alice",
-            model_type="akgentic.llm.prompts.PromptTemplate",
-            payload={},
-        )
-        tool_a = Entry(
-            id="tool_a",
-            kind="tool",
-            namespace="ns-1",
-            user_id="alice",
-            model_type="akgentic.tool.tool_card.ToolCard",
-            payload={},
-        )
-        model_b = Entry(
-            id="model_b",
-            kind="model",
-            namespace="ns-1",
-            user_id="alice",
-            model_type="akgentic.llm.model_config.ModelConfig",
-            payload={},
-        )
-        model_a = Entry(
-            id="model_a",
-            kind="model",
-            namespace="ns-1",
-            user_id="alice",
-            model_type="akgentic.llm.model_config.ModelConfig",
-            payload={},
-        )
-        # Input order scrambled on purpose; two models verify intra-kind id sub-sort.
-        entries = [model_b, tool_a, _agent("zulu"), prompt_a, model_a, _agent("alpha"), _team()]
+        entries = [
+            _model("model_b"),
+            _tool("tool_a"),
+            _agent("zulu"),
+            _prompt("prompt_a"),
+            _model("model_a"),
+            _agent("alpha"),
+            _team(),
+        ]
         text = dump_namespace(entries)
         doc = yaml.safe_load(text)
         assert list(doc["entries"].keys()) == [
@@ -228,8 +234,8 @@ class TestDumpNamespace:
         }
         entries = [_team(), _agent("a", payload=ref_payload)]
         text = dump_namespace(entries)
-        parsed = load_namespace(text)
-        round_tripped = next(e for e in parsed if e.id == "a")
+        parsed_entries, _header = load_namespace(text)
+        round_tripped = next(e for e in parsed_entries if e.id == "a")
         assert round_tripped.payload == ref_payload
 
 
@@ -258,11 +264,14 @@ class TestLoadNamespace:
             "bundle must declare at least one entry, including a `kind=team` entry"
         ]
 
-    def test_rejects_entries_as_list(self) -> None:
+    def test_rejects_entries_as_list_with_explicit_message(self) -> None:
+        """Story 17.6 — the rejected 17.5 wire shape (list-of-items) raises explicitly."""
         text = "namespace: ns-1\nuser_id: alice\nentries: []\n"
         with pytest.raises(CatalogValidationError) as exc_info:
             load_namespace(text)
-        assert any("entries" in e and "mapping" in e for e in exc_info.value.errors)
+        # Hand-edited 17.5-shape bundles surface a clear error pointing at the
+        # rejected shape, so a downstream caller (CLI / API) can render it.
+        assert any("Story 17.5" in e or "list-of-items" in e for e in exc_info.value.errors)
 
     def test_rejects_namespace_empty(self) -> None:
         text = "namespace: ''\nuser_id: alice\nentries:\n  team: {kind: team}\n"
@@ -286,7 +295,6 @@ class TestLoadNamespace:
         assert any("mapping" in e for e in exc_info.value.errors)
 
     def test_wraps_per_entry_validation(self) -> None:
-        # Missing model_type — Pydantic ValidationError surfaces as CatalogValidationError.
         text = "namespace: ns-1\nuser_id: alice\nentries:\n  a:\n    kind: agent\n    payload: {}\n"
         with pytest.raises(CatalogValidationError) as exc_info:
             load_namespace(text)
@@ -316,23 +324,78 @@ class TestLoadNamespace:
             "    model_type: akgentic.core.agent_card.AgentCard\n"
             "    payload: {}\n"
         )
-        parsed = load_namespace(text)
-        assert [e.id for e in parsed] == ["team", "zulu", "alpha"]
+        parsed_entries, _header = load_namespace(text)
+        assert [e.id for e in parsed_entries] == ["team", "zulu", "alpha"]
+
+    def test_legacy_pre_175_bundle_parses_with_header_absent(self) -> None:
+        """AC12 — pre-17.5 bundles (no header fields, no composite keys) parse identically."""
+        text = (
+            "namespace: tenant-A\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    payload: {name: team}\n"
+            "  agent_a:\n"
+            "    kind: agent\n"
+            "    model_type: akgentic.core.agent_card.AgentCard\n"
+            "    payload: {role: a}\n"
+        )
+        parsed_entries, header = load_namespace(text)
+        assert {e.id for e in parsed_entries} == {"team", "agent_a"}
+        # The header is absent — meta upsert will skip on import (AC11 / AC12).
+        assert header.present is False
+        assert header.name == ""
+        assert header.description == ""
+        assert header.properties == {}
+
+    def test_skips_composite_keyed_entries(self) -> None:
+        """AC10 — a key with a dot is treated as external and skipped."""
+        text = (
+            "namespace: tenant-A\n"
+            "user_id: alice\n"
+            "name: tenant-A\n"
+            "description: ''\n"
+            "properties: {}\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    payload: {name: team}\n"
+            "  global.shared-prompt:\n"
+            "    kind: prompt\n"
+            "    model_type: akgentic.llm.prompts.PromptTemplate\n"
+            "    payload: {template: shared}\n"
+        )
+        parsed_entries, header = load_namespace(text)
+        # Only the local team is constructed; the composite-keyed entry is skipped.
+        assert {e.id for e in parsed_entries} == {"team"}
+        assert header.present is True
+        assert header.name == "tenant-A"
+
+    def test_rejects_bundle_with_only_external_entries(self) -> None:
+        """A bundle whose entries: dict carries ONLY composite keys is empty post-skip."""
+        text = (
+            "namespace: tenant-A\n"
+            "user_id: alice\n"
+            "entries:\n"
+            "  global.id1:\n"
+            "    kind: prompt\n"
+            "    model_type: akgentic.llm.prompts.PromptTemplate\n"
+            "    payload: {}\n"
+        )
+        with pytest.raises(CatalogValidationError) as exc_info:
+            load_namespace(text)
+        assert any("bundle must declare at least one entry" in e for e in exc_info.value.errors)
 
 
-# --- section headers and spacing (Story 16.8) --------------------------------
+# --- section headers and spacing --------------------------------------------
 
 
 class TestSectionHeadersAndSpacing:
     def test_emits_header_per_non_empty_kind(self) -> None:
-        """Bundle with one entry of each kind produces all five section headers."""
-        entries = [
-            _team(),
-            _agent("a1"),
-            _prompt("p1"),
-            _tool("t1"),
-            _model("m1"),
-        ]
+        entries = [_team(), _agent("a1"), _prompt("p1"), _tool("t1"), _model("m1")]
         text = dump_namespace(entries)
         assert _KIND_HEADERS["team"] in text
         assert _KIND_HEADERS["agent"] in text
@@ -341,7 +404,6 @@ class TestSectionHeadersAndSpacing:
         assert _KIND_HEADERS["model"] in text
 
     def test_omits_header_for_absent_kind(self) -> None:
-        """Bundle with only a team entry produces only the Teams header."""
         text = dump_namespace([_team()])
         assert _KIND_HEADERS["team"] in text
         assert _KIND_HEADERS["agent"] not in text
@@ -350,14 +412,7 @@ class TestSectionHeadersAndSpacing:
         assert _KIND_HEADERS["model"] not in text
 
     def test_header_order_matches_kind_emit_order(self) -> None:
-        """Teams header appears before Agents, Agents before Prompts, etc."""
-        entries = [
-            _team(),
-            _agent("a1"),
-            _prompt("p1"),
-            _tool("t1"),
-            _model("m1"),
-        ]
+        entries = [_team(), _agent("a1"), _prompt("p1"), _tool("t1"), _model("m1")]
         text = dump_namespace(entries)
         teams_pos = text.index(_KIND_HEADERS["team"])
         agents_pos = text.index(_KIND_HEADERS["agent"])
@@ -367,7 +422,6 @@ class TestSectionHeadersAndSpacing:
         assert teams_pos < agents_pos < prompts_pos < tools_pos < models_pos
 
     def test_same_kind_entries_separated_by_blank_line(self) -> None:
-        """Three agents produce exactly two blank-line separators within the agent section."""
         entries = [_agent("a1"), _agent("a2"), _agent("a3"), _team()]
         text = dump_namespace(entries)
         agents_header = _KIND_HEADERS["agent"]
@@ -376,33 +430,13 @@ class TestSectionHeadersAndSpacing:
         double_newlines = agent_section.count("\n\n")
         assert double_newlines == 2
 
-    def test_no_blank_line_immediately_after_header(self) -> None:
-        """The first entry of a kind immediately follows the header — no blank line in between."""
-        entries = [_team(), _agent("a1"), _agent("a2")]
-        text = dump_namespace(entries)
-        for kind in ("team", "agent"):
-            header = _KIND_HEADERS[kind]
-            header_pos = text.index(header)
-            after_header = text[header_pos + len(header) :]
-            # Exactly one newline ends the header line; no empty line before the first entry key.
-            assert after_header.startswith("\n  "), (
-                f"Expected header for {kind!r} to be followed immediately by an entry key line, "
-                f"got: {after_header[:40]!r}"
-            )
-
     def test_no_blank_line_at_end_of_final_section(self) -> None:
-        """The output ends with exactly one trailing newline, no double newline at EOF."""
         entries = [_team(), _agent("a1")]
         text = dump_namespace(entries)
         assert text.endswith("\n")
         assert not text.endswith("\n\n")
 
     def test_round_trip_through_safe_load_preserves_values(self) -> None:
-        """load_namespace(dump_namespace(entries)) returns structurally equal list.
-
-        Covers: (a) single-team-only, (b) one of each kind, (c) multi-entry per kind
-        (3 agents, 3 prompts, 3 tools, 1 model), (d) enterprise bundle with user_id=None.
-        """
         entries = [
             _team(),
             _agent("agent_a"),
@@ -417,7 +451,7 @@ class TestSectionHeadersAndSpacing:
             _model("model_1"),
         ]
         text = dump_namespace(entries)
-        recovered = load_namespace(text)
+        recovered, _header = load_namespace(text)
         sort_key = lambda e: (e.kind, e.id)  # noqa: E731
         assert [e.model_dump() for e in sorted(recovered, key=sort_key)] == [
             e.model_dump() for e in sorted(entries, key=sort_key)
@@ -426,14 +460,9 @@ class TestSectionHeadersAndSpacing:
         assert set(parsed_doc["entries"].keys()) == {e.id for e in entries}
 
     def test_round_trip_enterprise_bundle(self) -> None:
-        """Enterprise bundle (user_id=None) round-trips correctly through dump/load."""
-        entries = [
-            _team(user_id=None),
-            _agent("a1", user_id=None),
-            _prompt("p1", user_id=None),
-        ]
+        entries = [_team(user_id=None), _agent("a1", user_id=None), _prompt("p1", user_id=None)]
         text = dump_namespace(entries)
-        recovered = load_namespace(text)
+        recovered, _header = load_namespace(text)
         sort_key = lambda e: (e.kind, e.id)  # noqa: E731
         assert [e.model_dump() for e in sorted(recovered, key=sort_key)] == [
             e.model_dump() for e in sorted(entries, key=sort_key)
@@ -442,33 +471,16 @@ class TestSectionHeadersAndSpacing:
         assert doc["user_id"] is None
 
 
-# --- Story 17.2 — meta entry emit order and round-trip ---------------------
-
-
-_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
-
-
-def _meta(
-    namespace: str = "ns-1",
-    user_id: str | None = "alice",
-    entry_id: str = "_meta",
-) -> Entry:
-    return Entry(
-        id=entry_id,
-        kind="meta",
-        namespace=namespace,
-        user_id=user_id,
-        model_type=_META_TYPE,
-        description="namespace meta",
-        payload={"name": "Tenant", "description": "primary tenant", "properties": {}},
-    )
+# --- Story 17.2 — meta entry emit order via legacy dump (no header trio) -----
 
 
 class TestMetaEmitOrderAndRoundTrip:
-    """Story 17.2 AC9 / AC10 — meta is emitted between team and agent."""
+    """Story 17.2 — when a meta entry is passed to ``dump_namespace`` directly
+    (without going through ``Catalog.export_namespace_yaml``), it appears in
+    ``entries:`` under the Meta section. This is the defensive case for
+    callers that hand-build bundles without the catalog service's hoist."""
 
     def test_meta_section_header_present_between_team_and_agent(self) -> None:
-        """When a bundle carries team + meta + agent, the Meta header sits between them."""
         entries = [_team(), _meta(), _agent("a1")]
         text = dump_namespace(entries)
         team_header = _KIND_HEADERS["team"]
@@ -480,18 +492,237 @@ class TestMetaEmitOrderAndRoundTrip:
         assert team_pos < meta_pos < agent_pos
 
     def test_meta_entry_round_trips_through_dump_load(self) -> None:
-        """``load_namespace(dump_namespace([team, meta, agent]))`` returns equal entries."""
         entries = [_team(), _meta(), _agent("a1")]
         text = dump_namespace(entries)
-        recovered = load_namespace(text)
+        recovered, _header = load_namespace(text)
         sort_key = lambda e: (e.kind, e.id)  # noqa: E731
         assert [e.model_dump() for e in sorted(recovered, key=sort_key)] == [
             e.model_dump() for e in sorted(entries, key=sort_key)
         ]
 
     def test_meta_emit_order_index_one(self) -> None:
-        """Bundle with team + meta + agent emits in (team, meta, agent) order."""
         text = dump_namespace([_agent("a1"), _meta(), _team()])
         doc = yaml.safe_load(text)
         # Outer keys are emitted in (kind emit order, id) — team @ 0, meta @ 1, agent @ 2.
         assert list(doc["entries"].keys()) == ["team", "_meta", "a1"]
+
+
+# --- Story 17.6 — header projection / external sections (dump-side) ---------
+
+
+class TestDumpWithHeader:
+    """``dump_namespace`` extended signature — header projection."""
+
+    def test_header_emits_six_top_level_keys_in_order(self) -> None:
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+            description="primary",
+            properties={"shared": "true"},
+        )
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "entries",
+        ]
+        assert doc["name"] == "Tenant A"
+        assert doc["description"] == "primary"
+        assert doc["properties"] == {"shared": "true"}
+
+    def test_no_header_emits_three_keys(self) -> None:
+        """Pre-17.5 callers (no kwargs) get the three-key shape verbatim."""
+        text = dump_namespace([_team(), _agent("a")])
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == ["namespace", "user_id", "entries"]
+
+    def test_properties_empty_dict_emitted_as_mapping_when_other_header_set(self) -> None:
+        """AC2 — properties is always a mapping, never null."""
+        text = dump_namespace([_team(), _agent("a")], name="Tenant A")
+        doc = yaml.safe_load(text)
+        # When `name` is set, all three header fields are emitted; properties
+        # falls back to an empty mapping.
+        assert doc["properties"] == {}
+        assert "properties: {}" in text or "properties:\n" in text
+
+    def test_no_external_section_when_external_refs_empty(self) -> None:
+        """No external_refs → no External-ref headers anywhere in the output."""
+        text = dump_namespace([_team(), _agent("a")], name="X")
+        for kind, header in _EXTERNAL_KIND_HEADERS.items():
+            assert header not in text, f"unexpected external header for {kind!r}"
+
+
+class TestDumpExternalSections:
+    """``dump_namespace`` extended signature — external section emission."""
+
+    def test_external_section_uses_composite_keys(self) -> None:
+        external = [
+            _model("id_gpt_41", namespace="global", user_id=None),
+            _model("id_gpt_52", namespace="global", user_id=None),
+        ]
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+            external_refs=external,
+        )
+        doc = yaml.safe_load(text)
+        # Both external entries appear under entries: with composite <ns>.<id> keys.
+        assert "global.id_gpt_41" in doc["entries"]
+        assert "global.id_gpt_52" in doc["entries"]
+
+    def test_external_section_header_emitted(self) -> None:
+        external = [_model("m1", namespace="global", user_id=None)]
+        text = dump_namespace([_team()], name="X", external_refs=external)
+        # The External-ref Models header appears.
+        assert _EXTERNAL_KIND_HEADERS["model"] in text
+
+    def test_external_kinds_in_pre_175_order(self) -> None:
+        """AC5 — external sections emit team → agent → prompt → tool → model."""
+        external = [
+            _model("m1", namespace="global", user_id=None),
+            _tool("t1", namespace="global", user_id=None),
+            _agent("ext_a", namespace="global", user_id=None),
+            _prompt("p1", namespace="global", user_id=None),
+            _team(namespace="global", user_id=None),
+        ]
+        text = dump_namespace([_team()], name="X", external_refs=external)
+        ext_team_pos = text.index(_EXTERNAL_KIND_HEADERS["team"])
+        ext_agent_pos = text.index(_EXTERNAL_KIND_HEADERS["agent"])
+        ext_prompt_pos = text.index(_EXTERNAL_KIND_HEADERS["prompt"])
+        ext_tool_pos = text.index(_EXTERNAL_KIND_HEADERS["tool"])
+        ext_model_pos = text.index(_EXTERNAL_KIND_HEADERS["model"])
+        assert ext_team_pos < ext_agent_pos < ext_prompt_pos < ext_tool_pos < ext_model_pos
+
+    def test_external_entries_sorted_by_namespace_then_id(self) -> None:
+        """AC7 — within an external section, sort by (namespace, id) ascending."""
+        external = [
+            _model("zeta", namespace="bbb", user_id=None),
+            _model("alpha", namespace="aaa", user_id=None),
+            _model("alpha", namespace="bbb", user_id=None),
+            _model("zeta", namespace="aaa", user_id=None),
+        ]
+        text = dump_namespace([_team()], name="X", external_refs=external)
+        doc = yaml.safe_load(text)
+        # Expect aaa.alpha, aaa.zeta, bbb.alpha, bbb.zeta.
+        composite_keys = [k for k in doc["entries"] if "." in k]
+        assert composite_keys == ["aaa.alpha", "aaa.zeta", "bbb.alpha", "bbb.zeta"]
+
+    def test_external_section_header_preceded_by_blank_line(self) -> None:
+        """AC5 — every section header is surrounded by a blank line above and below."""
+        external = [_model("m1", namespace="global", user_id=None)]
+        text = dump_namespace([_team()], name="X", external_refs=external)
+        header = _EXTERNAL_KIND_HEADERS["model"]
+        idx = text.index(header)
+        # The line preceding the header must be empty.
+        before = text[:idx].rstrip("\n").splitlines()
+        assert before, "header should have content before it"
+        # The line directly below the header must be blank, then the entry.
+        after = text[idx + len(header) :]
+        # After the header line we expect: \n\n  <key>:\n
+        assert after.startswith("\n\n  "), repr(after[:30])
+
+    def test_local_entry_after_external_section_does_not_emit(self) -> None:
+        """Externals come AFTER all local sections; no local-after-external emit."""
+        # Build a bundle where the first entry is local and the rest are external.
+        text = dump_namespace(
+            [_team()],
+            name="X",
+            external_refs=[_model("m1", namespace="global", user_id=None)],
+        )
+        # The local Teams header appears BEFORE the external Models header.
+        teams_pos = text.index(_KIND_HEADERS["team"])
+        ext_models_pos = text.index(_EXTERNAL_KIND_HEADERS["model"])
+        assert teams_pos < ext_models_pos
+
+
+# --- Story 17.6 — load_namespace for header projection ----------------------
+
+
+class TestLoadHeaderProjection:
+    def test_header_present_when_all_three_set(self) -> None:
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+            description="primary",
+            properties={"shared": "true"},
+        )
+        _entries, header = load_namespace(text)
+        assert header.present is True
+        assert header.name == "Tenant A"
+        assert header.description == "primary"
+        assert header.properties == {"shared": "true"}
+
+    def test_header_absent_for_pre_175_bundle(self) -> None:
+        text = dump_namespace([_team(), _agent("a")])
+        _entries, header = load_namespace(text)
+        assert header.present is False
+
+    def test_header_present_when_only_name_set(self) -> None:
+        """A bundle carrying just `name` (auto-fills the rest) is still a 17.6 bundle."""
+        text = dump_namespace([_team(), _agent("a")], name="Tenant A")
+        _entries, header = load_namespace(text)
+        assert header.present is True
+        assert header.name == "Tenant A"
+
+
+# --- Story 17.6 — round-trip with the new shape -----------------------------
+
+
+class TestRoundTripNewShape:
+    """Two consecutive dumps of the same input produce byte-identical output."""
+
+    def test_byte_identical_two_consecutive_dumps(self) -> None:
+        external = [_model("id_gpt_41", namespace="global", user_id=None)]
+        text_a = dump_namespace(
+            [_team(), _agent("a"), _prompt("p1")],
+            name="Tenant",
+            description="primary",
+            properties={"shared": "true"},
+            external_refs=external,
+        )
+        text_b = dump_namespace(
+            [_team(), _agent("a"), _prompt("p1")],
+            name="Tenant",
+            description="primary",
+            properties={"shared": "true"},
+            external_refs=external,
+        )
+        assert text_a == text_b
+
+    def test_round_trip_drops_external_entries_on_import(self) -> None:
+        """AC10 — composite-keyed entries skip on load, so re-dump without them is asymmetric.
+
+        This pins the documented behaviour: a 17.6 bundle with externals
+        round-trips its LOCAL entries verbatim; externals are display
+        projection only.
+        """
+        external = [_model("ext", namespace="global", user_id=None)]
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant",
+            external_refs=external,
+        )
+        local_entries, header = load_namespace(text)
+        # Externals dropped — only local entries are reconstructed.
+        assert {e.id for e in local_entries} == {"team", "a"}
+        assert header.name == "Tenant"
+
+
+# --- BundleHeader dataclass smoke ------------------------------------------
+
+
+class TestBundleHeader:
+    def test_default_present_false(self) -> None:
+        h = BundleHeader()
+        assert h.name == ""
+        assert h.description == ""
+        assert h.properties == {}
+        assert h.present is False
+
+    def test_explicit_present(self) -> None:
+        h = BundleHeader(name="X", description="d", properties={"k": "v"}, present=True)
+        assert h.present is True
+        assert h.properties == {"k": "v"}


### PR DESCRIPTION
## Summary

Story 17.6 supersedes 17.5: revert to the pre-17.5 dict-keyed `dump_namespace`, then extend it with header projection and per-kind external sections.

- Top-level keys (declaration order): `namespace`, `user_id`, `name`, `description`, `properties`, `entries`. No top-level `external_refs:` field.
- `entries:` is a YAML mapping. Local entries keyed by id, external entries keyed by composite `<ns>.<id>`. Per-kind external sections live AFTER local sections, marked `External ref, readonly`.
- Six pinned per-entry keys (`kind`, `model_type`, `parent_namespace`, `parent_id`, `description`, `payload`) — no per-entry `id`/`namespace`/`user_id`.
- Header projection: `name`/`description`/`properties` come from the `_meta` entry (with team-payload fallback). The `_meta` entry is hoisted to the document header and never appears in `entries:`.
- Import path: composite-keyed entries are skipped; `_meta` is upserted from header fields atomically with the entries replace; pre-17.5 bundles parse identically.

Branch parent: `feat/164-shared-flag-meta` (Story 17.4). PR #167 (Story 17.5) is being closed unmerged after this PR opens.

Relates to #168.

## Test plan

- [x] `pytest packages/akgentic-catalog/tests/` — 925 passed, 23 skipped (mongo skips without a live backend).
- [x] `ruff check` + `ruff format --check` clean on `src/` and `tests/`.
- [x] `mypy --strict` clean on `src/`.
- [x] Coverage 91.19% overall (`serialization.py` 93%, `catalog.py` 89%).
- [ ] CI green on the feature branch.
