### PR TITLE
feat: promote shared to typed root field on NamespaceMeta; widen namespaces route to surface team-less namespaces (story 17.7)

### DIFF
--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -71,8 +71,8 @@ def create_app(
 
     Cross-namespace sharing is data-driven (ADR-008 §D2 as updated
     2026-05-08 rev 2): a namespace declares itself shareable through its
-    own ``_meta`` entry's ``payload["shared"] is True`` flag (typed bool
-    at the root, strict-bool comparison). Operators provision shared
+    own ``_meta`` entry's ``payload["shareable"] is True`` flag (typed bool
+    at the root, strict-bool comparison). Operators provision shareable
     namespaces via bundle import; no app-factory wiring is required.
     """
     repo = _build_repository(

--- a/src/akgentic/catalog/api/app.py
+++ b/src/akgentic/catalog/api/app.py
@@ -70,10 +70,10 @@ def create_app(
             are missing.
 
     Cross-namespace sharing is data-driven (ADR-008 §D2 as updated
-    2026-05-08): a namespace declares itself shareable through its own
-    ``_meta`` entry's ``properties["shared"] == "true"`` flag. Operators
-    provision shared namespaces via bundle import; no app-factory wiring
-    is required.
+    2026-05-08 rev 2): a namespace declares itself shareable through its
+    own ``_meta`` entry's ``payload["shared"] is True`` flag (typed bool
+    at the root, strict-bool comparison). Operators provision shared
+    namespaces via bundle import; no app-factory wiring is required.
     """
     repo = _build_repository(
         backend=backend,

--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -83,8 +83,8 @@ class NamespaceSummary(BaseModel):
       namespace; ``False`` for team-less library namespaces (e.g. a
       platform-defined ``global`` carrying shared models / tools / prompts
       without a team).
-    * ``shared`` — ``True`` iff a ``kind="meta"`` entry exists AND its
-      ``payload["shared"] is True`` (typed bool at the root, strict-bool
+    * ``shareable`` — ``True`` iff a ``kind="meta"`` entry exists AND its
+      ``payload["shareable"] is True`` (typed bool at the root, strict-bool
       comparison — ADR-008 §D2 as updated 2026-05-08 rev 2).
     """
 
@@ -92,7 +92,7 @@ class NamespaceSummary(BaseModel):
     name: str
     description: str
     team: bool
-    shared: bool
+    shareable: bool
 
 
 logger = logging.getLogger(__name__)
@@ -238,8 +238,8 @@ async def list_namespaces() -> list[NamespaceSummary]:
     * ``description`` — ``meta.description`` if a meta entry exists; else
       ``team.description`` if a team exists; else ``""``.
     * ``team`` — ``True`` iff a team entry was found by the team query.
-    * ``shared`` — ``True`` iff a meta entry was found AND
-      ``meta.payload.get("shared") is True`` (typed-bool, strict
+    * ``shareable`` — ``True`` iff a meta entry was found AND
+      ``meta.payload.get("shareable") is True`` (typed-bool, strict
       comparison).
     """
     logger.debug("GET /catalog/namespaces")
@@ -269,8 +269,8 @@ def _build_namespace_summary(
       ``description`` still comes from the meta entry).
     * ``description`` — meta if present, else team, else empty string.
     * ``team`` — ``True`` iff ``team is not None``.
-    * ``shared`` — ``True`` iff a meta entry exists AND its
-      ``payload.get("shared") is True`` (strict-bool, no truthy-string
+    * ``shareable`` — ``True`` iff a meta entry exists AND its
+      ``payload.get("shareable") is True`` (strict-bool, no truthy-string
       coercion — ADR-008 §D2 as updated 2026-05-08 rev 2).
     """
     team_name = ""
@@ -282,21 +282,21 @@ def _build_namespace_summary(
         description = team.description
 
     name = team_name
-    shared = False
+    shareable = False
     if meta is not None:
         meta_payload = meta.payload if isinstance(meta.payload, dict) else {}
         meta_name = meta_payload.get("name")
         if isinstance(meta_name, str) and meta_name != "":
             name = meta_name
         description = meta.description
-        shared = meta_payload.get("shared") is True
+        shareable = meta_payload.get("shareable") is True
 
     return NamespaceSummary(
         namespace=namespace,
         name=name,
         description=description,
         team=team is not None,
-        shared=shared,
+        shareable=shareable,
     )
 
 

--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -68,16 +68,31 @@ _YAML_CONTENT_TYPES: frozenset[str] = frozenset({"application/yaml", "applicatio
 class NamespaceSummary(BaseModel):
     """Flat DTO for ``GET /catalog/namespaces`` — one row per namespace.
 
-    Every catalog namespace contains exactly one ``kind="team"`` entry
-    (enforced by the catalog service), so "list namespaces" is equivalent to
-    "list team entries, project to this DTO". The shape intentionally omits
+    Every namespace surfaced here has at least one ``kind="team"`` OR
+    ``kind="meta"`` entry; the picker now sees both classes via the
+    union-discovery handler (Story 17.7). The shape intentionally omits
     ``user_id``, ``parent_namespace``, and other entry-model fields to keep
     the payload minimal and to avoid leaking tenancy design to the picker.
+
+    Five pinned fields in declaration order:
+
+    * ``namespace`` — the namespace identifier.
+    * ``name`` — the display name (meta-then-team fallback).
+    * ``description`` — the human-readable description.
+    * ``team`` — ``True`` iff a ``kind="team"`` entry exists in the
+      namespace; ``False`` for team-less library namespaces (e.g. a
+      platform-defined ``global`` carrying shared models / tools / prompts
+      without a team).
+    * ``shared`` — ``True`` iff a ``kind="meta"`` entry exists AND its
+      ``payload["shared"] is True`` (typed bool at the root, strict-bool
+      comparison — ADR-008 §D2 as updated 2026-05-08 rev 2).
     """
 
     namespace: str
     name: str
     description: str
+    team: bool
+    shared: bool
 
 
 logger = logging.getLogger(__name__)
@@ -198,47 +213,91 @@ def _multi_format_body_openapi(model_name: str) -> dict[str, Any]:
 
 
 async def list_namespaces() -> list[NamespaceSummary]:
-    """List every catalog namespace with name and description (meta-then-team fallback).
+    """List every namespace surfaced by team OR meta entries (Story 17.7 union discovery).
 
-    Issues one ``EntryQuery(kind="team")`` to discover every namespace. For
-    each team entry, the handler attempts ``Catalog.get(team.namespace,
-    "_meta")``; when a meta entry exists, ``name`` and ``description`` are
-    drawn from the meta payload (ADR-008 §D1). Otherwise the values fall
-    back to the team entry — preserving behaviour for deployments that
-    pre-date the meta entry.
+    Issues exactly TWO repository round-trips, independent of the namespace
+    count:
 
-    The list is sorted alphabetically by ``namespace``. No ``user_id``
-    filter is applied — callers (or tier-specific middleware) are
-    responsible for tenancy filtering.
+    * ``EntryQuery(kind="team")`` — every namespace with a team entry.
+    * ``EntryQuery(kind="meta")`` — every namespace with a meta entry,
+      including team-less library namespaces (e.g. a platform-defined
+      ``global`` holding shared models / tools / prompts).
+
+    The result list contains one row per namespace in the union, sorted
+    alphabetically ascending by ``namespace``. Each row is built via
+    :func:`_build_namespace_summary` from the (optional) team and (optional)
+    meta entries already in memory — no extra ``catalog.get`` round-trip
+    per row. No ``user_id`` filter is applied — callers (or tier-specific
+    middleware) are responsible for tenancy filtering.
+
+    Projection rules (AC7):
+
+    * ``name`` — ``meta.payload["name"]`` if a meta entry exists and its
+      name is a non-empty string; else ``team.payload.get("name", "")`` if
+      a team exists; else ``""`` (last-resort fallback for completeness).
+    * ``description`` — ``meta.description`` if a meta entry exists; else
+      ``team.description`` if a team exists; else ``""``.
+    * ``team`` — ``True`` iff a team entry was found by the team query.
+    * ``shared`` — ``True`` iff a meta entry was found AND
+      ``meta.payload.get("shared") is True`` (typed-bool, strict
+      comparison).
     """
     logger.debug("GET /catalog/namespaces")
     catalog = _get_catalog()
-    teams = catalog.list(EntryQuery(kind="team"))
-    summaries = [_build_namespace_summary(catalog, t) for t in teams]
-    return sorted(summaries, key=lambda s: s.namespace)
+    teams_by_ns: dict[str, Entry] = {e.namespace: e for e in catalog.list(EntryQuery(kind="team"))}
+    metas_by_ns: dict[str, Entry] = {e.namespace: e for e in catalog.list(EntryQuery(kind="meta"))}
+    namespaces = sorted(set(teams_by_ns) | set(metas_by_ns))
+    return [
+        _build_namespace_summary(ns, teams_by_ns.get(ns), metas_by_ns.get(ns)) for ns in namespaces
+    ]
 
 
-def _build_namespace_summary(catalog: Catalog, team: Entry) -> NamespaceSummary:
-    """Project ``team`` to a ``NamespaceSummary`` with the meta-then-team fallback.
+def _build_namespace_summary(
+    namespace: str,
+    team: Entry | None,
+    meta: Entry | None,
+) -> NamespaceSummary:
+    """Project optional team/meta entries to a ``NamespaceSummary`` row.
 
-    Reads the namespace's ``_meta`` entry when present and uses its
-    ``payload["name"]`` / ``description``. Falls back to the team entry's
-    values when no meta entry exists OR when the meta payload's ``name`` is
-    missing / empty (graceful degradation per AC6).
+    Performs NO repository I/O — both entries are passed in from the
+    union-discovery query already issued by :func:`list_namespaces`. The
+    helper applies the four projection rules pinned by Story 17.7 AC7:
+
+    * ``name`` — meta-then-team fallback, with empty-meta-name graceful
+      degradation (when the meta payload's ``name`` is missing / empty,
+      fall back to the team's payload name for ``name`` only;
+      ``description`` still comes from the meta entry).
+    * ``description`` — meta if present, else team, else empty string.
+    * ``team`` — ``True`` iff ``team is not None``.
+    * ``shared`` — ``True`` iff a meta entry exists AND its
+      ``payload.get("shared") is True`` (strict-bool, no truthy-string
+      coercion — ADR-008 §D2 as updated 2026-05-08 rev 2).
     """
-    team_name = str(team.payload.get("name", ""))
+    team_name = ""
+    description = ""
+    if team is not None:
+        team_payload = team.payload if isinstance(team.payload, dict) else {}
+        raw_team_name = team_payload.get("name", "")
+        team_name = raw_team_name if isinstance(raw_team_name, str) else ""
+        description = team.description
+
     name = team_name
-    description = team.description
-    try:
-        meta = catalog.get(team.namespace, "_meta")
-    except EntryNotFoundError:
-        meta = None
-    if meta is not None and meta.kind == "meta":
-        meta_name = meta.payload.get("name") if isinstance(meta.payload, dict) else None
+    shared = False
+    if meta is not None:
+        meta_payload = meta.payload if isinstance(meta.payload, dict) else {}
+        meta_name = meta_payload.get("name")
         if isinstance(meta_name, str) and meta_name != "":
             name = meta_name
         description = meta.description
-    return NamespaceSummary(namespace=team.namespace, name=name, description=description)
+        shared = meta_payload.get("shared") is True
+
+    return NamespaceSummary(
+        namespace=namespace,
+        name=name,
+        description=description,
+        team=team is not None,
+        shared=shared,
+    )
 
 
 async def get_namespace_meta(namespace: str) -> Entry:

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -1108,7 +1108,8 @@ class Catalog:
         repository write commits, so the next ``_is_namespace_shared``
         lookup re-reads the meta entry. A non-meta entry write is a
         no-op — the cache only depends on the meta entry's
-        ``properties["shared"]`` value.
+        ``payload["shared"]`` value (typed bool at the root, per ADR-008
+        §D2 as updated 2026-05-08 rev 2).
         """
         if entry.kind == "meta":
             self._shared_flag_cache.pop(entry.namespace, None)

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -107,14 +107,14 @@ class Catalog:
         Args:
             repository: Any concrete ``EntryRepository`` implementation.
 
-        Cross-namespace sharing (ADR-008 §D2 as updated 2026-05-08) is
-        data-driven: a namespace declares itself shareable through its own
-        ``_meta`` entry (``properties["shared"] == "true"``). The catalog
-        consults the meta entry on demand via :meth:`_is_namespace_shared`
-        and caches the answer on ``self._shared_flag_cache`` for the
-        lifetime of the instance; meta-entry mutations (any
-        ``create``/``update``/``delete`` of a ``kind="meta"`` entry)
-        invalidate the affected cache slot.
+        Cross-namespace sharing (ADR-008 §D2 as updated 2026-05-08 rev 2)
+        is data-driven: a namespace declares itself shareable through its
+        own ``_meta`` entry (``payload["shared"] is True``, a typed bool at
+        the root). The catalog consults the meta entry on demand via
+        :meth:`_is_namespace_shared` and caches the answer on
+        ``self._shared_flag_cache`` for the lifetime of the instance;
+        meta-entry mutations (any ``create``/``update``/``delete`` of a
+        ``kind="meta"`` entry) invalidate the affected cache slot.
         """
         self._repository: EntryRepository = repository
         # Per-instance cache: namespace -> shared boolean. Populated lazily on
@@ -278,8 +278,8 @@ class Catalog:
         if target is None:
             raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
         errors = validate_delete(namespace, id, self._repository)
-        # ADR-008 §D2 (updated 2026-05-08) — when the deleted entry's namespace
-        # is shared (its `_meta` carries `properties["shared"] == "true"`),
+        # ADR-008 §D2 (updated 2026-05-08 rev 2) — when the deleted entry's
+        # namespace is shared (its `_meta` carries `payload["shared"] is True`),
         # widen the guard to a global-scope check so cross-tenant referrers
         # also block the delete. Otherwise, the shared-flag gate would have
         # rejected any cross-ns referrer at create time, so the namespace-
@@ -478,13 +478,14 @@ class Catalog:
         """
         entries = self._repository.list_by_namespace(namespace)
         meta_entry, local_entries = _partition_meta(entries)
-        name, description, properties = self._project_header(meta_entry, local_entries)
+        name, description, properties, shared = self._project_header(meta_entry, local_entries)
         external_refs = self._collect_external_refs(local_entries)
         return dump_namespace(
             local_entries,
             name=name,
             description=description,
             properties=properties,
+            shared=shared,
             external_refs=external_refs,
         )
 
@@ -492,8 +493,8 @@ class Catalog:
         self,
         meta_entry: Entry | None,
         local_entries: _list[Entry],
-    ) -> tuple[str, str, dict[str, str]]:
-        """Project ``name`` / ``description`` / ``properties`` for the bundle header.
+    ) -> tuple[str, str, dict[str, str], bool]:
+        """Project ``name`` / ``description`` / ``properties`` / ``shared`` for the bundle header.
 
         When ``meta_entry`` is present, read from its payload. When the
         meta's ``payload.name`` is empty / missing, fall back to the team
@@ -501,11 +502,16 @@ class Catalog:
         properties still come from the meta entry (mirrors the existing
         ``list_namespaces`` graceful-degradation rule for empty meta names).
 
+        Story 17.7 — ``shared`` is read from ``meta_entry.payload.get("shared")``
+        with strict-bool ``is True`` comparison; ``False`` when the key is
+        missing or non-bool. When ``meta_entry`` is absent, ``shared``
+        defaults to ``False``.
+
         When ``meta_entry`` is absent, fall back fully to the team:
-        ``(team.payload.get("name", ""), team.description, {})``. When the
-        team entry is also absent (defensive — should not happen in practice
-        because the catalog service enforces a team-bootstrap invariant),
-        return empty defaults.
+        ``(team.payload.get("name", ""), team.description, {}, False)``.
+        When the team entry is also absent (defensive — should not happen
+        in practice because the catalog service enforces a team-bootstrap
+        invariant), return empty defaults.
 
         Args:
             meta_entry: The namespace's ``_meta`` entry, or ``None``.
@@ -513,8 +519,8 @@ class Catalog:
                 entry is located inside this list.
 
         Returns:
-            ``(name, description, properties)`` triple — the header
-            projection ready to pass to :func:`dump_namespace`.
+            ``(name, description, properties, shared)`` 4-tuple — the
+            header projection ready to pass to :func:`dump_namespace`.
         """
         team_entry = next((e for e in local_entries if e.kind == "team"), None)
         team_name = ""
@@ -526,7 +532,7 @@ class Catalog:
             team_description = team_entry.description
 
         if meta_entry is None:
-            return team_name, team_description, {}
+            return team_name, team_description, {}, False
 
         payload = meta_entry.payload if isinstance(meta_entry.payload, dict) else {}
         meta_name = payload.get("name", "")
@@ -541,9 +547,11 @@ class Catalog:
             meta_properties = {
                 str(k): str(v) for k, v in meta_properties_raw.items() if isinstance(k, str)
             }
+        # Strict-bool projection — only a real ``True`` flips the flag.
+        meta_shared = payload.get("shared") is True
         # Empty-meta-name graceful degradation — team-fallback for name only.
         name = meta_name if meta_name else team_name
-        return name, meta_description, meta_properties
+        return name, meta_description, meta_properties, meta_shared
 
     def _collect_external_refs(self, entries: _list[Entry]) -> _list[Entry]:
         """Return the deduplicated, shared-flag-filtered, transitively-reached cross-ns targets.
@@ -738,6 +746,7 @@ class Catalog:
                 name=header.name,
                 description=header.description,
                 properties=dict(header.properties),
+                shared=header.shared,
             ).model_dump()
         except ValueError as exc:
             raise CatalogValidationError([f"bundle header is invalid: {exc}"]) from exc
@@ -1058,13 +1067,14 @@ class Catalog:
         )
 
     def _is_namespace_shared(self, namespace: str) -> bool:
-        """Return ``True`` iff ``namespace``'s ``_meta`` has ``properties["shared"] == "true"``.
+        """Return ``True`` iff ``namespace``'s ``_meta`` has ``payload["shared"] is True``.
 
-        Per ADR-008 §D2 (updated 2026-05-08), a namespace is cross-namespace-
-        referenceable iff its meta entry carries the literal lowercase
-        string ``"true"`` under ``properties["shared"]``. The check is
-        exact-string equality — no truthy-string coercion, no case folding —
-        so operators must opt in unambiguously.
+        Per ADR-008 §D2 (updated 2026-05-08, rev 2), a namespace is cross-
+        namespace-referenceable iff its meta entry carries a typed boolean
+        ``True`` at the root under ``payload["shared"]``. The check is
+        strict-bool comparison — ``1``, ``"true"``, ``"True"``, and other
+        truthy strings all fall through to ``False``. Operators must opt in
+        unambiguously with a real boolean.
 
         The result is cached on ``self._shared_flag_cache`` keyed by
         namespace; subsequent calls for the same namespace return the
@@ -1078,18 +1088,16 @@ class Catalog:
 
         Returns:
             ``True`` if a meta entry exists in ``namespace`` and carries
-            ``properties["shared"] == "true"``; ``False`` otherwise (no
-            meta entry, missing key, or any other value).
+            ``payload["shared"] is True``; ``False`` otherwise (no meta
+            entry, missing key, ``False``, or any non-bool value).
         """
         cached = self._shared_flag_cache.get(namespace)
         if cached is not None:
             return cached
         meta = self._repository.get(namespace, "_meta")
         shared = False
-        if meta is not None:
-            properties = meta.payload.get("properties") if isinstance(meta.payload, dict) else None
-            if isinstance(properties, dict):
-                shared = properties.get("shared") == "true"
+        if meta is not None and isinstance(meta.payload, dict):
+            shared = meta.payload.get("shared") is True
         self._shared_flag_cache[namespace] = shared
         return shared
 

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -109,20 +109,20 @@ class Catalog:
 
         Cross-namespace sharing (ADR-008 §D2 as updated 2026-05-08 rev 2)
         is data-driven: a namespace declares itself shareable through its
-        own ``_meta`` entry (``payload["shared"] is True``, a typed bool at
-        the root). The catalog consults the meta entry on demand via
-        :meth:`_is_namespace_shared` and caches the answer on
-        ``self._shared_flag_cache`` for the lifetime of the instance;
+        own ``_meta`` entry (``payload["shareable"] is True``, a typed bool
+        at the root). The catalog consults the meta entry on demand via
+        :meth:`_is_namespace_shareable` and caches the answer on
+        ``self._shareable_flag_cache`` for the lifetime of the instance;
         meta-entry mutations (any ``create``/``update``/``delete`` of a
         ``kind="meta"`` entry) invalidate the affected cache slot.
         """
         self._repository: EntryRepository = repository
-        # Per-instance cache: namespace -> shared boolean. Populated lazily on
-        # first cross-ns ref resolution touching that namespace; invalidated
+        # Per-instance cache: namespace -> shareable boolean. Populated lazily
+        # on first cross-ns ref resolution touching that namespace; invalidated
         # whenever a meta entry in that namespace is created / updated /
-        # deleted (see ``_invalidate_shared_flag_cache`` callsites in the
+        # deleted (see ``_invalidate_shareable_flag_cache`` callsites in the
         # write paths).
-        self._shared_flag_cache: dict[str, bool] = {}
+        self._shareable_flag_cache: dict[str, bool] = {}
 
     # --- Read -----------------------------------------------------------------
 
@@ -204,10 +204,10 @@ class Catalog:
         prepared = prepare_for_write(
             entry,
             self._repository,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
         self._repository.put(prepared)
-        self._invalidate_shared_flag_cache(prepared)
+        self._invalidate_shareable_flag_cache(prepared)
         return prepared
 
     def update(self, entry: Entry) -> Entry:
@@ -250,13 +250,13 @@ class Catalog:
         prepared = prepare_for_write(
             entry,
             self._repository,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
         self._check_lineage_unchanged_or_reset(existing, prepared)
         if prepared.kind != "team":
             self._check_ownership(prepared)
         self._repository.put(prepared)
-        self._invalidate_shared_flag_cache(prepared)
+        self._invalidate_shareable_flag_cache(prepared)
         return prepared
 
     def delete(self, namespace: str, id: str) -> None:
@@ -279,12 +279,12 @@ class Catalog:
             raise EntryNotFoundError(f"Entry ({namespace}, {id}) not found")
         errors = validate_delete(namespace, id, self._repository)
         # ADR-008 §D2 (updated 2026-05-08 rev 2) — when the deleted entry's
-        # namespace is shared (its `_meta` carries `payload["shared"] is True`),
-        # widen the guard to a global-scope check so cross-tenant referrers
-        # also block the delete. Otherwise, the shared-flag gate would have
-        # rejected any cross-ns referrer at create time, so the namespace-
-        # local check is sufficient.
-        if self._is_namespace_shared(namespace):
+        # namespace is shareable (its `_meta` carries
+        # `payload["shareable"] is True`), widen the guard to a global-scope
+        # check so cross-tenant referrers also block the delete. Otherwise,
+        # the shareable-flag gate would have rejected any cross-ns referrer
+        # at create time, so the namespace-local check is sufficient.
+        if self._is_namespace_shareable(namespace):
             global_referrers = self._repository.find_references_global(namespace, id)
             errors = errors + [
                 f"Entry '{r.id}' (kind={r.kind}) in namespace '{r.namespace}' references '{id}'"
@@ -293,7 +293,7 @@ class Catalog:
         if errors:
             raise CatalogValidationError(errors)
         self._repository.delete(namespace, id)
-        self._invalidate_shared_flag_cache(target)
+        self._invalidate_shareable_flag_cache(target)
 
     # --- Clone ----------------------------------------------------------------
 
@@ -372,7 +372,7 @@ class Catalog:
         return _resolve(
             entry,
             self._repository,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
 
     def resolve_by_id(self, namespace: str, id: str) -> BaseModel:
@@ -406,17 +406,17 @@ class Catalog:
             raise CatalogValidationError([f"Namespace '{namespace}' has no team entry"])
         team_entry = team_entries[0]
         # Fall back to the live repository for cross-ns ref lookups so a team
-        # payload that references entries in a shared namespace (e.g.
+        # payload that references entries in a shareable namespace (e.g.
         # ``global.shared-prompt``) still resolves while preserving the
         # single-query invariant for the local namespace. The fallback is
-        # always wired — the shared-flag gate (consulted via
-        # ``self._is_namespace_shared``) is the authoritative permission
+        # always wired — the shareable-flag gate (consulted via
+        # ``self._is_namespace_shareable``) is the authoritative permission
         # check, not the presence of a fallback.
         in_memory = _InMemoryEntryRepository(entries, fallback=self._repository)
         result = _resolve(
             team_entry,
             in_memory,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
         if not isinstance(result, TeamCard):
             raise CatalogValidationError(
@@ -478,14 +478,14 @@ class Catalog:
         """
         entries = self._repository.list_by_namespace(namespace)
         meta_entry, local_entries = _partition_meta(entries)
-        name, description, properties, shared = self._project_header(meta_entry, local_entries)
+        name, description, properties, shareable = self._project_header(meta_entry, local_entries)
         external_refs = self._collect_external_refs(local_entries)
         return dump_namespace(
             local_entries,
             name=name,
             description=description,
             properties=properties,
-            shared=shared,
+            shareable=shareable,
             external_refs=external_refs,
         )
 
@@ -494,7 +494,7 @@ class Catalog:
         meta_entry: Entry | None,
         local_entries: _list[Entry],
     ) -> tuple[str, str, dict[str, str], bool]:
-        """Project ``name`` / ``description`` / ``properties`` / ``shared`` for the bundle header.
+        """Project ``name`` / ``description`` / ``properties`` / ``shareable`` for header.
 
         When ``meta_entry`` is present, read from its payload. When the
         meta's ``payload.name`` is empty / missing, fall back to the team
@@ -502,10 +502,10 @@ class Catalog:
         properties still come from the meta entry (mirrors the existing
         ``list_namespaces`` graceful-degradation rule for empty meta names).
 
-        Story 17.7 — ``shared`` is read from ``meta_entry.payload.get("shared")``
-        with strict-bool ``is True`` comparison; ``False`` when the key is
-        missing or non-bool. When ``meta_entry`` is absent, ``shared``
-        defaults to ``False``.
+        Story 17.7 — ``shareable`` is read from
+        ``meta_entry.payload.get("shareable")`` with strict-bool ``is True``
+        comparison; ``False`` when the key is missing or non-bool. When
+        ``meta_entry`` is absent, ``shareable`` defaults to ``False``.
 
         When ``meta_entry`` is absent, fall back fully to the team:
         ``(team.payload.get("name", ""), team.description, {}, False)``.
@@ -519,7 +519,7 @@ class Catalog:
                 entry is located inside this list.
 
         Returns:
-            ``(name, description, properties, shared)`` 4-tuple — the
+            ``(name, description, properties, shareable)`` 4-tuple — the
             header projection ready to pass to :func:`dump_namespace`.
         """
         team_entry = next((e for e in local_entries if e.kind == "team"), None)
@@ -548,13 +548,13 @@ class Catalog:
                 str(k): str(v) for k, v in meta_properties_raw.items() if isinstance(k, str)
             }
         # Strict-bool projection — only a real ``True`` flips the flag.
-        meta_shared = payload.get("shared") is True
+        meta_shareable = payload.get("shareable") is True
         # Empty-meta-name graceful degradation — team-fallback for name only.
         name = meta_name if meta_name else team_name
-        return name, meta_description, meta_properties, meta_shared
+        return name, meta_description, meta_properties, meta_shareable
 
     def _collect_external_refs(self, entries: _list[Entry]) -> _list[Entry]:
-        """Return the deduplicated, shared-flag-filtered, transitively-reached cross-ns targets.
+        """Return the deduplicated, shareable-flag-filtered, transitively-reached cross-ns targets.
 
         Worklist algorithm carried over from Story 17.5 (unchanged):
 
@@ -568,7 +568,7 @@ class Catalog:
            cycle set).
         3. For each pair popped from the worklist:
            - Skip if already in ``visited``.
-           - Skip if the target namespace is not shared (silent omission per
+           - Skip if the target namespace is not shareable (silent omission per
              ADR-008 §D2).
            - Try ``repository.get(target_ns, target_id)``; on
              ``EntryNotFoundError`` semantics (``None``), skip silently.
@@ -604,7 +604,7 @@ class Catalog:
             if key in visited:
                 continue
             visited.add(key)
-            if not self._is_namespace_shared(target_ns):
+            if not self._is_namespace_shareable(target_ns):
                 continue
             target_entry = self._repository.get(target_ns, target_id)
             if target_entry is None:
@@ -683,7 +683,7 @@ class Catalog:
             prepare_for_write(
                 e,
                 overlay,
-                is_namespace_shared=self._is_namespace_shared,
+                is_namespace_shareable=self._is_namespace_shareable,
             )
             for e in parsed
         ]
@@ -746,7 +746,7 @@ class Catalog:
                 name=header.name,
                 description=header.description,
                 properties=dict(header.properties),
-                shared=header.shared,
+                shareable=header.shareable,
             ).model_dump()
         except ValueError as exc:
             raise CatalogValidationError([f"bundle header is invalid: {exc}"]) from exc
@@ -763,7 +763,7 @@ class Catalog:
         """Upsert ``meta_entry`` via :meth:`update` if exists else :meth:`create`.
 
         Goes through the standard write pipeline so ``prepare_for_write`` /
-        ownership / shared-flag-cache invalidation all fire normally. The
+        ownership / shareable-flag-cache invalidation all fire normally. The
         meta-singleton check inside :meth:`create` is satisfied by the
         canonical id ``"_meta"`` — at most one meta entry per namespace.
         """
@@ -785,16 +785,16 @@ class Catalog:
         ``namespace`` when ``validate_entries`` saw zero entries, so the caller
         sees the requested label in the report even on an empty namespace.
 
-        The shared-flag check (per ADR-008 §D2 as updated 2026-05-08) is
+        The shareable-flag check (per ADR-008 §D2 as updated 2026-05-08) is
         threaded into ``validate_entries`` so transient validation surfaces
-        cross-ns errors (shared-flag violations, ownership violations) per
+        cross-ns errors (shareable-flag violations, ownership violations) per
         entry.
         """
         entries = self._repository.list_by_namespace(namespace)
         report = validate_entries(
             entries,
             self._repository,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
         if report.namespace is None:
             report = report.model_copy(update={"namespace": namespace})
@@ -833,7 +833,7 @@ class Catalog:
         return validate_entries(
             entries,
             self._repository,
-            is_namespace_shared=self._is_namespace_shared,
+            is_namespace_shareable=self._is_namespace_shareable,
         )
 
     # --- Private helpers ------------------------------------------------------
@@ -949,13 +949,13 @@ class Catalog:
         stale_team = [e for e in stale if e.kind == "team"]
         for e in stale_non_team:
             self._repository.delete(namespace, e.id)
-            self._invalidate_shared_flag_cache(e)
+            self._invalidate_shareable_flag_cache(e)
         for e in stale_team:
             self._repository.delete(namespace, e.id)
-            self._invalidate_shared_flag_cache(e)
+            self._invalidate_shareable_flag_cache(e)
         for e in ordered:
             self._repository.put(e)
-            self._invalidate_shared_flag_cache(e)
+            self._invalidate_shareable_flag_cache(e)
 
     def _mint_team_namespace(self, entry: Entry) -> Entry:
         """Return a copy of ``entry`` with ``namespace`` set to a fresh UUID string."""
@@ -1066,17 +1066,17 @@ class Catalog:
             ]
         )
 
-    def _is_namespace_shared(self, namespace: str) -> bool:
-        """Return ``True`` iff ``namespace``'s ``_meta`` has ``payload["shared"] is True``.
+    def _is_namespace_shareable(self, namespace: str) -> bool:
+        """Return ``True`` iff ``namespace``'s ``_meta`` has ``payload["shareable"] is True``.
 
         Per ADR-008 §D2 (updated 2026-05-08, rev 2), a namespace is cross-
         namespace-referenceable iff its meta entry carries a typed boolean
-        ``True`` at the root under ``payload["shared"]``. The check is
+        ``True`` at the root under ``payload["shareable"]``. The check is
         strict-bool comparison — ``1``, ``"true"``, ``"True"``, and other
         truthy strings all fall through to ``False``. Operators must opt in
         unambiguously with a real boolean.
 
-        The result is cached on ``self._shared_flag_cache`` keyed by
+        The result is cached on ``self._shareable_flag_cache`` keyed by
         namespace; subsequent calls for the same namespace return the
         cached boolean without re-querying the repository. Cache
         invalidation happens in :meth:`create`, :meth:`update`, and
@@ -1088,31 +1088,31 @@ class Catalog:
 
         Returns:
             ``True`` if a meta entry exists in ``namespace`` and carries
-            ``payload["shared"] is True``; ``False`` otherwise (no meta
+            ``payload["shareable"] is True``; ``False`` otherwise (no meta
             entry, missing key, ``False``, or any non-bool value).
         """
-        cached = self._shared_flag_cache.get(namespace)
+        cached = self._shareable_flag_cache.get(namespace)
         if cached is not None:
             return cached
         meta = self._repository.get(namespace, "_meta")
-        shared = False
+        shareable = False
         if meta is not None and isinstance(meta.payload, dict):
-            shared = meta.payload.get("shared") is True
-        self._shared_flag_cache[namespace] = shared
-        return shared
+            shareable = meta.payload.get("shareable") is True
+        self._shareable_flag_cache[namespace] = shareable
+        return shareable
 
-    def _invalidate_shared_flag_cache(self, entry: Entry) -> None:
-        """Drop the cached shared-flag for ``entry.namespace`` if ``entry`` is a meta entry.
+    def _invalidate_shareable_flag_cache(self, entry: Entry) -> None:
+        """Drop the cached shareable-flag for ``entry.namespace`` if ``entry`` is a meta entry.
 
         Called from ``create`` / ``update`` / ``delete`` after the
-        repository write commits, so the next ``_is_namespace_shared``
+        repository write commits, so the next ``_is_namespace_shareable``
         lookup re-reads the meta entry. A non-meta entry write is a
         no-op — the cache only depends on the meta entry's
-        ``payload["shared"]`` value (typed bool at the root, per ADR-008
+        ``payload["shareable"]`` value (typed bool at the root, per ADR-008
         §D2 as updated 2026-05-08 rev 2).
         """
         if entry.kind == "meta":
-            self._shared_flag_cache.pop(entry.namespace, None)
+            self._shareable_flag_cache.pop(entry.namespace, None)
 
     def _check_ownership(self, entry: Entry) -> None:
         """Ensure ``entry.user_id == team_entry.user_id`` within ``entry.namespace``."""
@@ -1268,7 +1268,7 @@ def _iter_cross_ns_targets(payload: Any) -> builtins.list[tuple[str, str]]:
     * No call to ``populate_refs``.
     * No Pydantic validation.
     * No repository access.
-    * No allowlist or shared-flag check (the shared-flag gate fires later,
+    * No allowlist or shareable-flag check (the shareable-flag gate fires later,
       when :meth:`Catalog._collect_external_refs` decides whether to fetch
       the target).
 

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -3,7 +3,7 @@
 This module exposes a single Pydantic ``BaseModel`` (:class:`NamespaceMeta`)
 used as the payload-validation class for the ``kind="meta"`` catalog entry
 introduced by ADR-008 §D1. The model carries four pinned fields — ``name``,
-``description``, a free-form ``properties`` map, and a typed ``shared``
+``description``, a free-form ``properties`` map, and a typed ``shareable``
 boolean — so the namespace picker reads tenant-level metadata from a stable,
 purpose-built shape instead of leaking ``TeamCard``'s schema.
 
@@ -42,13 +42,13 @@ class NamespaceMeta(BaseModel):
       should NOT pollute :class:`~akgentic.team.models.TeamCard`. The map is
       fully free-form: there are NO catalog-reserved keys. Both keys and
       values are strings.
-    * ``shared`` — typed boolean controlling cross-namespace
+    * ``shareable`` — typed boolean controlling cross-namespace
       referenceability (ADR-008 §D2 as updated 2026-05-08, rev 2). When
       ``True``, the namespace is cross-namespace-referenceable as a target —
       other namespaces may carry refs into this one (subject to the existing
       ``user_id is None`` ownership gate). When ``False`` (the default), the
-      namespace is not shared. Pydantic strict-mode rejects non-bool inputs
-      so operators must opt in unambiguously with a real boolean.
+      namespace is not shareable. Pydantic strict-mode rejects non-bool
+      inputs so operators must opt in unambiguously with a real boolean.
 
     Convention id is ``"_meta"``; the route fallback in
     ``GET /catalog/namespaces`` reads ``payload["name"]`` /
@@ -80,7 +80,7 @@ class NamespaceMeta(BaseModel):
             "the map is fully operator-owned."
         ),
     )
-    shared: bool = Field(
+    shareable: bool = Field(
         default=False,
         description=(
             "When True, the namespace is cross-namespace-referenceable as a "

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -2,10 +2,10 @@
 
 This module exposes a single Pydantic ``BaseModel`` (:class:`NamespaceMeta`)
 used as the payload-validation class for the ``kind="meta"`` catalog entry
-introduced by ADR-008 §D1. The model intentionally carries only three pinned
-fields — ``name``, ``description``, and a free-form ``properties`` map — so
-the namespace picker reads tenant-level metadata from a stable, purpose-built
-shape instead of leaking ``TeamCard``'s schema.
+introduced by ADR-008 §D1. The model carries four pinned fields — ``name``,
+``description``, a free-form ``properties`` map, and a typed ``shared``
+boolean — so the namespace picker reads tenant-level metadata from a stable,
+purpose-built shape instead of leaking ``TeamCard``'s schema.
 
 Key exports:
 
@@ -31,7 +31,7 @@ __all__ = ["NamespaceMeta"]
 class NamespaceMeta(BaseModel):
     """Payload model for the per-namespace metadata entry (``kind="meta"``).
 
-    Three pinned fields:
+    Four pinned fields, in declaration order:
 
     * ``name`` — required non-empty display name for the namespace; surfaced
       by ``GET /catalog/namespaces`` to feed the picker.
@@ -39,25 +39,16 @@ class NamespaceMeta(BaseModel):
       empty string.
     * ``properties`` — free-form ``str -> str`` annotations carrying
       tenant-level metadata (display tier, owner team, custom labels) that
-      should NOT pollute :class:`~akgentic.team.models.TeamCard`.
-
-    Reserved property key — ``"shared"``:
-
-    The single catalog-reserved key in ``properties`` is ``"shared"``. When
-    ``properties["shared"] == "true"`` (the literal lowercase string, exact
-    match), the namespace is cross-namespace-referenceable as a target —
-    other namespaces may carry refs into this one (subject to the existing
-    ``user_id is None`` ownership gate). Any other value (``"false"``,
-    ``"True"``, ``"1"``, ``""``, …) or absence of the key means the
-    namespace is **not** shared. The catalog gate is exact-string equality —
-    no truthy-string coercion, no case folding — so operators must opt in
-    unambiguously.
-
-    All keys in ``properties`` other than ``"shared"`` remain free-form
-    operator annotations: the catalog never inspects them. Pydantic does
-    NOT enforce the value of ``"shared"`` at the model layer; the
-    enforcement happens in the resolver pipeline at write / resolve time
-    (per ADR-008 §D2 as updated 2026-05-08).
+      should NOT pollute :class:`~akgentic.team.models.TeamCard`. The map is
+      fully free-form: there are NO catalog-reserved keys. Both keys and
+      values are strings.
+    * ``shared`` — typed boolean controlling cross-namespace
+      referenceability (ADR-008 §D2 as updated 2026-05-08, rev 2). When
+      ``True``, the namespace is cross-namespace-referenceable as a target —
+      other namespaces may carry refs into this one (subject to the existing
+      ``user_id is None`` ownership gate). When ``False`` (the default), the
+      namespace is not shared. Pydantic strict-mode rejects non-bool inputs
+      so operators must opt in unambiguously with a real boolean.
 
     Convention id is ``"_meta"``; the route fallback in
     ``GET /catalog/namespaces`` reads ``payload["name"]`` /
@@ -85,6 +76,18 @@ class NamespaceMeta(BaseModel):
         description=(
             "Free-form string-to-string annotations carrying tenant-level "
             "metadata (display tier, owner team, custom labels). Both keys "
-            "and values are strings."
+            "and values are strings. There are NO catalog-reserved keys — "
+            "the map is fully operator-owned."
+        ),
+    )
+    shared: bool = Field(
+        default=False,
+        description=(
+            "When True, the namespace is cross-namespace-referenceable as a "
+            "target — other namespaces may carry refs into this one (subject "
+            "to the existing ``user_id is None`` ownership gate). Strict-bool "
+            '— non-bool inputs (e.g. the string ``"true"``) are rejected by '
+            "Pydantic at construction time. ADR-008 §D2 as updated "
+            "2026-05-08 (rev 2)."
         ),
     )

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -50,10 +50,10 @@ class EntryRepository(Protocol):
     def find_references_global(self, namespace: str, target_id: str) -> _list[Entry]:
         """Return entries whose payload carries a cross-ns ref to ``(namespace, target_id)``.
 
-        Implements ADR-008 §D2 (updated 2026-05-08) — the global-scope
+        Implements ADR-008 §D2 (updated 2026-05-08 rev 2) — the global-scope
         referrer walker that widens the namespace-bounded delete guard to
         a cross-tenant guard for shared namespaces (target's ``_meta`` has
-        ``properties["shared"] == "true"``). The match shape recognises
+        ``payload["shared"] is True``, strict-bool). The match shape recognises
         both the canonical sentinel (``__namespace__ == namespace`` AND
         ``__ref__ == target_id``) and the shorthand form (``__ref__ ==
         "<namespace>.<target_id>"``).

--- a/src/akgentic/catalog/repositories/base.py
+++ b/src/akgentic/catalog/repositories/base.py
@@ -52,8 +52,9 @@ class EntryRepository(Protocol):
 
         Implements ADR-008 §D2 (updated 2026-05-08 rev 2) — the global-scope
         referrer walker that widens the namespace-bounded delete guard to
-        a cross-tenant guard for shared namespaces (target's ``_meta`` has
-        ``payload["shared"] is True``, strict-bool). The match shape recognises
+        a cross-tenant guard for shareable namespaces (target's ``_meta``
+        has ``payload["shareable"] is True``, strict-bool). The match shape
+        recognises
         both the canonical sentinel (``__namespace__ == namespace`` AND
         ``__ref__ == target_id``) and the shorthand form (``__ref__ ==
         "<namespace>.<target_id>"``).

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -58,7 +58,8 @@ from .repositories.base import EntryRepository
 
 # Type alias for the shared-flag check threaded through the resolver.
 # A callable that takes a target namespace and returns True if the
-# namespace's ``_meta`` entry carries ``properties["shared"] == "true"``.
+# namespace's ``_meta`` entry carries ``payload["shared"] is True``
+# (typed bool at the root — ADR-008 §D2 as updated 2026-05-08 rev 2).
 IsNamespaceSharedFn = Callable[[str], bool]
 
 __all__ = [
@@ -97,7 +98,7 @@ Implements ADR-008 §D2 — the canonical cross-ns sentinel. A ref-marker dict
 may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
 to address an entry in a different namespace; the resolver gates the lookup
 on the data-driven shared-flag (the target namespace's ``_meta`` entry has
-``properties["shared"] == "true"`` — ADR-008 §D2 as updated 2026-05-08) and
+``payload["shared"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2) and
 on the target's ``user_id is None`` privacy constraint. The shorthand
 ``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
 the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
@@ -201,10 +202,11 @@ def populate_refs(
             cross-ns marker — when it returns ``False`` (or when the argument
             is ``None``), the marker is rejected with the substring
             ``"is not shared"``. Same-namespace refs bypass the gate. Per
-            ADR-008 §D2 (updated 2026-05-08) the canonical implementation
+            ADR-008 §D2 (updated 2026-05-08 rev 2) the canonical implementation
             consults the target namespace's ``_meta`` entry and answers
-            ``True`` iff ``properties["shared"] == "true"``. Default ``None``
-            ⇒ no namespace is shared (cross-ns refs unconditionally rejected).
+            ``True`` iff ``payload["shared"] is True`` (typed bool at the
+            root, strict-bool comparison). Default ``None`` ⇒ no namespace
+            is shared (cross-ns refs unconditionally rejected).
 
     Returns:
         A new payload subtree with every ref marker replaced by a typed

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -56,17 +56,17 @@ from .models.entry import Entry
 from .models.errors import CatalogValidationError
 from .repositories.base import EntryRepository
 
-# Type alias for the shared-flag check threaded through the resolver.
+# Type alias for the shareable-flag check threaded through the resolver.
 # A callable that takes a target namespace and returns True if the
-# namespace's ``_meta`` entry carries ``payload["shared"] is True``
+# namespace's ``_meta`` entry carries ``payload["shareable"] is True``
 # (typed bool at the root — ADR-008 §D2 as updated 2026-05-08 rev 2).
-IsNamespaceSharedFn = Callable[[str], bool]
+IsNamespaceShareableFn = Callable[[str], bool]
 
 __all__ = [
     "NAMESPACE_KEY",
     "REF_KEY",
     "TYPE_KEY",
-    "IsNamespaceSharedFn",
+    "IsNamespaceShareableFn",
     "enumerate_allowlisted_model_types",
     "load_model_type",
     "populate_refs",
@@ -97,8 +97,8 @@ NAMESPACE_KEY: Final[str] = "__namespace__"
 Implements ADR-008 §D2 — the canonical cross-ns sentinel. A ref-marker dict
 may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
 to address an entry in a different namespace; the resolver gates the lookup
-on the data-driven shared-flag (the target namespace's ``_meta`` entry has
-``payload["shared"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2) and
+on the data-driven shareable-flag (the target namespace's ``_meta`` entry has
+``payload["shareable"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2) and
 on the target's ``user_id is None`` privacy constraint. The shorthand
 ``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
 the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
@@ -159,7 +159,7 @@ def populate_refs(
     namespace: str,
     _visiting: set[tuple[str, str]] | None = None,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> Any:
     """Recursively replace ref markers in ``node`` with their resolved payloads.
 
@@ -197,16 +197,16 @@ def populate_refs(
         _visiting: Internal cycle-detection set of ``(namespace, target_id)``
             pairs already traversed on the current ref chain. Callers pass
             ``None`` (the default); the function builds a fresh set per call.
-        is_namespace_shared: Optional callable answering "is this namespace
+        is_namespace_shareable: Optional callable answering "is this namespace
             cross-namespace-referenceable?". The resolver invokes it for every
             cross-ns marker — when it returns ``False`` (or when the argument
             is ``None``), the marker is rejected with the substring
-            ``"is not shared"``. Same-namespace refs bypass the gate. Per
+            ``"is not shareable"``. Same-namespace refs bypass the gate. Per
             ADR-008 §D2 (updated 2026-05-08 rev 2) the canonical implementation
             consults the target namespace's ``_meta`` entry and answers
-            ``True`` iff ``payload["shared"] is True`` (typed bool at the
+            ``True`` iff ``payload["shareable"] is True`` (typed bool at the
             root, strict-bool comparison). Default ``None`` ⇒ no namespace
-            is shared (cross-ns refs unconditionally rejected).
+            is shareable (cross-ns refs unconditionally rejected).
 
     Returns:
         A new payload subtree with every ref marker replaced by a typed
@@ -233,7 +233,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                is_namespace_shared=is_namespace_shared,
+                is_namespace_shareable=is_namespace_shareable,
             )
         return {
             k: populate_refs(
@@ -241,7 +241,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                is_namespace_shared=is_namespace_shared,
+                is_namespace_shareable=is_namespace_shareable,
             )
             for k, v in node.items()
         }
@@ -253,7 +253,7 @@ def populate_refs(
                 repository,
                 namespace,
                 visiting,
-                is_namespace_shared=is_namespace_shared,
+                is_namespace_shareable=is_namespace_shareable,
             )
             for v in node
         ]
@@ -305,25 +305,25 @@ def _resolve_target_namespace(
     return current_namespace, raw_ref
 
 
-def _check_cross_ns_shared_flag(
+def _check_cross_ns_shareable_flag(
     target_namespace: str,
     target_id: str,
     current_namespace: str,
-    is_namespace_shared: IsNamespaceSharedFn | None,
+    is_namespace_shareable: IsNamespaceShareableFn | None,
 ) -> None:
-    """Raise when a cross-ns ref points at a non-shared namespace.
+    """Raise when a cross-ns ref points at a non-shareable namespace.
 
     The same-namespace path is exempt — a marker resolving to
     ``current_namespace`` is not a cross-ns ref and is never gated by the
-    shared-flag check.
+    shareable-flag check.
 
-    Per ADR-008 §D2 (updated 2026-05-08, rev 2), a namespace is "shared" iff
-    its ``_meta`` entry's ``payload["shared"] is True`` (typed bool at the
-    root, strict-bool comparison — no truthy-string coercion). The check is
-    delegated to the ``is_namespace_shared`` callable so the resolver stays
-    a pure function over the repository protocol — the per-``Catalog``
-    shared-flag cache lives on the ``Catalog`` instance and is consulted
-    via this callback.
+    Per ADR-008 §D2 (updated 2026-05-08, rev 2), a namespace is "shareable"
+    iff its ``_meta`` entry's ``payload["shareable"] is True`` (typed bool
+    at the root, strict-bool comparison — no truthy-string coercion). The
+    check is delegated to the ``is_namespace_shareable`` callable so the
+    resolver stays a pure function over the repository protocol — the
+    per-``Catalog`` shareable-flag cache lives on the ``Catalog`` instance
+    and is consulted via this callback.
 
     Args:
         target_namespace: The namespace resolved from the marker (canonical
@@ -332,25 +332,25 @@ def _check_cross_ns_shared_flag(
             message only).
         current_namespace: The enclosing namespace; refs resolving to this
             namespace bypass the gate.
-        is_namespace_shared: Callable answering "is this namespace shared?"
-            or ``None``. ``None`` is interpreted as "no namespace is shared"
-            — every cross-ns ref is unconditionally rejected with the
-            ``"is not shared"`` substring.
+        is_namespace_shareable: Callable answering "is this namespace
+            shareable?" or ``None``. ``None`` is interpreted as "no
+            namespace is shareable" — every cross-ns ref is unconditionally
+            rejected with the ``"is not shareable"`` substring.
 
     Raises:
         CatalogValidationError: When ``target_namespace != current_namespace``
-            and ``is_namespace_shared`` returns ``False`` (or is ``None``).
+            and ``is_namespace_shareable`` returns ``False`` (or is ``None``).
             The message carries the substring
-            ``"namespace '<target_namespace>' is not shared"``.
+            ``"namespace '<target_namespace>' is not shareable"``.
     """
     if target_namespace == current_namespace:
         return
-    if is_namespace_shared is not None and is_namespace_shared(target_namespace):
+    if is_namespace_shareable is not None and is_namespace_shareable(target_namespace):
         return
     raise CatalogValidationError(
         [
             f"Cross-namespace ref to '{target_namespace}.{target_id}': "
-            f"namespace '{target_namespace}' is not shared"
+            f"namespace '{target_namespace}' is not shareable"
         ]
     )
 
@@ -361,12 +361,12 @@ def _populate_ref_marker(
     namespace: str,
     visiting: set[tuple[str, str]],
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> Any:
     """Resolve a single ref-marker dict into a typed Pydantic instance.
 
     Checks run in order — parse target namespace (canonical
-    ``__namespace__`` or first-dot shorthand), shared-flag gate (cross-ns
+    ``__namespace__`` or first-dot shorthand), shareable-flag gate (cross-ns
     only), cycle, missing target, cross-ns ownership gate (target's
     ``user_id`` MUST be ``None``), ``__type__`` mismatch, then (Story 15.6)
     recursive population of nested refs inside the target's payload,
@@ -374,8 +374,8 @@ def _populate_ref_marker(
     (Story 20.1 / ADR-010), ``load_model_type`` on the target's declared
     ``model_type``, and ``cls.model_validate`` to build a typed instance.
 
-    Order rationale: the shared-flag gate fires BEFORE the repository
-    lookup so a denied cross-ns ref produces the ``"is not shared"`` error
+    Order rationale: the shareable-flag gate fires BEFORE the repository
+    lookup so a denied cross-ns ref produces the ``"is not shareable"`` error
     even when the target id genuinely does not exist (ADR-008 §D2 —
     denying access takes precedence over reporting "not found"). Cycle
     comes next because the cross-ns target may be visited along a chain we
@@ -387,7 +387,7 @@ def _populate_ref_marker(
     ``__ref__`` / ``__type__`` / ``__namespace__`` are collected as
     overrides. When non-empty, the override dict is itself run through
     :func:`populate_refs` against the **target's namespace** (so nested
-    cross-ns refs in the override are subject to the same shared-flag +
+    cross-ns refs in the override are subject to the same shareable-flag +
     ownership gates), then shallow-merged on top of the populated target
     payload via ``{**target, **overrides}``. The merge is top-level — no
     recursive descent into shared subkeys — and runs before
@@ -398,9 +398,10 @@ def _populate_ref_marker(
     expected = node.get(TYPE_KEY)
     key = (target_namespace, target_id)
 
-    # Shared-flag gate fires BEFORE repository.get so a denied cross-ns ref
-    # raises the "is not shared" error even when the target id does not exist.
-    _check_cross_ns_shared_flag(target_namespace, target_id, namespace, is_namespace_shared)
+    # Shareable-flag gate fires BEFORE repository.get so a denied cross-ns
+    # ref raises the "is not shareable" error even when the target id does
+    # not exist.
+    _check_cross_ns_shareable_flag(target_namespace, target_id, namespace, is_namespace_shareable)
 
     if key in visiting:
         raise CatalogValidationError(
@@ -439,13 +440,13 @@ def _populate_ref_marker(
         repository,
         target_namespace,
         visiting | {key},
-        is_namespace_shared=is_namespace_shared,
+        is_namespace_shareable=is_namespace_shareable,
     )
 
     # Story 20.1 / ADR-010: merge non-reserved siblings on top of the target
     # payload as a shallow override. The override dict is resolved against
     # the TARGET's namespace so nested cross-ns refs in the override are
-    # gated by the same shared-flag + ownership rules.
+    # gated by the same shareable-flag + ownership rules.
     overrides = {k: v for k, v in node.items() if k not in _RESERVED_KEYS}
     if overrides:
         resolved_overrides = populate_refs(
@@ -453,7 +454,7 @@ def _populate_ref_marker(
             repository,
             target_namespace,
             visiting | {key},
-            is_namespace_shared=is_namespace_shared,
+            is_namespace_shareable=is_namespace_shareable,
         )
         # resolved_overrides is always a dict here: populate_refs preserves
         # the dict shape of any non-ref-marker dict input (the outer override
@@ -485,7 +486,7 @@ def resolve(
     entry: Entry,
     repository: EntryRepository,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> BaseModel:
     """Hydrate ``entry`` into an instance of its declared runtime Pydantic class.
 
@@ -524,7 +525,7 @@ def resolve(
         entry.payload,
         repository,
         entry.namespace,
-        is_namespace_shared=is_namespace_shared,
+        is_namespace_shareable=is_namespace_shareable,
     )
     try:
         return cls.model_validate(populated)
@@ -598,7 +599,7 @@ def prepare_for_write(
     entry: Entry,
     repository: EntryRepository,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> Entry:
     """Run the five-step write pipeline and return a ref-preserving ``Entry``.
 
@@ -639,7 +640,7 @@ def prepare_for_write(
         entry.payload,
         repository,
         entry.namespace,
-        is_namespace_shared=is_namespace_shared,
+        is_namespace_shareable=is_namespace_shareable,
     )
     cls = load_model_type(entry.model_type)
     obj = _validate_payload(cls, resolved, entry.model_type)

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -315,12 +315,13 @@ def _check_cross_ns_shared_flag(
     ``current_namespace`` is not a cross-ns ref and is never gated by the
     shared-flag check.
 
-    Per ADR-008 §D2 (updated 2026-05-08), a namespace is "shared" iff its
-    ``_meta`` entry's ``payload["properties"]["shared"]`` equals the literal
-    lowercase string ``"true"``. The check is delegated to the
-    ``is_namespace_shared`` callable so the resolver stays a pure function
-    over the repository protocol — the per-``Catalog`` shared-flag cache
-    lives on the ``Catalog`` instance and is consulted via this callback.
+    Per ADR-008 §D2 (updated 2026-05-08, rev 2), a namespace is "shared" iff
+    its ``_meta`` entry's ``payload["shared"] is True`` (typed bool at the
+    root, strict-bool comparison — no truthy-string coercion). The check is
+    delegated to the ``is_namespace_shared`` callable so the resolver stays
+    a pure function over the repository protocol — the per-``Catalog``
+    shared-flag cache lives on the ``Catalog`` instance and is consulted
+    via this callback.
 
     Args:
         target_namespace: The namespace resolved from the marker (canonical

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -52,15 +52,15 @@ logger = logging.getLogger(__name__)
 class BundleHeader:
     """Parsed top-level header fields for an export bundle.
 
-    Story 17.7 — fourth field ``shared: bool`` added after ``properties`` to
-    mirror :class:`~akgentic.catalog.models.namespace_meta.NamespaceMeta`'s
+    Story 17.7 — fourth field ``shareable: bool`` added after ``properties``
+    to mirror :class:`~akgentic.catalog.models.namespace_meta.NamespaceMeta`'s
     declaration order. Bundles produced by 17.7+ exports always carry
-    ``shared`` at the top level (alongside ``name`` / ``description`` /
-    ``properties``); legacy export bundles (pre-17.7 — no ``shared``)
-    project to ``shared=False`` (default).
+    ``shareable`` at the top level (alongside ``name`` / ``description`` /
+    ``properties``); legacy export bundles (pre-17.7 — no ``shareable``)
+    project to ``shareable=False`` (default).
 
     ``present`` is ``True`` iff at least one of ``name`` / ``description`` /
-    ``properties`` / ``shared`` was explicitly set in the source YAML.
+    ``properties`` / ``shareable`` was explicitly set in the source YAML.
     Pre-17.5 bundles (no header fields at all) parse to
     ``BundleHeader(present=False, ...)`` so the import handler can skip the
     meta-upsert step (AC11 / AC12).
@@ -69,7 +69,7 @@ class BundleHeader:
     name: str = ""
     description: str = ""
     properties: dict[str, str] = field(default_factory=dict)
-    shared: bool = False
+    shareable: bool = False
     present: bool = False
 
 
@@ -138,17 +138,17 @@ def dump_namespace(
     name: str = "",
     description: str = "",
     properties: dict[str, str] | None = None,
-    shared: bool = False,
+    shareable: bool = False,
     external_refs: list[Entry] | None = None,
 ) -> str:
     """Serialise a uniform-namespace list of entries to bundle YAML.
 
     The output document carries up to seven top-level keys in declaration order:
     ``namespace``, ``user_id``, ``name``, ``description``, ``properties``,
-    ``shared``, ``entries``. The header (Story 17.7 — adds the typed-bool
-    ``shared`` field after ``properties``) is emitted ONLY when at least one
-    of the five optional parameters forces it: ``name`` is non-empty,
-    ``description`` is non-empty, ``properties`` is non-empty, ``shared``
+    ``shareable``, ``entries``. The header (Story 17.7 — adds the typed-bool
+    ``shareable`` field after ``properties``) is emitted ONLY when at least
+    one of the five optional parameters forces it: ``name`` is non-empty,
+    ``description`` is non-empty, ``properties`` is non-empty, ``shareable``
     is ``True``, or ``external_refs`` is non-empty. When all five parameters
     are at their default values, the function emits the pre-17.5 wire shape
     verbatim (three top-level keys: ``namespace``, ``user_id``, ``entries``)
@@ -218,7 +218,7 @@ def dump_namespace(
     properties = properties if properties is not None else {}
     external_refs = external_refs if external_refs is not None else []
     has_header = (
-        bool(name) or bool(description) or bool(properties) or shared or bool(external_refs)
+        bool(name) or bool(description) or bool(properties) or shareable or bool(external_refs)
     )
 
     sorted_entries = _sort_entries_for_emit(entries)
@@ -234,11 +234,11 @@ def dump_namespace(
         doc["name"] = name
         doc["description"] = description
         doc["properties"] = properties
-        # Story 17.7 — emit ``shared`` between ``properties`` and ``entries``
-        # whenever a header is emitted (declaration order pinned by
-        # NamespaceMeta + AC8). When the header is suppressed entirely
-        # (pre-17.5 three-key shape), ``shared`` is also suppressed.
-        doc["shared"] = shared
+        # Story 17.7 — emit ``shareable`` between ``properties`` and
+        # ``entries`` whenever a header is emitted (declaration order pinned
+        # by NamespaceMeta + AC8). When the header is suppressed entirely
+        # (pre-17.5 three-key shape), ``shareable`` is also suppressed.
+        doc["shareable"] = shareable
     doc["entries"] = entries_map
 
     raw = yaml.dump(
@@ -481,16 +481,16 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
 
 
 def _project_header(doc: dict[str, Any]) -> BundleHeader:
-    """Project the optional ``name`` / ``description`` / ``properties`` / ``shared`` fields.
+    """Project the optional ``name`` / ``description`` / ``properties`` / ``shareable`` fields.
 
-    Story 17.7 — ``shared`` joins the projected fields. Defensive parsing:
+    Story 17.7 — ``shareable`` joins the projected fields. Defensive parsing:
     a missing key projects to ``False``; a non-bool value also projects to
     ``False`` (Pydantic strict-mode at the upsert site surfaces the typing
     contract for non-bool inputs, but the dataclass projection itself stays
     infallible to keep ``load_namespace`` parse-only).
 
     ``present=True`` iff at least one of the four header fields
-    (``name`` / ``description`` / ``properties`` / ``shared``) is
+    (``name`` / ``description`` / ``properties`` / ``shareable``) is
     explicitly present in the document (regardless of value). This signal
     lets the import handler distinguish a pre-17.5 bundle (no header at
     all → skip meta upsert) from a 17.6+ bundle whose header carries empty
@@ -500,11 +500,11 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
     name_present = "name" in doc
     desc_present = "description" in doc
     props_present = "properties" in doc
-    shared_present = "shared" in doc
+    shareable_present = "shareable" in doc
     name_val = doc.get("name", "")
     desc_val = doc.get("description", "")
     props_val = doc.get("properties", {})
-    shared_val = doc.get("shared", False)
+    shareable_val = doc.get("shareable", False)
     if not isinstance(name_val, str):
         name_val = ""
     if not isinstance(desc_val, str):
@@ -513,8 +513,8 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
         props_val = {}
     # Strict-bool projection — only a real bool ``True`` projects to True.
     # Truthy strings / ints fall through to False, matching the catalog
-    # gate's ``meta.payload.get("shared") is True`` semantics.
-    shared_bool = shared_val is True
+    # gate's ``meta.payload.get("shareable") is True`` semantics.
+    shareable_bool = shareable_val is True
     # Coerce property values to strings if any leaked through; this is a
     # display projection so strict typing is enforced upstream by NamespaceMeta.
     properties: dict[str, str] = {
@@ -524,8 +524,8 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
         name=name_val,
         description=desc_val,
         properties=properties,
-        shared=shared_bool,
-        present=name_present or desc_present or props_present or shared_present,
+        shareable=shareable_bool,
+        present=name_present or desc_present or props_present or shareable_present,
     )
 
 

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -52,15 +52,24 @@ logger = logging.getLogger(__name__)
 class BundleHeader:
     """Parsed top-level header fields for an export bundle.
 
+    Story 17.7 — fourth field ``shared: bool`` added after ``properties`` to
+    mirror :class:`~akgentic.catalog.models.namespace_meta.NamespaceMeta`'s
+    declaration order. Bundles produced by 17.7+ exports always carry
+    ``shared`` at the top level (alongside ``name`` / ``description`` /
+    ``properties``); legacy export bundles (pre-17.7 — no ``shared``)
+    project to ``shared=False`` (default).
+
     ``present`` is ``True`` iff at least one of ``name`` / ``description`` /
-    ``properties`` was explicitly set in the source YAML. Pre-17.5 bundles
-    (no header fields at all) parse to ``BundleHeader(present=False, ...)``
-    so the import handler can skip the meta-upsert step (AC11 / AC12).
+    ``properties`` / ``shared`` was explicitly set in the source YAML.
+    Pre-17.5 bundles (no header fields at all) parse to
+    ``BundleHeader(present=False, ...)`` so the import handler can skip the
+    meta-upsert step (AC11 / AC12).
     """
 
     name: str = ""
     description: str = ""
     properties: dict[str, str] = field(default_factory=dict)
+    shared: bool = False
     present: bool = False
 
 
@@ -129,16 +138,18 @@ def dump_namespace(
     name: str = "",
     description: str = "",
     properties: dict[str, str] | None = None,
+    shared: bool = False,
     external_refs: list[Entry] | None = None,
 ) -> str:
     """Serialise a uniform-namespace list of entries to bundle YAML.
 
-    The output document carries up to six top-level keys in declaration order:
+    The output document carries up to seven top-level keys in declaration order:
     ``namespace``, ``user_id``, ``name``, ``description``, ``properties``,
-    ``entries``. The header trio (``name`` / ``description`` / ``properties``)
-    is emitted ONLY when at least one of the four optional parameters is set
-    (i.e. ``name`` is non-empty, ``description`` is non-empty, ``properties``
-    is non-empty, or ``external_refs`` is non-empty). When all four parameters
+    ``shared``, ``entries``. The header (Story 17.7 — adds the typed-bool
+    ``shared`` field after ``properties``) is emitted ONLY when at least one
+    of the five optional parameters forces it: ``name`` is non-empty,
+    ``description`` is non-empty, ``properties`` is non-empty, ``shared``
+    is ``True``, or ``external_refs`` is non-empty. When all five parameters
     are at their default values, the function emits the pre-17.5 wire shape
     verbatim (three top-level keys: ``namespace``, ``user_id``, ``entries``)
     so legacy callers see no behaviour change.
@@ -206,7 +217,9 @@ def dump_namespace(
 
     properties = properties if properties is not None else {}
     external_refs = external_refs if external_refs is not None else []
-    has_header = bool(name) or bool(description) or bool(properties) or bool(external_refs)
+    has_header = (
+        bool(name) or bool(description) or bool(properties) or shared or bool(external_refs)
+    )
 
     sorted_entries = _sort_entries_for_emit(entries)
     entries_map: dict[str, Any] = {e.id: _entry_to_map(e) for e in sorted_entries}
@@ -221,6 +234,11 @@ def dump_namespace(
         doc["name"] = name
         doc["description"] = description
         doc["properties"] = properties
+        # Story 17.7 — emit ``shared`` between ``properties`` and ``entries``
+        # whenever a header is emitted (declaration order pinned by
+        # NamespaceMeta + AC8). When the header is suppressed entirely
+        # (pre-17.5 three-key shape), ``shared`` is also suppressed.
+        doc["shared"] = shared
     doc["entries"] = entries_map
 
     raw = yaml.dump(
@@ -463,27 +481,40 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
 
 
 def _project_header(doc: dict[str, Any]) -> BundleHeader:
-    """Project the optional ``name`` / ``description`` / ``properties`` fields.
+    """Project the optional ``name`` / ``description`` / ``properties`` / ``shared`` fields.
 
-    ``present=True`` iff at least one of the three header fields is explicitly
-    present in the document (regardless of value). This signal lets the
-    import handler distinguish a pre-17.5 bundle (no header at all → skip
-    meta upsert) from a 17.6 bundle whose header carries empty strings (still
-    upsert meta, possibly with the team-fallback values that the export path
-    synthesised).
+    Story 17.7 — ``shared`` joins the projected fields. Defensive parsing:
+    a missing key projects to ``False``; a non-bool value also projects to
+    ``False`` (Pydantic strict-mode at the upsert site surfaces the typing
+    contract for non-bool inputs, but the dataclass projection itself stays
+    infallible to keep ``load_namespace`` parse-only).
+
+    ``present=True`` iff at least one of the four header fields
+    (``name`` / ``description`` / ``properties`` / ``shared``) is
+    explicitly present in the document (regardless of value). This signal
+    lets the import handler distinguish a pre-17.5 bundle (no header at
+    all → skip meta upsert) from a 17.6+ bundle whose header carries empty
+    strings (still upsert meta, possibly with the team-fallback values
+    that the export path synthesised).
     """
     name_present = "name" in doc
     desc_present = "description" in doc
     props_present = "properties" in doc
+    shared_present = "shared" in doc
     name_val = doc.get("name", "")
     desc_val = doc.get("description", "")
     props_val = doc.get("properties", {})
+    shared_val = doc.get("shared", False)
     if not isinstance(name_val, str):
         name_val = ""
     if not isinstance(desc_val, str):
         desc_val = ""
     if not isinstance(props_val, dict):
         props_val = {}
+    # Strict-bool projection — only a real bool ``True`` projects to True.
+    # Truthy strings / ints fall through to False, matching the catalog
+    # gate's ``meta.payload.get("shared") is True`` semantics.
+    shared_bool = shared_val is True
     # Coerce property values to strings if any leaked through; this is a
     # display projection so strict typing is enforced upstream by NamespaceMeta.
     properties: dict[str, str] = {
@@ -493,7 +524,8 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
         name=name_val,
         description=desc_val,
         properties=properties,
-        present=name_present or desc_present or props_present,
+        shared=shared_bool,
+        present=name_present or desc_present or props_present or shared_present,
     )
 
 

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -32,7 +32,7 @@ from akgentic.catalog.repositories.base import EntryRepository
 from akgentic.catalog.resolver import (
     NAMESPACE_KEY,
     REF_KEY,
-    IsNamespaceSharedFn,
+    IsNamespaceShareableFn,
     load_model_type,
     populate_refs,
 )
@@ -80,7 +80,7 @@ def validate_entries(
     entries: list[Entry],
     repository: EntryRepository,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> NamespaceValidationReport:
     """Run every check against ``entries``; return a structured report.
 
@@ -97,8 +97,8 @@ def validate_entries(
         entries: The list of entries to validate. May be empty.
         repository: Entry repository used for transient-validation ref
             resolution (read-only).
-        is_namespace_shared: Forwarded to ``populate_refs`` so cross-ns
-            ref errors (shared-flag + ownership) surface as per-entry
+        is_namespace_shareable: Forwarded to ``populate_refs`` so cross-ns
+            ref errors (shareable-flag + ownership) surface as per-entry
             issues in the returned report (ADR-008 §D2 as updated
             2026-05-08).
 
@@ -120,7 +120,7 @@ def validate_entries(
         entries,
         repository,
         namespace,
-        is_namespace_shared=is_namespace_shared,
+        is_namespace_shareable=is_namespace_shareable,
     )
 
     return NamespaceValidationReport(
@@ -257,7 +257,7 @@ def _collect_entry_issues(
     repository: EntryRepository,
     namespace: str,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> list[EntryValidationIssue]:
     """Build per-entry issues; skip entries with empty error lists."""
     issues: list[EntryValidationIssue] = []
@@ -266,7 +266,7 @@ def _collect_entry_issues(
             e,
             repository,
             namespace,
-            is_namespace_shared=is_namespace_shared,
+            is_namespace_shareable=is_namespace_shareable,
         )
         if errs:
             issues.append(EntryValidationIssue(entry_id=e.id, kind=e.kind, errors=errs))
@@ -278,7 +278,7 @@ def _per_entry_checks(
     repository: EntryRepository,
     namespace: str,
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> list[str]:
     """Run model-type allowlist, lineage-pair, and transient-validation checks for ``entry``."""
     errors: list[str] = []
@@ -295,7 +295,7 @@ def _per_entry_checks(
                 repository,
                 namespace,
                 cls,
-                is_namespace_shared=is_namespace_shared,
+                is_namespace_shareable=is_namespace_shareable,
             )
         )
     return errors
@@ -319,7 +319,7 @@ def _check_transient_validation(
     namespace: str,
     cls: type[BaseModel],
     *,
-    is_namespace_shared: IsNamespaceSharedFn | None = None,
+    is_namespace_shareable: IsNamespaceShareableFn | None = None,
 ) -> list[str]:
     """Run ``populate_refs`` + ``cls.model_validate`` and collect every message."""
     try:
@@ -327,7 +327,7 @@ def _check_transient_validation(
             entry.payload,
             repository,
             namespace,
-            is_namespace_shared=is_namespace_shared,
+            is_namespace_shareable=is_namespace_shareable,
         )
     except CatalogValidationError as exc:
         return list(exc.errors)

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -46,7 +46,7 @@ _NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 def make_meta_entry(
     namespace: str,
     *,
-    shared: bool | str = True,
+    shared: bool = True,
     name: str | None = None,
     description: str = "",
     extra_properties: dict[str, str] | None = None,
@@ -55,25 +55,20 @@ def make_meta_entry(
     """Build a ``kind="meta"`` Entry with the canonical id ``"_meta"``.
 
     Used by cross-ns shared-flag tests to opt the target namespace into
-    being a cross-ns ref target. ``shared=True`` writes the literal
-    ``"true"`` string under ``properties["shared"]``; ``shared=False``
-    writes ``"false"``; ``shared`` may also be passed as a raw string for
-    edge-case tests asserting that anything other than ``"true"`` is
-    treated as not-shared.
+    being a cross-ns ref target. Story 17.7 / AC1 — ``shared`` is a typed
+    bool at the root of the meta payload. ``shared=True`` writes
+    ``payload["shared"] = True``; ``shared=False`` writes
+    ``payload["shared"] = False``. The factory always emits the typed-bool
+    shape; legacy-shape fixtures construct the payload by hand.
     """
     properties: dict[str, str] = {}
-    if shared is True:
-        properties["shared"] = "true"
-    elif shared is False:
-        properties["shared"] = "false"
-    elif isinstance(shared, str):
-        properties["shared"] = shared
     if extra_properties:
         properties.update(extra_properties)
-    payload = {
+    payload: dict[str, Any] = {
         "name": name if name is not None else namespace,
         "description": description,
         "properties": properties,
+        "shared": shared,
     }
     return Entry(
         id="_meta",

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -46,7 +46,7 @@ _NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 def make_meta_entry(
     namespace: str,
     *,
-    shared: bool = True,
+    shareable: bool = True,
     name: str | None = None,
     description: str = "",
     extra_properties: dict[str, str] | None = None,
@@ -54,11 +54,11 @@ def make_meta_entry(
 ) -> Entry:
     """Build a ``kind="meta"`` Entry with the canonical id ``"_meta"``.
 
-    Used by cross-ns shared-flag tests to opt the target namespace into
-    being a cross-ns ref target. Story 17.7 / AC1 — ``shared`` is a typed
-    bool at the root of the meta payload. ``shared=True`` writes
-    ``payload["shared"] = True``; ``shared=False`` writes
-    ``payload["shared"] = False``. The factory always emits the typed-bool
+    Used by cross-ns shareable-flag tests to opt the target namespace into
+    being a cross-ns ref target. Story 17.7 / AC1 — ``shareable`` is a typed
+    bool at the root of the meta payload. ``shareable=True`` writes
+    ``payload["shareable"] = True``; ``shareable=False`` writes
+    ``payload["shareable"] = False``. The factory always emits the typed-bool
     shape; legacy-shape fixtures construct the payload by hand.
     """
     properties: dict[str, str] = {}
@@ -68,7 +68,7 @@ def make_meta_entry(
         "name": name if name is not None else namespace,
         "description": description,
         "properties": properties,
-        "shared": shared,
+        "shareable": shareable,
     }
     return Entry(
         id="_meta",

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -585,8 +585,8 @@ class TestNamespaceExport:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/yaml")
         doc = yaml.safe_load(response.text)
-        # Story 17.6 — six top-level keys in declaration order. The header
-        # trio (name/description/properties) is auto-synthesised from the
+        # Story 17.7 — seven top-level keys in declaration order. The header
+        # (name/description/properties/shared) is auto-synthesised from the
         # team-payload fallback when no _meta entry exists in the namespace.
         assert list(doc.keys()) == [
             "namespace",
@@ -594,9 +594,11 @@ class TestNamespaceExport:
             "name",
             "description",
             "properties",
+            "shared",
             "entries",
         ]
         assert doc["namespace"] == "ns-exp"
+        assert doc["shared"] is False
         assert set(doc["entries"].keys()) == {"team", "a-1"}
 
     def test_export_empty_namespace_409(self, api_client: tuple[TestClient, Catalog]) -> None:
@@ -1146,8 +1148,20 @@ class TestListNamespaces:
         assert response.status_code == 200
         data = response.json()
         assert data == [
-            {"namespace": "ns-a", "name": "Team A", "description": "alpha team"},
-            {"namespace": "ns-b", "name": "Team B", "description": "beta team"},
+            {
+                "namespace": "ns-a",
+                "name": "Team A",
+                "description": "alpha team",
+                "team": True,
+                "shared": False,
+            },
+            {
+                "namespace": "ns-b",
+                "name": "Team B",
+                "description": "beta team",
+                "team": True,
+                "shared": False,
+            },
         ]
 
     def test_missing_name_in_payload_falls_back_to_empty_string(
@@ -1175,7 +1189,15 @@ class TestListNamespaces:
         response = client.get("/catalog/namespaces")
         assert response.status_code == 200
         data = response.json()
-        assert data == [{"namespace": "ns-no-name", "name": "", "description": ""}]
+        assert data == [
+            {
+                "namespace": "ns-no-name",
+                "name": "",
+                "description": "",
+                "team": True,
+                "shared": False,
+            }
+        ]
 
     def test_namespace_without_team_entry_is_skipped(
         self, api_client: tuple[TestClient, Catalog]
@@ -1232,7 +1254,25 @@ class TestListNamespaces:
         ref = content["items"]["$ref"]
         assert ref.endswith("/NamespaceSummary")
         component = spec["components"]["schemas"]["NamespaceSummary"]
-        assert set(component["properties"].keys()) == {"namespace", "name", "description"}
+        # Story 17.7 — five pinned fields in declaration order.
+        assert set(component["properties"].keys()) == {
+            "namespace",
+            "name",
+            "description",
+            "team",
+            "shared",
+        }
+        # AC5 — declaration order pinned via OpenAPI's required-list ordering
+        # (FastAPI emits declaration order in ``required:`` for required
+        # fields). All five fields are required (no defaults that allow
+        # omission in the response shape).
+        assert component["required"] == [
+            "namespace",
+            "name",
+            "description",
+            "team",
+            "shared",
+        ]
 
 
 def test_router_namespace_import_malformed_yaml_returns_422(
@@ -1316,6 +1356,8 @@ class TestListNamespacesMetaFallback:
                 "namespace": "tenant-42",
                 "name": "Friendly Display",
                 "description": "meta description",
+                "team": True,
+                "shared": False,
             }
         ]
 
@@ -1341,6 +1383,8 @@ class TestListNamespacesMetaFallback:
                 "namespace": "tenant-42",
                 "name": "Team Display Name",
                 "description": "team description",
+                "team": True,
+                "shared": False,
             }
         ]
 
@@ -1384,6 +1428,8 @@ class TestListNamespacesMetaFallback:
                 "namespace": "tenant-42",
                 "name": "Team Display",
                 "description": "meta description",
+                "team": True,
+                "shared": False,
             }
         ]
 
@@ -1486,3 +1532,209 @@ class TestPutNamespaceMeta:
         body = {"name": "ghost", "description": "", "properties": {}}
         response = client.put("/catalog/namespace/ghost-ns/meta", json=body)
         assert response.status_code == 409
+
+
+# --- Story 17.7 — union discovery (team + meta) for /catalog/namespaces ---
+
+
+_NAMESPACE_META_TYPE_17_7 = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _seed_meta(
+    catalog: Catalog,
+    namespace: str,
+    *,
+    name: str = "Display",
+    description: str = "",
+    shared: bool = False,
+    user_id: str | None = None,
+) -> Entry:
+    """Seed a kind=meta entry directly through the catalog (typed-bool shape)."""
+    return catalog.create(
+        Entry(
+            id="_meta",
+            kind="meta",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_NAMESPACE_META_TYPE_17_7,
+            description=description,
+            payload={
+                "name": name,
+                "description": description,
+                "properties": {},
+                "shared": shared,
+            },
+        )
+    )
+
+
+class TestListNamespacesUnionDiscovery:
+    """Story 17.7 / AC19 — union discovery surfaces team-only, team+meta, meta-only namespaces."""
+
+    def test_three_namespace_fixture_team_meta_union(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """Three-namespace fixture with all three row classes per AC19.
+
+        * ``ns-team-only`` — team entry, no meta. Expect ``team=True, shared=False``.
+        * ``ns-team-meta-shared`` — team + meta (shared=True). Expect ``team=True, shared=True``.
+        * ``ns-meta-only`` — meta entry only (no team), shared=True. Expect
+          ``team=False, shared=True``. This is the regression guard for the
+          union-discovery widening — pre-17.7 this row was invisible.
+        """
+        client, catalog = api_client
+
+        # Case 1: team-only.
+        team_payload = _team_payload()
+        team_payload["name"] = "Team Only"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-team-only",
+                model_type=_TEAM_TYPE,
+                description="team only desc",
+                payload=team_payload,
+            )
+        )
+
+        # Case 2: team + meta with shared=True.
+        team_payload_2 = _team_payload()
+        team_payload_2["name"] = "Team Plus Shared Meta"
+        catalog.create(
+            Entry(
+                id="team",
+                kind="team",
+                namespace="ns-team-meta-shared",
+                model_type=_TEAM_TYPE,
+                description="team team desc",
+                payload=team_payload_2,
+            )
+        )
+        _seed_meta(
+            catalog,
+            "ns-team-meta-shared",
+            name="Friendly Display",
+            description="meta description",
+            shared=True,
+        )
+
+        # Case 3: meta-only (no team), shared=True. Bypass create to avoid the
+        # bootstrap invariant — meta-only library namespaces are out-of-band
+        # for ``Catalog.create`` but legitimate state for the discovery query.
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="ns-meta-only",
+                user_id=None,
+                model_type=_NAMESPACE_META_TYPE_17_7,
+                description="meta-only desc",
+                payload={
+                    "name": "Library NS",
+                    "description": "meta-only desc",
+                    "properties": {},
+                    "shared": True,
+                },
+            )
+        )
+
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+
+        # Sorted alphabetically by namespace.
+        assert [r["namespace"] for r in rows] == [
+            "ns-meta-only",
+            "ns-team-meta-shared",
+            "ns-team-only",
+        ]
+
+        by_ns = {r["namespace"]: r for r in rows}
+        assert by_ns["ns-team-only"] == {
+            "namespace": "ns-team-only",
+            "name": "Team Only",
+            "description": "team only desc",
+            "team": True,
+            "shared": False,
+        }
+        assert by_ns["ns-team-meta-shared"] == {
+            "namespace": "ns-team-meta-shared",
+            "name": "Friendly Display",
+            "description": "meta description",
+            "team": True,
+            "shared": True,
+        }
+        assert by_ns["ns-meta-only"] == {
+            "namespace": "ns-meta-only",
+            "name": "Library NS",
+            "description": "meta-only desc",
+            "team": False,
+            "shared": True,
+        }
+
+
+class TestListNamespacesNoExtraRoundtrip:
+    """Story 17.7 / AC20 — counting-spy regression guard against per-row catalog.get round-trips."""
+
+    def test_at_most_two_repository_listings_independent_of_n(
+        self, counting_catalog: tuple[Catalog, Any]
+    ) -> None:
+        """For N namespaces, exactly 2 repository ``list`` calls fire — not 2 + N.
+
+        Wraps the underlying repository with ``CountingEntryRepository`` and
+        seeds N=3 namespaces (matching AC20's "N >= 3" minimum so a per-row
+        round-trip would produce >= 5 calls vs the asserted 2).
+        """
+        from akgentic.catalog.api.router import build_router, set_catalog
+        from akgentic.catalog.api._errors import add_exception_handlers
+        from akgentic.catalog.api._settings import CatalogRouterSettings
+
+        catalog, counting = counting_catalog
+
+        # Seed three namespaces — each with a team to satisfy bootstrap.
+        for ns_name in ("ns-1", "ns-2", "ns-3"):
+            _seed_team(catalog, ns_name)
+        # Add a meta to ns-2 to broaden coverage of the union path.
+        _seed_meta(catalog, "ns-2", name="N2", shared=True)
+
+        # Reset call counts AFTER seeding (we only care about counts during
+        # the route handler dispatch).
+        counting.reset()
+
+        pytest.importorskip("fastapi")
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI(title="counting")
+        app.include_router(build_router(CatalogRouterSettings(expose_generic_kind_crud=True)))
+        set_catalog(catalog)
+        add_exception_handlers(app)
+        client = TestClient(app)
+
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+        # All three namespaces surface (regression guard for union widening).
+        assert sorted(r["namespace"] for r in rows) == ["ns-1", "ns-2", "ns-3"]
+
+        # AC20 — exactly two ``list`` calls hit the repository: one for
+        # kind="team", one for kind="meta". A per-row ``catalog.get(ns,
+        # "_meta")`` round-trip would produce 2 + N (= 5) repository calls
+        # under the previous shape; we explicitly assert 2.
+        list_calls = [c for c in counting.calls if c[0] == "list"]
+        assert counting.count("list") == 2, (
+            f"expected exactly 2 list() calls, got {counting.count('list')}: {list_calls}"
+        )
+        # Verify the two queries are kind="team" and kind="meta".
+        kinds = sorted(c[1][0].kind for c in list_calls)
+        assert kinds == ["meta", "team"]
+
+        # No per-row ``catalog.get(ns, "_meta")`` round-trip during the
+        # handler — this is the regression we are guarding against.
+        meta_gets = [
+            c for c in counting.calls if c[0] == "get" and len(c[1]) == 2 and c[1][1] == "_meta"
+        ]
+        assert meta_gets == [], (
+            f"expected 0 catalog.get(*, _meta) calls during handler dispatch, got {meta_gets}"
+        )

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -586,7 +586,7 @@ class TestNamespaceExport:
         assert response.headers["content-type"].startswith("application/yaml")
         doc = yaml.safe_load(response.text)
         # Story 17.7 — seven top-level keys in declaration order. The header
-        # (name/description/properties/shared) is auto-synthesised from the
+        # (name/description/properties/shareable) is auto-synthesised from the
         # team-payload fallback when no _meta entry exists in the namespace.
         assert list(doc.keys()) == [
             "namespace",
@@ -594,11 +594,11 @@ class TestNamespaceExport:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
         assert doc["namespace"] == "ns-exp"
-        assert doc["shared"] is False
+        assert doc["shareable"] is False
         assert set(doc["entries"].keys()) == {"team", "a-1"}
 
     def test_export_empty_namespace_409(self, api_client: tuple[TestClient, Catalog]) -> None:
@@ -1153,14 +1153,14 @@ class TestListNamespaces:
                 "name": "Team A",
                 "description": "alpha team",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             },
             {
                 "namespace": "ns-b",
                 "name": "Team B",
                 "description": "beta team",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             },
         ]
 
@@ -1195,7 +1195,7 @@ class TestListNamespaces:
                 "name": "",
                 "description": "",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             }
         ]
 
@@ -1260,7 +1260,7 @@ class TestListNamespaces:
             "name",
             "description",
             "team",
-            "shared",
+            "shareable",
         }
         # AC5 — declaration order pinned via OpenAPI's required-list ordering
         # (FastAPI emits declaration order in ``required:`` for required
@@ -1271,7 +1271,7 @@ class TestListNamespaces:
             "name",
             "description",
             "team",
-            "shared",
+            "shareable",
         ]
 
 
@@ -1357,7 +1357,7 @@ class TestListNamespacesMetaFallback:
                 "name": "Friendly Display",
                 "description": "meta description",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             }
         ]
 
@@ -1384,7 +1384,7 @@ class TestListNamespacesMetaFallback:
                 "name": "Team Display Name",
                 "description": "team description",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             }
         ]
 
@@ -1429,7 +1429,7 @@ class TestListNamespacesMetaFallback:
                 "name": "Team Display",
                 "description": "meta description",
                 "team": True,
-                "shared": False,
+                "shareable": False,
             }
         ]
 
@@ -1546,7 +1546,7 @@ def _seed_meta(
     *,
     name: str = "Display",
     description: str = "",
-    shared: bool = False,
+    shareable: bool = False,
     user_id: str | None = None,
 ) -> Entry:
     """Seed a kind=meta entry directly through the catalog (typed-bool shape)."""
@@ -1562,7 +1562,7 @@ def _seed_meta(
                 "name": name,
                 "description": description,
                 "properties": {},
-                "shared": shared,
+                "shareable": shareable,
             },
         )
     )
@@ -1576,10 +1576,11 @@ class TestListNamespacesUnionDiscovery:
     ) -> None:
         """Three-namespace fixture with all three row classes per AC19.
 
-        * ``ns-team-only`` — team entry, no meta. Expect ``team=True, shared=False``.
-        * ``ns-team-meta-shared`` — team + meta (shared=True). Expect ``team=True, shared=True``.
-        * ``ns-meta-only`` — meta entry only (no team), shared=True. Expect
-          ``team=False, shared=True``. This is the regression guard for the
+        * ``ns-team-only`` — team entry, no meta. Expect ``team=True, shareable=False``.
+        * ``ns-team-meta-shared`` — team + meta (shareable=True). Expect ``team=True,
+          shareable=True``.
+        * ``ns-meta-only`` — meta entry only (no team), shareable=True. Expect
+          ``team=False, shareable=True``. This is the regression guard for the
           union-discovery widening — pre-17.7 this row was invisible.
         """
         client, catalog = api_client
@@ -1598,7 +1599,7 @@ class TestListNamespacesUnionDiscovery:
             )
         )
 
-        # Case 2: team + meta with shared=True.
+        # Case 2: team + meta with shareable=True.
         team_payload_2 = _team_payload()
         team_payload_2["name"] = "Team Plus Shared Meta"
         catalog.create(
@@ -1616,10 +1617,10 @@ class TestListNamespacesUnionDiscovery:
             "ns-team-meta-shared",
             name="Friendly Display",
             description="meta description",
-            shared=True,
+            shareable=True,
         )
 
-        # Case 3: meta-only (no team), shared=True. Bypass create to avoid the
+        # Case 3: meta-only (no team), shareable=True. Bypass create to avoid the
         # bootstrap invariant — meta-only library namespaces are out-of-band
         # for ``Catalog.create`` but legitimate state for the discovery query.
         catalog._repository.put(
@@ -1634,7 +1635,7 @@ class TestListNamespacesUnionDiscovery:
                     "name": "Library NS",
                     "description": "meta-only desc",
                     "properties": {},
-                    "shared": True,
+                    "shareable": True,
                 },
             )
         )
@@ -1656,21 +1657,21 @@ class TestListNamespacesUnionDiscovery:
             "name": "Team Only",
             "description": "team only desc",
             "team": True,
-            "shared": False,
+            "shareable": False,
         }
         assert by_ns["ns-team-meta-shared"] == {
             "namespace": "ns-team-meta-shared",
             "name": "Friendly Display",
             "description": "meta description",
             "team": True,
-            "shared": True,
+            "shareable": True,
         }
         assert by_ns["ns-meta-only"] == {
             "namespace": "ns-meta-only",
             "name": "Library NS",
             "description": "meta-only desc",
             "team": False,
-            "shared": True,
+            "shareable": True,
         }
 
 
@@ -1686,9 +1687,9 @@ class TestListNamespacesNoExtraRoundtrip:
         seeds N=3 namespaces (matching AC20's "N >= 3" minimum so a per-row
         round-trip would produce >= 5 calls vs the asserted 2).
         """
-        from akgentic.catalog.api.router import build_router, set_catalog
         from akgentic.catalog.api._errors import add_exception_handlers
         from akgentic.catalog.api._settings import CatalogRouterSettings
+        from akgentic.catalog.api.router import build_router, set_catalog
 
         catalog, counting = counting_catalog
 
@@ -1696,7 +1697,7 @@ class TestListNamespacesNoExtraRoundtrip:
         for ns_name in ("ns-1", "ns-2", "ns-3"):
             _seed_team(catalog, ns_name)
         # Add a meta to ns-2 to broaden coverage of the union path.
-        _seed_meta(catalog, "ns-2", name="N2", shared=True)
+        _seed_meta(catalog, "ns-2", name="N2", shareable=True)
 
         # Reset call counts AFTER seeding (we only care about counts during
         # the route handler dispatch).

--- a/tests/v2/test_app_factory_cross_ns.py
+++ b/tests/v2/test_app_factory_cross_ns.py
@@ -2,7 +2,7 @@
 
 Story 17.3 shipped ``create_app(cross_namespace_refs_allowed=...)`` and
 ``Catalog(repo, cross_namespace_refs_allowed=...)``. Story 17.4 deletes
-both per Epic 17 Addendum (2026-05-08) — the data-driven shared-flag
+both per Epic 17 Addendum (2026-05-08) — the data-driven shareable-flag
 mechanism replaces them. These tests pin the deletion: passing the
 removed kwarg raises ``TypeError`` ("unexpected keyword argument").
 """
@@ -48,4 +48,4 @@ class TestCatalogCtorRejectsRemovedKwarg:
 
         catalog = Catalog(FakeEntryRepository())
         # The internal cache attribute is still per-instance state.
-        assert catalog._shared_flag_cache == {}
+        assert catalog._shareable_flag_cache == {}

--- a/tests/v2/test_catalog_clone.py
+++ b/tests/v2/test_catalog_clone.py
@@ -472,13 +472,13 @@ class TestCloneCrossNs:
         from akgentic.catalog.repositories.yaml import YamlEntryRepository
 
         leaf, _sub, root = _register_models(monkeypatch)
-        # The target namespace must be marked shared so the source entry
+        # The target namespace must be marked shareable so the source entry
         # passes prepare_for_write at create() time.
         repo = YamlEntryRepository(tmp_path)
         catalog = Catalog(repo)
         # Seed the cross-ns target.
         _seed_team(catalog, namespace="global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -524,7 +524,7 @@ class TestCloneCrossNs:
         repo = YamlEntryRepository(tmp_path)
         catalog = Catalog(repo)
         _seed_team(catalog, namespace="global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -564,9 +564,9 @@ class TestCloneCrossNs:
         repo = YamlEntryRepository(tmp_path)
         catalog = Catalog(repo)
 
-        # Seed global cross-ns target with a shared meta entry.
+        # Seed global cross-ns target with a shareable meta entry.
         _seed_team(catalog, namespace="global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="global-leaf",

--- a/tests/v2/test_catalog_delete_global.py
+++ b/tests/v2/test_catalog_delete_global.py
@@ -1,13 +1,13 @@
 """Tests for Story 17.4 — ``Catalog.delete`` widens to a global-scope check.
 
-When the deleted entry's namespace is shared (its ``_meta`` carries
-``properties["shared"] == "true"``), ``Catalog.delete`` runs the existing
+When the deleted entry's namespace is shareable (its ``_meta`` carries
+``payload["shareable"] is True``), ``Catalog.delete`` runs the existing
 namespace-local ``validate_delete`` AND the new
 ``repository.find_references_global(...)`` walker; their referrer messages
 are concatenated into a single ``CatalogValidationError``.
 
-When the deleted entry's namespace is NOT shared (no meta entry, or meta
-entry with ``shared != "true"``), the global check short-circuits — no
+When the deleted entry's namespace is NOT shareable (no meta entry, or meta
+entry with ``shareable is not True``), the global check short-circuits — no
 extra repository call, no behaviour change vs. the pre-17.3 baseline.
 """
 
@@ -88,22 +88,22 @@ def _seed_team(catalog: Catalog, namespace: str) -> None:
     )
 
 
-def _mark_shared(catalog: Catalog, namespace: str) -> None:
+def _mark_shareable(catalog: Catalog, namespace: str) -> None:
     """Seed a meta entry making ``namespace`` cross-namespace-referenceable."""
-    catalog.create(make_meta_entry(namespace, shared=True))
+    catalog.create(make_meta_entry(namespace, shareable=True))
 
 
 class TestGlobalScopeBlocksDelete:
-    """Cross-tenant referrer to a shared entry blocks the delete."""
+    """Cross-tenant referrer to a shareable entry blocks the delete."""
 
-    def test_shared_ns_target_blocked_by_tenant_referrer(
+    def test_shareable_ns_target_blocked_by_tenant_referrer(
         self, model_paths: tuple[str, str]
     ) -> None:
         leaf, holder = model_paths
         repo = FakeEntryRepository()
         catalog = Catalog(repo)
         _seed_team(catalog, "global")
-        _mark_shared(catalog, "global")
+        _mark_shareable(catalog, "global")
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -140,14 +140,14 @@ class TestGlobalScopeBlocksDelete:
         assert "agent-1" in joined
 
 
-class TestNonSharedNamespaceShortCircuits:
-    """Deleting from a non-shared namespace skips the global scan."""
+class TestNonShareableNamespaceShortCircuits:
+    """Deleting from a non-shareable namespace skips the global scan."""
 
     def test_no_meta_entry_skips_global_call(self, model_paths: tuple[str, str]) -> None:
         leaf, _holder = model_paths
         inner = FakeEntryRepository()
         counting = CountingEntryRepository(inner)
-        # No meta entry on 'tenant-A' — namespace is not shared.
+        # No meta entry on 'tenant-A' — namespace is not shareable.
         catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "tenant-A")
         catalog.create(
@@ -164,14 +164,14 @@ class TestNonSharedNamespaceShortCircuits:
         catalog.delete("tenant-A", "leaf-1")
         assert counting.count("find_references_global") == 0
 
-    def test_shared_false_skips_global_call(self, model_paths: tuple[str, str]) -> None:
+    def test_shareable_false_skips_global_call(self, model_paths: tuple[str, str]) -> None:
         leaf, _holder = model_paths
         inner = FakeEntryRepository()
         counting = CountingEntryRepository(inner)
         catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "tenant-A")
-        # Meta entry with shared="false" ⇒ not shared.
-        catalog.create(make_meta_entry("tenant-A", shared=False))
+        # Meta entry with shareable=False ⇒ not shareable.
+        catalog.create(make_meta_entry("tenant-A", shareable=False))
         catalog.create(
             Entry(
                 id="leaf-1",
@@ -196,7 +196,7 @@ class TestNoMetaEntryByteIdentical:
         counting = CountingEntryRepository(inner)
         catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "global")
-        # No meta entry for global — namespace is not shared by default.
+        # No meta entry for global — namespace is not shareable by default.
         catalog.create(
             Entry(
                 id="leaf-1",

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -514,19 +514,19 @@ class TestBundleImportMetaSingleton:
 
 
 class TestImportBundleCrossNs:
-    """Story 17.4 — cross-ns markers exempt from bundle dangling-ref rule + shared-flag gate."""
+    """Story 17.4 — cross-ns markers exempt from bundle dangling-ref rule + shareable-flag gate."""
 
-    def test_cross_ns_ref_with_shared_target_imports(
+    def test_cross_ns_ref_with_shareable_target_imports(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bundle agent payload references global.shared — target exists in a shared namespace."""
+        """Bundle agent payload references global.shared — target in shareable namespace."""
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, repo = catalog_factory()
-        # Seed the global target + meta with shared=true.
+        # Seed the global target + meta with shareable=true.
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -565,15 +565,15 @@ class TestImportBundleCrossNs:
         ids = {e.id for e in repo.list_by_namespace("tenant-A")}
         assert ids == {"team", "agent-1"}
 
-    def test_cross_ns_ref_to_non_shared_namespace_rejected(
+    def test_cross_ns_ref_to_non_shareable_namespace_rejected(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bundle with cross-ns ref to a non-shared namespace fails at prepare_for_write."""
+        """Bundle with cross-ns ref to a non-shareable namespace fails at prepare_for_write."""
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
-        # global has no meta entry — namespace is not shared.
+        # global has no meta entry — namespace is not shareable.
         bundle = [
             Entry(
                 id="team",
@@ -596,19 +596,19 @@ class TestImportBundleCrossNs:
         with pytest.raises(CatalogValidationError) as exc_info:
             catalog.import_namespace_yaml(yaml_text)
         msg = " | ".join(exc_info.value.errors)
-        assert "is not shared" in msg
+        assert "is not shareable" in msg
 
-    def test_cross_ns_ref_target_missing_in_shared_namespace(
+    def test_cross_ns_ref_target_missing_in_shareable_namespace(
         self,
         catalog_factory: CatalogFactory,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Shared namespace exists but target id missing ⇒ standard not-found."""
+        """Shareable namespace exists but target id missing ⇒ standard not-found."""
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
-        # Mark global shared but seed no target id.
+        # Mark global shareable but seed no target id.
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         bundle = [
             Entry(
                 id="team",
@@ -645,12 +645,12 @@ def _seed_meta(
     name: str = "Tenant",
     description: str = "primary tenant",
     properties: dict[str, str] | None = None,
-    shared: bool = False,
+    shareable: bool = False,
     user_id: str | None = "alice",
 ) -> Entry:
     """Create a `_meta` entry in ``namespace`` and return it.
 
-    Story 17.7 — ``shared`` is a typed bool at the root of the meta payload.
+    Story 17.7 — ``shareable`` is a typed bool at the root of the meta payload.
     """
     return catalog.create(
         Entry(
@@ -663,7 +663,7 @@ def _seed_meta(
                 "name": name,
                 "description": description,
                 "properties": properties if properties is not None else {},
-                "shared": shared,
+                "shareable": shareable,
             },
         )
     )
@@ -692,7 +692,7 @@ class TestHeaderProjection:
             name="Agent Team",
             description="Manager-led team",
             properties={"tier": "gold"},
-            shared=True,
+            shareable=True,
         )
         text = catalog.export_namespace_yaml("tenant-A")
         import yaml as _yaml
@@ -705,13 +705,13 @@ class TestHeaderProjection:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
         assert doc["name"] == "Agent Team"
         assert doc["description"] == "Manager-led team"
         assert doc["properties"] == {"tier": "gold"}
-        assert doc["shared"] is True
+        assert doc["shareable"] is True
         # AC2 — the meta entry is NEVER in `entries:` for bundles produced
         # by Catalog.export_namespace_yaml.
         assert "_meta" not in doc["entries"]
@@ -752,7 +752,7 @@ class TestHeaderProjection:
                     "name": "",
                     "description": "tenant description",
                     "properties": {"tier": "gold"},
-                    "shared": False,
+                    "shareable": False,
                 },
             )
         )
@@ -766,21 +766,21 @@ class TestHeaderProjection:
         assert doc["description"] == "tenant description"
         assert doc["properties"] == {"tier": "gold"}
 
-    def test_shared_flag_round_trips(self, catalog_factory: CatalogFactory) -> None:
-        """Story 17.7 / AC8 — `shared=True` on the meta entry propagates to the bundle header."""
+    def test_shareable_flag_round_trips(self, catalog_factory: CatalogFactory) -> None:
+        """Story 17.7 / AC8 — `shareable=True` on the meta entry propagates to the bundle header."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "tenant-D")
         _seed_meta(
             catalog,
             "tenant-D",
             name="Shared Tenant",
-            shared=True,
+            shareable=True,
         )
         text = catalog.export_namespace_yaml("tenant-D")
         import yaml as _yaml
 
         doc = _yaml.safe_load(text)
-        assert doc["shared"] is True
+        assert doc["shareable"] is True
         # `properties` is now fully free-form (no reserved keys).
         assert doc["properties"] == {}
 
@@ -830,8 +830,8 @@ class TestImportHeaderUpsert:
         assert meta.payload["name"] == "X-name"
         assert meta.payload["description"] == "X-desc"
         assert meta.payload["properties"] == {"owner_team": "platform"}
-        # Story 17.7 — `shared` is a typed bool at the root of the meta payload.
-        assert meta.payload["shared"] is False
+        # Story 17.7 — `shareable` is a typed bool at the root of the meta payload.
+        assert meta.payload["shareable"] is False
 
     def test_import_updates_meta_when_present(self, catalog_factory: CatalogFactory) -> None:
         """Bundle has header → existing meta is UPDATED in place."""
@@ -960,8 +960,8 @@ class TestExportExternalRefs:
     """Story 17.6 reshape of Story 17.5's behaviour pins.
 
     Behaviours pinned (carry over from Story 17.5):
-    * Cross-ns targets in shared namespaces appear in external sections.
-    * Cross-ns targets in non-shared namespaces are silently omitted.
+    * Cross-ns targets in shareable namespaces appear in external sections.
+    * Cross-ns targets in non-shareable namespaces are silently omitted.
     * Cross-ns targets that are missing are silently omitted.
     * Same-namespace short-circuit (cross-ns marker pointing at the bundle's
       own namespace is not external).
@@ -975,14 +975,14 @@ class TestExportExternalRefs:
     * No top-level `external_refs:` field.
     """
 
-    def test_external_target_in_shared_namespace_appears(
+    def test_external_target_in_shareable_namespace_appears(
         self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
-        # Seed a shared global namespace + a target.
+        # Seed a shareable global namespace + a target.
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-model",
@@ -1018,12 +1018,12 @@ class TestExportExternalRefs:
         # No top-level external_refs key.
         assert "external_refs" not in doc
 
-    def test_external_target_non_shared_silently_omitted(
+    def test_external_target_non_shareable_silently_omitted(
         self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, _ = catalog_factory()
-        # Seed global with a target but NO shared-flag.
+        # Seed global with a target but NO shareable-flag.
         _seed_team(catalog, "global", user_id=None)
         catalog.create(
             Entry(
@@ -1036,8 +1036,8 @@ class TestExportExternalRefs:
             )
         )
         # We cannot create a tenant entry with a cross-ns ref to a
-        # non-shared target through Catalog.create (the shared-flag gate
-        # rejects). Bypass by writing directly to the repo.
+        # non-shareable target through Catalog.create (the shareable-flag
+        # gate rejects). Bypass by writing directly to the repo.
         _seed_team(catalog, "tenant-N", user_id=None)
         catalog._repository.put(
             Entry(
@@ -1055,7 +1055,7 @@ class TestExportExternalRefs:
         import yaml as _yaml
 
         doc = _yaml.safe_load(text)
-        # The non-shared target is silently omitted (no external section emitted).
+        # The non-shareable target is silently omitted (no external section emitted).
         assert "global.hidden-model" not in doc["entries"]
 
     def test_external_target_missing_silently_omitted(
@@ -1063,9 +1063,9 @@ class TestExportExternalRefs:
     ) -> None:
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _ = catalog_factory()
-        # Mark global shared but seed no target id.
+        # Mark global shareable but seed no target id.
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         # Bypass the catalog gate by writing the bad ref directly.
         _seed_team(catalog, "tenant-M", user_id=None)
         catalog._repository.put(
@@ -1112,7 +1112,7 @@ class TestRoundTripBundle:
             name="Roundtrip Tenant",
             description="rt",
             properties={"owner_team": "platform"},
-            shared=True,
+            shareable=True,
         )
         _seed_agent(catalog, "tenant-RT", "a-1", user_id="alice")
 
@@ -1132,9 +1132,9 @@ class TestRoundTripBundle:
         assert parsed_a["name"] == parsed_b["name"]
         assert parsed_a["description"] == parsed_b["description"]
         assert parsed_a["properties"] == parsed_b["properties"]
-        # Story 17.7 — `shared` round-trips through the header → meta upsert.
-        assert parsed_a["shared"] == parsed_b["shared"]
-        assert parsed_a["shared"] is True
+        # Story 17.7 — `shareable` round-trips through the header → meta upsert.
+        assert parsed_a["shareable"] == parsed_b["shareable"]
+        assert parsed_a["shareable"] is True
 
     def test_pre_175_bundle_imports_cleanly(self, catalog_factory: CatalogFactory) -> None:
         """AC12 — a hand-written legacy pre-17.5 bundle imports without errors."""
@@ -1156,21 +1156,21 @@ class TestRoundTripBundle:
         # No header trio → no meta upsert; only the team is created.
         assert ids == {"team"}
 
-    def test_legacy_bundle_with_nested_shared_property_does_not_flip_root_shared(
+    def test_legacy_bundle_with_nested_shared_property_does_not_flip_root_shareable(
         self, catalog_factory: CatalogFactory
     ) -> None:
         """Story 17.7 / AC22 — strict cutover: legacy `properties: {shared: "true"}`
-        is preserved as plain string data but does NOT flip `payload["shared"]`
+        is preserved as plain string data but does NOT flip `payload["shareable"]`
         to True (no read-time fallback).
 
         The legacy bundle (pre-17.7) carries six top-level keys: `name`,
-        `description`, `properties`, no `shared`. The import upserts a meta
-        entry from the header — `shared` defaults to False, even though the
+        `description`, `properties`, no `shareable`. The import upserts a meta
+        entry from the header — `shareable` defaults to False, even though the
         legacy `properties: {shared: "true"}` sits under the meta payload's
         `properties` map.
         """
         catalog, repo = catalog_factory()
-        # Build a bundle by hand: six top-level keys (no `shared`).
+        # Build a bundle by hand: six top-level keys (no `shareable`).
         # `properties.shared = "true"` is the Story 17.4 wire shape — plain
         # string data now, NOT consulted by the catalog gate.
         legacy_text = (
@@ -1194,17 +1194,17 @@ class TestRoundTripBundle:
         assert meta is not None
         # The legacy nested `shared` is preserved verbatim under properties.
         assert meta.payload["properties"] == {"shared": "true"}
-        # But `payload["shared"]` is False — strict cutover, no read-time
+        # But `payload["shareable"]` is False — strict cutover, no read-time
         # fallback to the legacy nested shape.
-        assert meta.payload["shared"] is False
-        # Resolver gate evaluates False — the namespace is NOT shared.
-        assert catalog._is_namespace_shared("tenant-LEGSH") is False
+        assert meta.payload["shareable"] is False
+        # Resolver gate evaluates False — the namespace is NOT shareable.
+        assert catalog._is_namespace_shareable("tenant-LEGSH") is False
 
     def test_byte_identical_export_no_writes(self, catalog_factory: CatalogFactory) -> None:
         """AC20 strict byte-identical contract."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "ns-bi")
-        _seed_meta(catalog, "ns-bi", name="X", shared=True)
+        _seed_meta(catalog, "ns-bi", name="X", shareable=True)
         _seed_agent(catalog, "ns-bi", "a")
         text_a = catalog.export_namespace_yaml("ns-bi")
         text_b = catalog.export_namespace_yaml("ns-bi")
@@ -1223,7 +1223,7 @@ class TestSnapshotShape:
         # - 3 local kinds: team + agent + prompt (and meta hoisted to header).
         # - 2 external kinds: model + tool (in shared global namespace).
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="m1",
@@ -1251,7 +1251,7 @@ class TestSnapshotShape:
             "tenant-Snap",
             name="Snap Tenant",
             description="snap",
-            shared=False,
+            shareable=False,
             user_id=None,
         )
         catalog.create(
@@ -1300,14 +1300,14 @@ class TestSnapshotShape:
 
         doc = _yaml.safe_load(text)
 
-        # Story 17.7 / AC8 — seven top-level keys in order (adds ``shared``).
+        # Story 17.7 / AC8 — seven top-level keys in order (adds ``shareable``).
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
 

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -645,9 +645,13 @@ def _seed_meta(
     name: str = "Tenant",
     description: str = "primary tenant",
     properties: dict[str, str] | None = None,
+    shared: bool = False,
     user_id: str | None = "alice",
 ) -> Entry:
-    """Create a `_meta` entry in ``namespace`` and return it."""
+    """Create a `_meta` entry in ``namespace`` and return it.
+
+    Story 17.7 — ``shared`` is a typed bool at the root of the meta payload.
+    """
     return catalog.create(
         Entry(
             id="_meta",
@@ -659,6 +663,7 @@ def _seed_meta(
                 "name": name,
                 "description": description,
                 "properties": properties if properties is not None else {},
+                "shared": shared,
             },
         )
     )
@@ -686,24 +691,27 @@ class TestHeaderProjection:
             "tenant-A",
             name="Agent Team",
             description="Manager-led team",
-            properties={"shared": "true", "tier": "gold"},
+            properties={"tier": "gold"},
+            shared=True,
         )
         text = catalog.export_namespace_yaml("tenant-A")
         import yaml as _yaml
 
         doc = _yaml.safe_load(text)
-        # AC1 — six top-level keys in declaration order.
+        # Story 17.7 / AC8 — seven top-level keys in declaration order.
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
             "name",
             "description",
             "properties",
+            "shared",
             "entries",
         ]
         assert doc["name"] == "Agent Team"
         assert doc["description"] == "Manager-led team"
-        assert doc["properties"] == {"shared": "true", "tier": "gold"}
+        assert doc["properties"] == {"tier": "gold"}
+        assert doc["shared"] is True
         # AC2 — the meta entry is NEVER in `entries:` for bundles produced
         # by Catalog.export_namespace_yaml.
         assert "_meta" not in doc["entries"]
@@ -743,7 +751,8 @@ class TestHeaderProjection:
                 payload={
                     "name": "",
                     "description": "tenant description",
-                    "properties": {"shared": "true"},
+                    "properties": {"tier": "gold"},
+                    "shared": False,
                 },
             )
         )
@@ -755,23 +764,25 @@ class TestHeaderProjection:
         assert doc["name"] == "team"
         # description and properties still come from the meta entry.
         assert doc["description"] == "tenant description"
-        assert doc["properties"] == {"shared": "true"}
+        assert doc["properties"] == {"tier": "gold"}
 
-    def test_shared_property_round_trips(self, catalog_factory: CatalogFactory) -> None:
-        """AC2 — `properties.shared='true'` propagates verbatim to top-level properties."""
+    def test_shared_flag_round_trips(self, catalog_factory: CatalogFactory) -> None:
+        """Story 17.7 / AC8 — `shared=True` on the meta entry propagates to the bundle header."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "tenant-D")
         _seed_meta(
             catalog,
             "tenant-D",
             name="Shared Tenant",
-            properties={"shared": "true"},
+            shared=True,
         )
         text = catalog.export_namespace_yaml("tenant-D")
         import yaml as _yaml
 
         doc = _yaml.safe_load(text)
-        assert doc["properties"] == {"shared": "true"}
+        assert doc["shared"] is True
+        # `properties` is now fully free-form (no reserved keys).
+        assert doc["properties"] == {}
 
 
 # --- Story 17.6 — header upsert on import ----------------------------------
@@ -811,14 +822,16 @@ class TestImportHeaderUpsert:
             namespace="tenant-X",
             name="X-name",
             description="X-desc",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
         )
         catalog.import_namespace_yaml(yaml_text)
         meta = repo.get("tenant-X", "_meta")
         assert meta is not None
         assert meta.payload["name"] == "X-name"
         assert meta.payload["description"] == "X-desc"
-        assert meta.payload["properties"] == {"shared": "true"}
+        assert meta.payload["properties"] == {"owner_team": "platform"}
+        # Story 17.7 — `shared` is a typed bool at the root of the meta payload.
+        assert meta.payload["shared"] is False
 
     def test_import_updates_meta_when_present(self, catalog_factory: CatalogFactory) -> None:
         """Bundle has header → existing meta is UPDATED in place."""
@@ -835,14 +848,14 @@ class TestImportHeaderUpsert:
             namespace="tenant-Y",
             name="NEW",
             description="NEW-desc",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
         )
         catalog.import_namespace_yaml(yaml_text)
         meta = repo.get("tenant-Y", "_meta")
         assert meta is not None
         assert meta.payload["name"] == "NEW"
         assert meta.payload["description"] == "NEW-desc"
-        assert meta.payload["properties"] == {"shared": "true"}
+        assert meta.payload["properties"] == {"owner_team": "platform"}
 
     def test_import_legacy_bundle_skips_meta_upsert(self, catalog_factory: CatalogFactory) -> None:
         """AC11 / AC12 — pre-17.5 bundle (no header trio) leaves existing _meta untouched."""
@@ -1098,7 +1111,8 @@ class TestRoundTripBundle:
             "tenant-RT",
             name="Roundtrip Tenant",
             description="rt",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
+            shared=True,
         )
         _seed_agent(catalog, "tenant-RT", "a-1", user_id="alice")
 
@@ -1114,10 +1128,13 @@ class TestRoundTripBundle:
         parsed_b = _yaml.safe_load(yaml_b)
         # Entries dict equality (key-order-independent).
         assert parsed_a["entries"] == parsed_b["entries"]
-        # Header trio survives the round-trip via meta upsert.
+        # Header survives the round-trip via meta upsert.
         assert parsed_a["name"] == parsed_b["name"]
         assert parsed_a["description"] == parsed_b["description"]
         assert parsed_a["properties"] == parsed_b["properties"]
+        # Story 17.7 — `shared` round-trips through the header → meta upsert.
+        assert parsed_a["shared"] == parsed_b["shared"]
+        assert parsed_a["shared"] is True
 
     def test_pre_175_bundle_imports_cleanly(self, catalog_factory: CatalogFactory) -> None:
         """AC12 — a hand-written legacy pre-17.5 bundle imports without errors."""
@@ -1139,11 +1156,55 @@ class TestRoundTripBundle:
         # No header trio → no meta upsert; only the team is created.
         assert ids == {"team"}
 
+    def test_legacy_bundle_with_nested_shared_property_does_not_flip_root_shared(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Story 17.7 / AC22 — strict cutover: legacy `properties: {shared: "true"}`
+        is preserved as plain string data but does NOT flip `payload["shared"]`
+        to True (no read-time fallback).
+
+        The legacy bundle (pre-17.7) carries six top-level keys: `name`,
+        `description`, `properties`, no `shared`. The import upserts a meta
+        entry from the header — `shared` defaults to False, even though the
+        legacy `properties: {shared: "true"}` sits under the meta payload's
+        `properties` map.
+        """
+        catalog, repo = catalog_factory()
+        # Build a bundle by hand: six top-level keys (no `shared`).
+        # `properties.shared = "true"` is the Story 17.4 wire shape — plain
+        # string data now, NOT consulted by the catalog gate.
+        legacy_text = (
+            "namespace: tenant-LEGSH\n"
+            "user_id: alice\n"
+            "name: Legacy Tenant\n"
+            "description: from-pre-17.7\n"
+            "properties:\n"
+            "  shared: 'true'\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            f"    payload: {_team_payload()!r}\n"
+        )
+        catalog.import_namespace_yaml(legacy_text)
+        meta = repo.get("tenant-LEGSH", "_meta")
+        assert meta is not None
+        # The legacy nested `shared` is preserved verbatim under properties.
+        assert meta.payload["properties"] == {"shared": "true"}
+        # But `payload["shared"]` is False — strict cutover, no read-time
+        # fallback to the legacy nested shape.
+        assert meta.payload["shared"] is False
+        # Resolver gate evaluates False — the namespace is NOT shared.
+        assert catalog._is_namespace_shared("tenant-LEGSH") is False
+
     def test_byte_identical_export_no_writes(self, catalog_factory: CatalogFactory) -> None:
         """AC20 strict byte-identical contract."""
         catalog, _ = catalog_factory()
         _seed_team(catalog, "ns-bi")
-        _seed_meta(catalog, "ns-bi", name="X", properties={"shared": "true"})
+        _seed_meta(catalog, "ns-bi", name="X", shared=True)
         _seed_agent(catalog, "ns-bi", "a")
         text_a = catalog.export_namespace_yaml("ns-bi")
         text_b = catalog.export_namespace_yaml("ns-bi")
@@ -1190,7 +1251,7 @@ class TestSnapshotShape:
             "tenant-Snap",
             name="Snap Tenant",
             description="snap",
-            properties={"shared": "false"},
+            shared=False,
             user_id=None,
         )
         catalog.create(
@@ -1239,13 +1300,14 @@ class TestSnapshotShape:
 
         doc = _yaml.safe_load(text)
 
-        # Snapshot — top-level keys in order.
+        # Story 17.7 / AC8 — seven top-level keys in order (adds ``shared``).
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
             "name",
             "description",
             "properties",
+            "shared",
             "entries",
         ]
 

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -331,15 +331,15 @@ class TestValidateNamespaceYamlIsReadOnly:
 
 
 class TestValidateNamespaceCrossNs:
-    """Story 17.4 — validate_namespace surfaces cross-ns shared-flag errors per entry."""
+    """Story 17.4 — validate_namespace surfaces cross-ns shareable-flag errors per entry."""
 
-    def test_non_shared_cross_ns_ref_appears_in_entry_issues(
+    def test_non_shareable_cross_ns_ref_appears_in_entry_issues(
         self, catalog_factory: CatalogFactory
     ) -> None:
         catalog, repo = catalog_factory()
-        # Seed global target via shared-flag-enabled global namespace.
+        # Seed global target via shareable-flag-enabled global namespace.
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared",
@@ -365,14 +365,14 @@ class TestValidateNamespaceCrossNs:
                 "metadata": {"ptr": {"__ref__": "global.shared"}},
             },
         )
-        # Flip global to not-shared so the cross-ns marker now fails the gate.
+        # Flip global to not-shareable so the cross-ns marker now fails the gate.
         catalog._repository.delete("global", "_meta")
-        catalog._shared_flag_cache.pop("global", None)
+        catalog._shareable_flag_cache.pop("global", None)
         report = catalog.validate_namespace("tenant-A")
         assert report.ok is False
         assert report.entry_issues, "expected per-entry issue for cross-ns ref"
         joined = " | ".join(err for issue in report.entry_issues for err in issue.errors)
-        assert "is not shared" in joined
+        assert "is not shareable" in joined
         # Cross-ns errors live in entry_issues only — the dangling-ref
         # walker must NOT flag the cross-ns marker as a global-error.
         assert not any("dangling ref" in m for m in report.global_errors), (
@@ -387,11 +387,11 @@ class TestValidateNamespaceCrossNs:
 
         The dangling-ref walker is the bundle-internal completeness check;
         cross-ns markers are external by design and must not be reported as
-        missing from the bundle (regardless of shared-flag state).
+        missing from the bundle (regardless of shareable-flag state).
         """
         catalog, _repo = catalog_factory()
         _seed_team(catalog, "global", user_id=None)
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared",
@@ -418,7 +418,7 @@ class TestValidateNamespaceCrossNs:
             },
         )
         report = catalog.validate_namespace("tenant-B")
-        # Cross-ns ref target's namespace is shared and the target exists —
+        # Cross-ns ref target's namespace is shareable and the target exists —
         # report ok.
         assert report.ok is True, (
             f"expected ok, got entry_issues={report.entry_issues!r} "

--- a/tests/v2/test_catalog_shared_flag_cache.py
+++ b/tests/v2/test_catalog_shared_flag_cache.py
@@ -284,21 +284,62 @@ class TestSharedFlagCachePerInstance:
         assert c2._shared_flag_cache == {}
 
 
-class TestSharedFlagExactStringSemantics:
-    """AC1 — only the literal lowercase string "true" enables sharing."""
+class TestSharedFlagStrictBoolSemantics:
+    """Story 17.7 / AC3 + AC18 — only typed-bool ``True`` at the root enables sharing.
+
+    The gate body is ``meta.payload.get("shared") is True`` — strict-bool
+    comparison. ``1``, ``"true"``, ``"True"``, and other truthy strings all
+    fall through to ``False``. The legacy nested
+    ``payload["properties"]["shared"]`` shape is plain string data now and
+    is NOT consulted by the gate (strict-cutover, no read-time fallback).
+    """
 
     @pytest.mark.parametrize(
-        "shared_value",
-        ["false", "True", "TRUE", "1", "", "yes"],
+        "non_true_payload",
+        [
+            # Strict-cutover (AC11): legacy nested shape is plain data,
+            # gate sees no root-level ``shared`` key → shared=False.
+            {"properties": {"shared": "true"}},
+            # Strict-bool (AC18): the string ``"true"`` at the root is NOT
+            # coerced to ``True`` by the gate.
+            {"shared": "true"},
+            # Strict-bool: integer 1 (a truthy value) is NOT coerced.
+            {"shared": 1},
+            # Explicit False root value.
+            {"shared": False},
+            # Missing key entirely.
+            {},
+        ],
+        ids=["legacy-nested", "string-true", "int-1", "bool-false", "absent"],
     )
-    def test_non_true_values_are_not_shared(
-        self, shared_value: str, model_paths: tuple[str, str]
+    def test_non_typed_true_values_are_not_shared(
+        self, non_true_payload: dict[str, object], model_paths: tuple[str, str]
     ) -> None:
         leaf, holder = model_paths
         repo = FakeEntryRepository()
         catalog = Catalog(repo)
         _seed_team(catalog, "global")
-        catalog.create(make_meta_entry("global", shared=shared_value))
+        # Bypass the catalog write pipeline (which routes through
+        # ``NamespaceMeta`` and would reject ``"true"`` strings under strict
+        # mode). The gate's behaviour is the focus: it must read the stored
+        # payload's ``shared`` key with strict-bool ``is True`` semantics
+        # regardless of how the entry got into the repository.
+        meta_payload: dict[str, object] = {
+            "name": "global",
+            "description": "",
+            "properties": {},
+        }
+        meta_payload.update(non_true_payload)
+        repo.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="global",
+                user_id=None,
+                model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+                payload=meta_payload,
+            )
+        )
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -327,3 +368,41 @@ class TestSharedFlagExactStringSemantics:
                 )
             )
         assert "is not shared" in exc_info.value.errors[0]
+
+    def test_typed_bool_true_at_root_is_shared(
+        self, model_paths: tuple[str, str]
+    ) -> None:
+        """Positive control — the canonical post-17.7 shape resolves cross-ns refs."""
+        leaf, holder = model_paths
+        repo = FakeEntryRepository()
+        catalog = Catalog(repo)
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id=None,
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        # No exception — the cross-ns ref resolves because the meta entry
+        # carries ``payload["shared"] is True`` at the root.
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id=None,
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )

--- a/tests/v2/test_catalog_shared_flag_cache.py
+++ b/tests/v2/test_catalog_shared_flag_cache.py
@@ -1,6 +1,6 @@
-"""Tests for Story 17.4 / AC10, AC11 — per-Catalog shared-flag cache + invalidation.
+"""Tests for Story 17.4 / AC10, AC11 — per-Catalog shareable-flag cache + invalidation.
 
-The resolver caches the per-namespace shared flag for the lifetime of a
+The resolver caches the per-namespace shareable flag for the lifetime of a
 ``Catalog`` instance, with cache invalidation on meta-entry mutation
 (create / update / delete).
 """
@@ -78,7 +78,7 @@ def _seed_team(catalog: Catalog, namespace: str) -> None:
     )
 
 
-class TestSharedFlagCacheHit:
+class TestShareableFlagCacheHit:
     """AC10 — repeated cross-ns resolves issue exactly one ``repository.get`` per ns."""
 
     def test_repeated_resolve_does_not_reissue_meta_lookup(
@@ -89,7 +89,7 @@ class TestSharedFlagCacheHit:
         counting = CountingEntryRepository(inner)
         catalog = Catalog(counting)  # type: ignore[arg-type]
         _seed_team(catalog, "global")
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -127,17 +127,17 @@ class TestSharedFlagCacheHit:
         assert meta_lookups == 0, f"expected 0 meta lookups, got {meta_lookups}: {counting.calls}"
 
 
-class TestSharedFlagCacheInvalidation:
+class TestShareableFlagCacheInvalidation:
     """AC10 — flipping the meta entry invalidates the cache."""
 
-    def test_flip_shared_true_to_false_makes_resolve_fail(
+    def test_flip_shareable_true_to_false_makes_resolve_fail(
         self, model_paths: tuple[str, str]
     ) -> None:
         leaf, holder = model_paths
         repo = FakeEntryRepository()
         catalog = Catalog(repo)
         _seed_team(catalog, "global")
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -167,19 +167,19 @@ class TestSharedFlagCacheInvalidation:
         # Cold resolve succeeds.
         catalog.resolve_by_id("tenant-A", "agent-1")
 
-        # Flip global meta to shared=false via update — this must invalidate
-        # the cache so the next resolve fails.
-        catalog.update(make_meta_entry("global", shared=False))
+        # Flip global meta to shareable=false via update — this must
+        # invalidate the cache so the next resolve fails.
+        catalog.update(make_meta_entry("global", shareable=False))
         with pytest.raises(CatalogValidationError) as exc_info:
             catalog.resolve_by_id("tenant-A", "agent-1")
-        assert "is not shared" in exc_info.value.errors[0]
+        assert "is not shareable" in exc_info.value.errors[0]
 
     def test_delete_meta_invalidates_cache(self, model_paths: tuple[str, str]) -> None:
         leaf, holder = model_paths
         repo = FakeEntryRepository()
         catalog = Catalog(repo)
         _seed_team(catalog, "global")
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -213,7 +213,7 @@ class TestSharedFlagCacheInvalidation:
         catalog.delete("global", "_meta")
         with pytest.raises(CatalogValidationError) as exc_info:
             catalog.resolve_by_id("tenant-A", "agent-1")
-        assert "is not shared" in exc_info.value.errors[0]
+        assert "is not shareable" in exc_info.value.errors[0]
 
     def test_create_meta_invalidates_cache(self, model_paths: tuple[str, str]) -> None:
         leaf, holder = model_paths
@@ -251,9 +251,9 @@ class TestSharedFlagCacheInvalidation:
             )
         except CatalogValidationError:
             pass
-        # Now mark global shared by creating a meta entry — cache should
+        # Now mark global shareable by creating a meta entry — cache should
         # invalidate so the next resolve succeeds.
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         # Now we can create the agent without hitting the gate.
         catalog.create(
             Entry(
@@ -272,7 +272,7 @@ class TestSharedFlagCacheInvalidation:
         )
 
 
-class TestSharedFlagCachePerInstance:
+class TestShareableFlagCachePerInstance:
     """AC11 — the cache is per-Catalog-instance, not module-global."""
 
     def test_two_catalogs_have_independent_caches(self) -> None:
@@ -280,14 +280,14 @@ class TestSharedFlagCachePerInstance:
         c1 = Catalog(repo)
         c2 = Catalog(repo)
         # Independent dicts — mutating one must not affect the other.
-        c1._shared_flag_cache["global"] = True
-        assert c2._shared_flag_cache == {}
+        c1._shareable_flag_cache["global"] = True
+        assert c2._shareable_flag_cache == {}
 
 
-class TestSharedFlagStrictBoolSemantics:
+class TestShareableFlagStrictBoolSemantics:
     """Story 17.7 / AC3 + AC18 — only typed-bool ``True`` at the root enables sharing.
 
-    The gate body is ``meta.payload.get("shared") is True`` — strict-bool
+    The gate body is ``meta.payload.get("shareable") is True`` — strict-bool
     comparison. ``1``, ``"true"``, ``"True"``, and other truthy strings all
     fall through to ``False``. The legacy nested
     ``payload["properties"]["shared"]`` shape is plain string data now and
@@ -298,21 +298,21 @@ class TestSharedFlagStrictBoolSemantics:
         "non_true_payload",
         [
             # Strict-cutover (AC11): legacy nested shape is plain data,
-            # gate sees no root-level ``shared`` key → shared=False.
+            # gate sees no root-level ``shareable`` key → shareable=False.
             {"properties": {"shared": "true"}},
             # Strict-bool (AC18): the string ``"true"`` at the root is NOT
             # coerced to ``True`` by the gate.
-            {"shared": "true"},
+            {"shareable": "true"},
             # Strict-bool: integer 1 (a truthy value) is NOT coerced.
-            {"shared": 1},
+            {"shareable": 1},
             # Explicit False root value.
-            {"shared": False},
+            {"shareable": False},
             # Missing key entirely.
             {},
         ],
         ids=["legacy-nested", "string-true", "int-1", "bool-false", "absent"],
     )
-    def test_non_typed_true_values_are_not_shared(
+    def test_non_typed_true_values_are_not_shareable(
         self, non_true_payload: dict[str, object], model_paths: tuple[str, str]
     ) -> None:
         leaf, holder = model_paths
@@ -322,7 +322,7 @@ class TestSharedFlagStrictBoolSemantics:
         # Bypass the catalog write pipeline (which routes through
         # ``NamespaceMeta`` and would reject ``"true"`` strings under strict
         # mode). The gate's behaviour is the focus: it must read the stored
-        # payload's ``shared`` key with strict-bool ``is True`` semantics
+        # payload's ``shareable`` key with strict-bool ``is True`` semantics
         # regardless of how the entry got into the repository.
         meta_payload: dict[str, object] = {
             "name": "global",
@@ -367,17 +367,15 @@ class TestSharedFlagStrictBoolSemantics:
                     },
                 )
             )
-        assert "is not shared" in exc_info.value.errors[0]
+        assert "is not shareable" in exc_info.value.errors[0]
 
-    def test_typed_bool_true_at_root_is_shared(
-        self, model_paths: tuple[str, str]
-    ) -> None:
+    def test_typed_bool_true_at_root_is_shareable(self, model_paths: tuple[str, str]) -> None:
         """Positive control — the canonical post-17.7 shape resolves cross-ns refs."""
         leaf, holder = model_paths
         repo = FakeEntryRepository()
         catalog = Catalog(repo)
         _seed_team(catalog, "global")
-        catalog.create(make_meta_entry("global", shared=True))
+        catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
@@ -390,7 +388,7 @@ class TestSharedFlagStrictBoolSemantics:
         )
         _seed_team(catalog, "tenant-A")
         # No exception — the cross-ns ref resolves because the meta entry
-        # carries ``payload["shared"] is True`` at the root.
+        # carries ``payload["shareable"] is True`` at the root.
         catalog.create(
             Entry(
                 id="agent-1",

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -143,14 +143,14 @@ class TestExportVerb:
         )
         assert result.exit_code == 0, result.stderr
         payload = yaml.safe_load(result.stdout)
-        # Story 17.7 — seven top-level keys including the header (adds ``shared``).
+        # Story 17.7 — seven top-level keys including the header (adds ``shareable``).
         assert set(payload.keys()) == {
             "namespace",
             "user_id",
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         }
         assert payload["namespace"] == "ns-a"

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -143,13 +143,14 @@ class TestExportVerb:
         )
         assert result.exit_code == 0, result.stderr
         payload = yaml.safe_load(result.stdout)
-        # Story 17.6 — six top-level keys including the header trio.
+        # Story 17.7 — seven top-level keys including the header (adds ``shared``).
         assert set(payload.keys()) == {
             "namespace",
             "user_id",
             "name",
             "description",
             "properties",
+            "shared",
             "entries",
         }
         assert payload["namespace"] == "ns-a"

--- a/tests/v2/test_namespace_meta.py
+++ b/tests/v2/test_namespace_meta.py
@@ -1,6 +1,6 @@
 """Tests for ``NamespaceMeta`` — the payload model for the ``kind="meta"`` entry.
 
-Story 17.7 / AC17 — pin the typed ``shared: bool`` root field contract:
+Story 17.7 / AC17 — pin the typed ``shareable: bool`` root field contract:
 
 * default ``False``, accepts ``True`` / ``False``, round-trips through
   ``model_dump`` with the key present;
@@ -11,7 +11,7 @@ The model also pins that ``properties`` is fully free-form ``str -> str``
 with NO catalog-reserved keys (AC2): a caller may supply
 ``properties["shared"] = "true"`` as plain string data and Pydantic accepts
 it without complaint, but the catalog gate / route projection / serializer
-header consult ``payload["shared"]`` only.
+header consult ``payload["shareable"]`` only.
 """
 
 from __future__ import annotations
@@ -22,52 +22,52 @@ from pydantic import ValidationError
 from akgentic.catalog.models.namespace_meta import NamespaceMeta
 
 
-class TestNamespaceMetaSharedField:
-    """AC17 — ``shared: bool`` root-field contract."""
+class TestNamespaceMetaShareableField:
+    """AC17 — ``shareable: bool`` root-field contract."""
 
-    def test_default_shared_is_false(self) -> None:
+    def test_default_shareable_is_false(self) -> None:
         meta = NamespaceMeta(name="x")
-        assert meta.shared is False
+        assert meta.shareable is False
         # AC1 — model_dump of a default-constructed instance carries
-        # ``shared: False`` (no special opcode / exclude flag required).
+        # ``shareable: False`` (no special opcode / exclude flag required).
         dumped = meta.model_dump()
-        assert dumped["shared"] is False
+        assert dumped["shareable"] is False
 
-    def test_explicit_shared_true_round_trip(self) -> None:
-        meta = NamespaceMeta(name="x", shared=True)
-        assert meta.shared is True
+    def test_explicit_shareable_true_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", shareable=True)
+        assert meta.shareable is True
         dumped = meta.model_dump()
-        assert dumped["shared"] is True
+        assert dumped["shareable"] is True
 
-    def test_explicit_shared_false_round_trip(self) -> None:
-        meta = NamespaceMeta(name="x", shared=False)
-        assert meta.shared is False
+    def test_explicit_shareable_false_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", shareable=False)
+        assert meta.shareable is False
         dumped = meta.model_dump()
-        assert dumped["shared"] is False
+        assert dumped["shareable"] is False
 
     def test_pydantic_rejects_non_bool_string(self) -> None:
         # AC1 — strict-mode rejection of non-bool input. Pydantic's default
         # bool validation is permissive of true/false-like strings; we pin
         # that ``"true"`` is rejected via ``model_validate(strict=True)`` —
         # the catalog write pipeline runs validation at construction so an
-        # operator cannot smuggle a string through ``payload["shared"]``
+        # operator cannot smuggle a string through ``payload["shareable"]``
         # at the NamespaceMeta layer.
         with pytest.raises(ValidationError):
             NamespaceMeta.model_validate(
-                {"name": "x", "shared": "true"},
+                {"name": "x", "shareable": "true"},
                 strict=True,
             )
 
     def test_pydantic_rejects_int_under_strict(self) -> None:
         with pytest.raises(ValidationError):
             NamespaceMeta.model_validate(
-                {"name": "x", "shared": 1},
+                {"name": "x", "shareable": 1},
                 strict=True,
             )
 
 
 class TestNamespaceMetaFieldOrder:
-    """AC1 — declared field order is ``name``, ``description``, ``properties``, ``shared``."""
+    """AC1 — declared field order is ``name``, ``description``, ``properties``, ``shareable``."""
 
     def test_model_fields_declaration_order(self) -> None:
         # AC1 — declaration order pins the export-bundle header projection
@@ -77,7 +77,7 @@ class TestNamespaceMetaFieldOrder:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
         ]
 
 
@@ -85,17 +85,17 @@ class TestNamespaceMetaPropertiesFreeForm:
     """AC2 — ``properties`` is fully free-form ``str -> str`` with NO reserved keys."""
 
     def test_properties_accepts_arbitrary_string_keys(self) -> None:
-        # ``properties["shared"]`` is plain string data now: Pydantic accepts
+        # ``properties["shared"]`` is plain string data: Pydantic accepts
         # it because the field type is ``dict[str, str]``. Only the catalog
-        # gate / route projection / serializer consult ``payload["shared"]``.
+        # gate / route projection / serializer consult ``payload["shareable"]``.
         meta = NamespaceMeta(
             name="x",
             properties={"shared": "true", "owner_team": "platform"},
         )
         assert meta.properties == {"shared": "true", "owner_team": "platform"}
-        # Default ``shared`` is still False — ``properties["shared"]`` is
+        # Default ``shareable`` is still False — ``properties["shared"]`` is
         # plain data and does NOT influence the typed root field.
-        assert meta.shared is False
+        assert meta.shareable is False
 
     def test_properties_rejects_non_string_value(self) -> None:
         # ``dict[str, str]`` is enforced at the Pydantic layer.

--- a/tests/v2/test_namespace_meta.py
+++ b/tests/v2/test_namespace_meta.py
@@ -1,0 +1,106 @@
+"""Tests for ``NamespaceMeta`` — the payload model for the ``kind="meta"`` entry.
+
+Story 17.7 / AC17 — pin the typed ``shared: bool`` root field contract:
+
+* default ``False``, accepts ``True`` / ``False``, round-trips through
+  ``model_dump`` with the key present;
+* Pydantic strict-mode rejects non-bool inputs (e.g. the string ``"true"``)
+  with a ``ValidationError`` — no truthy-string coercion at the model layer.
+
+The model also pins that ``properties`` is fully free-form ``str -> str``
+with NO catalog-reserved keys (AC2): a caller may supply
+``properties["shared"] = "true"`` as plain string data and Pydantic accepts
+it without complaint, but the catalog gate / route projection / serializer
+header consult ``payload["shared"]`` only.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from akgentic.catalog.models.namespace_meta import NamespaceMeta
+
+
+class TestNamespaceMetaSharedField:
+    """AC17 — ``shared: bool`` root-field contract."""
+
+    def test_default_shared_is_false(self) -> None:
+        meta = NamespaceMeta(name="x")
+        assert meta.shared is False
+        # AC1 — model_dump of a default-constructed instance carries
+        # ``shared: False`` (no special opcode / exclude flag required).
+        dumped = meta.model_dump()
+        assert dumped["shared"] is False
+
+    def test_explicit_shared_true_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", shared=True)
+        assert meta.shared is True
+        dumped = meta.model_dump()
+        assert dumped["shared"] is True
+
+    def test_explicit_shared_false_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", shared=False)
+        assert meta.shared is False
+        dumped = meta.model_dump()
+        assert dumped["shared"] is False
+
+    def test_pydantic_rejects_non_bool_string(self) -> None:
+        # AC1 — strict-mode rejection of non-bool input. Pydantic's default
+        # bool validation is permissive of true/false-like strings; we pin
+        # that ``"true"`` is rejected via ``model_validate(strict=True)`` —
+        # the catalog write pipeline runs validation at construction so an
+        # operator cannot smuggle a string through ``payload["shared"]``
+        # at the NamespaceMeta layer.
+        with pytest.raises(ValidationError):
+            NamespaceMeta.model_validate(
+                {"name": "x", "shared": "true"},
+                strict=True,
+            )
+
+    def test_pydantic_rejects_int_under_strict(self) -> None:
+        with pytest.raises(ValidationError):
+            NamespaceMeta.model_validate(
+                {"name": "x", "shared": 1},
+                strict=True,
+            )
+
+
+class TestNamespaceMetaFieldOrder:
+    """AC1 — declared field order is ``name``, ``description``, ``properties``, ``shared``."""
+
+    def test_model_fields_declaration_order(self) -> None:
+        # AC1 — declaration order pins the export-bundle header projection
+        # order (architecture §07-api emits header keys by declaration order
+        # — see Story 17.7 AC8).
+        assert list(NamespaceMeta.model_fields.keys()) == [
+            "name",
+            "description",
+            "properties",
+            "shared",
+        ]
+
+
+class TestNamespaceMetaPropertiesFreeForm:
+    """AC2 — ``properties`` is fully free-form ``str -> str`` with NO reserved keys."""
+
+    def test_properties_accepts_arbitrary_string_keys(self) -> None:
+        # ``properties["shared"]`` is plain string data now: Pydantic accepts
+        # it because the field type is ``dict[str, str]``. Only the catalog
+        # gate / route projection / serializer consult ``payload["shared"]``.
+        meta = NamespaceMeta(
+            name="x",
+            properties={"shared": "true", "owner_team": "platform"},
+        )
+        assert meta.properties == {"shared": "true", "owner_team": "platform"}
+        # Default ``shared`` is still False — ``properties["shared"]`` is
+        # plain data and does NOT influence the typed root field.
+        assert meta.shared is False
+
+    def test_properties_rejects_non_string_value(self) -> None:
+        # ``dict[str, str]`` is enforced at the Pydantic layer.
+        with pytest.raises(ValidationError):
+            NamespaceMeta.model_validate(
+                {"name": "x", "properties": {"k": 42}},
+                strict=True,
+            )

--- a/tests/v2/test_resolver_cross_ns.py
+++ b/tests/v2/test_resolver_cross_ns.py
@@ -1,9 +1,9 @@
 """Tests for ``akgentic.catalog.resolver.load_model_type`` and the cross-ns shared-flag gate.
 
-The cross-namespace tests in this file pin ADR-008 §D2 (updated 2026-05-08)
-— canonical ``__namespace__`` sentinel + ``<ns>.<id>`` shorthand parsing,
-shared-flag gate (target namespace's ``_meta`` carries
-``properties["shared"] == "true"``), ownership gate, cycle detection across
+The cross-namespace tests in this file pin ADR-008 §D2 (updated 2026-05-08
+rev 2) — canonical ``__namespace__`` sentinel + ``<ns>.<id>`` shorthand
+parsing, shared-flag gate (target namespace's ``_meta`` carries
+``payload["shared"] is True``), ownership gate, cycle detection across
 namespaces, and the ``populate_refs`` ``is_namespace_shared`` keyword.
 """
 

--- a/tests/v2/test_resolver_cross_ns.py
+++ b/tests/v2/test_resolver_cross_ns.py
@@ -1,10 +1,10 @@
-"""Tests for ``akgentic.catalog.resolver.load_model_type`` and the cross-ns shared-flag gate.
+"""Tests for ``akgentic.catalog.resolver.load_model_type`` and the cross-ns shareable-flag gate.
 
 The cross-namespace tests in this file pin ADR-008 §D2 (updated 2026-05-08
 rev 2) — canonical ``__namespace__`` sentinel + ``<ns>.<id>`` shorthand
-parsing, shared-flag gate (target namespace's ``_meta`` carries
-``payload["shared"] is True``), ownership gate, cycle detection across
-namespaces, and the ``populate_refs`` ``is_namespace_shared`` keyword.
+parsing, shareable-flag gate (target namespace's ``_meta`` carries
+``payload["shareable"] is True``), ownership gate, cycle detection across
+namespaces, and the ``populate_refs`` ``is_namespace_shareable`` keyword.
 """
 
 from __future__ import annotations
@@ -44,8 +44,8 @@ def _model_with_reserved_field(reserved_name: str) -> type[BaseModel]:
     return _Host
 
 
-def _shared_set(*namespaces: str) -> Callable[[str], bool]:
-    """Return an ``is_namespace_shared`` callable accepting any of ``namespaces``."""
+def _shareable_set(*namespaces: str) -> Callable[[str], bool]:
+    """Return an ``is_namespace_shareable`` callable accepting any of ``namespaces``."""
     allowed = set(namespaces)
 
     def _check(ns: str) -> bool:
@@ -194,8 +194,8 @@ class TestCrossNamespaceShorthandParsing:
     """Story 17.3 / AC3 — ``__ref__`` value with ``.`` is split on the FIRST dot.
 
     Preserved verbatim from Story 17.3 — the parsing rules are unchanged
-    by the shared-flag migration. Only the gate name + assertion substring
-    move from ``"is not in the allowlist"`` to ``"is not shared"``.
+    by the shareable-flag migration. Only the gate name + assertion substring
+    move from ``"is not in the allowlist"`` to ``"is not shareable"``.
     """
 
     def test_single_dot_parses_ns_then_id(self, coord_module: str) -> None:
@@ -212,7 +212,7 @@ class TestCrossNamespaceShorthandParsing:
             {"__ref__": "global.prompt"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "hi"
@@ -231,13 +231,13 @@ class TestCrossNamespaceShorthandParsing:
             {"__ref__": "global.x.y.z"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "compound"
 
     def test_no_dot_is_same_namespace(self, coord_module: str) -> None:
-        """No dot ⇒ same-namespace ref, shared-flag gate not consulted."""
+        """No dot ⇒ same-namespace ref, shareable-flag gate not consulted."""
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -247,7 +247,7 @@ class TestCrossNamespaceShorthandParsing:
                 payload={"text": "local"},
             )
         )
-        # No is_namespace_shared callable — same-ns refs work unconditionally.
+        # No is_namespace_shareable callable — same-ns refs work unconditionally.
         result = populate_refs({"__ref__": "local-prompt"}, repo, "tenant-A")
         assert isinstance(result, _Coord)
         assert result.text == "local"
@@ -256,17 +256,17 @@ class TestCrossNamespaceShorthandParsing:
         self,
         coord_module: str,  # noqa: ARG002
     ) -> None:
-        """``"."<id>"`` ⇒ namespace="" — gated by the shared-flag check."""
+        """``"."<id>"`` ⇒ namespace="" — gated by the shareable-flag check."""
         repo = FakeEntryRepository()
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": ".foo"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=_shared_set("global"),
+                is_namespace_shareable=_shareable_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not shared" in msg
+        assert "is not shareable" in msg
 
 
 class TestExplicitAndShorthandAgreement:
@@ -289,7 +289,7 @@ class TestExplicitAndShorthandAgreement:
             {"__ref__": "global.x", "__namespace__": "global"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
 
@@ -300,7 +300,7 @@ class TestExplicitAndShorthandAgreement:
                 {"__ref__": "A.x", "__namespace__": "B"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=_shared_set("A", "B"),
+                is_namespace_shareable=_shareable_set("A", "B"),
             )
         msg = exc_info.value.errors[0]
         assert "shorthand 'ns.id' and explicit __namespace__" in msg
@@ -322,14 +322,14 @@ class TestExplicitAndShorthandAgreement:
             {"__ref__": "bare-id", "__namespace__": "global"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "verbatim"
 
 
 class TestPopulateRefsKwarg:
-    """``populate_refs`` accepts the ``is_namespace_shared`` keyword argument."""
+    """``populate_refs`` accepts the ``is_namespace_shareable`` keyword argument."""
 
     def test_default_no_kwarg_same_ns(self, coord_module: str) -> None:
         """No kwarg passed ⇒ same-ns refs work, no behaviour change."""
@@ -346,37 +346,37 @@ class TestPopulateRefsKwarg:
         assert isinstance(result, _Coord)
 
 
-class TestCrossNamespaceSharedFlagGate:
-    """Story 17.4 — shared-flag gate fires before repository lookup."""
+class TestCrossNamespaceShareableFlagGate:
+    """Story 17.4 — shareable-flag gate fires before repository lookup."""
 
-    def test_no_shared_callable_rejects_cross_ns(self) -> None:
+    def test_no_shareable_callable_rejects_cross_ns(self) -> None:
         repo = FakeEntryRepository()
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "global.x"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=None,
+                is_namespace_shareable=None,
             )
         msg = exc_info.value.errors[0]
-        assert "is not shared" in msg
+        assert "is not shareable" in msg
         assert "global.x" in msg
         assert "'global'" in msg
 
-    def test_namespace_not_shared_rejected(self) -> None:
+    def test_namespace_not_shareable_rejected(self) -> None:
         repo = FakeEntryRepository()
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "other-ns.x"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=_shared_set("global"),
+                is_namespace_shareable=_shareable_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not shared" in msg
+        assert "is not shareable" in msg
         assert "'other-ns'" in msg
 
-    def test_shared_namespace_resolves(self, coord_module: str) -> None:
+    def test_shareable_namespace_resolves(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -390,26 +390,26 @@ class TestCrossNamespaceSharedFlagGate:
             {"__ref__": "global.p"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
         assert result.text == "shared"
 
     def test_gate_fires_before_repo_lookup(self) -> None:
-        """Denied cross-ns ref raises shared-flag error even if target id is missing."""
+        """Denied cross-ns ref raises shareable-flag error even if target id is missing."""
         repo = FakeEntryRepository()  # empty repo — no global.does-not-exist
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {"__ref__": "global.does-not-exist"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=None,
+                is_namespace_shareable=None,
             )
-        # The "is not shared" message wins; "not found" is never reached.
-        assert "is not shared" in exc_info.value.errors[0]
+        # The "is not shareable" message wins; "not found" is never reached.
+        assert "is not shareable" in exc_info.value.errors[0]
 
-    def test_same_ns_unaffected_by_no_shared_callable(self, coord_module: str) -> None:
-        """A same-namespace ref resolves regardless of the shared-flag callable."""
+    def test_same_ns_unaffected_by_no_shareable_callable(self, coord_module: str) -> None:
+        """A same-namespace ref resolves regardless of the shareable-flag callable."""
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -423,7 +423,7 @@ class TestCrossNamespaceSharedFlagGate:
             {"__ref__": "p"},
             repo,
             "tenant-A",
-            is_namespace_shared=None,
+            is_namespace_shareable=None,
         )
         assert isinstance(result, _Coord)
 
@@ -447,7 +447,7 @@ class TestCrossNamespaceOwnershipGate:
                 {"__ref__": "global.user-p"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=_shared_set("global"),
+                is_namespace_shareable=_shareable_set("global"),
             )
         msg = exc_info.value.errors[0]
         assert "only globally-scoped entries (user_id=None)" in msg
@@ -468,7 +468,7 @@ class TestCrossNamespaceOwnershipGate:
             {"__ref__": "global.global-p"},
             repo,
             "tenant-A",
-            is_namespace_shared=_shared_set("global"),
+            is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
 
@@ -482,7 +482,7 @@ class _RefHolder(BaseModel):
 class TestCrossNamespaceCycleDetection:
     """Story 17.3 / AC11 — 3-hop cross-ns cycle reuses the existing message.
 
-    Preserved verbatim — cycle detection is unchanged by the shared-flag
+    Preserved verbatim — cycle detection is unchanged by the shareable-flag
     migration.
     """
 
@@ -517,6 +517,6 @@ class TestCrossNamespaceCycleDetection:
                 {"__ref__": "x"},
                 repo,
                 "tenant-A",
-                is_namespace_shared=_shared_set("tenant-A", "global"),
+                is_namespace_shareable=_shareable_set("tenant-A", "global"),
             )
         assert "Reference cycle detected" in exc_info.value.errors[0]

--- a/tests/v2/test_resolver_sibling_overrides.py
+++ b/tests/v2/test_resolver_sibling_overrides.py
@@ -592,7 +592,7 @@ class TestCrossNamespaceSiblingOverrides:
     """Story 17.4 — overrides on a cross-ns ref merge in the target's namespace."""
 
     @staticmethod
-    def _shared_set(*namespaces: str) -> Callable[[str], bool]:
+    def _shareable_set(*namespaces: str) -> Callable[[str], bool]:
         allowed = set(namespaces)
 
         def _check(ns: str) -> bool:
@@ -620,7 +620,7 @@ class TestCrossNamespaceSiblingOverrides:
             {"__ref__": "global.shared-prompt", "role": "Manager"},
             repo,
             "tenant-A",
-            is_namespace_shared=self._shared_set("global"),
+            is_namespace_shareable=self._shareable_set("global"),
         )
         assert isinstance(result, Anything)
         dumped = result.model_dump()
@@ -629,7 +629,7 @@ class TestCrossNamespaceSiblingOverrides:
         # Target's other field preserved.
         assert dumped["tone"] == "calm"
 
-    def test_nested_cross_ns_ref_in_override_gated_by_shared_flag(
+    def test_nested_cross_ns_ref_in_override_gated_by_shareable_flag(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A nested cross-ns ref inside an override value is gated."""
@@ -648,7 +648,7 @@ class TestCrossNamespaceSiblingOverrides:
                 payload={"x": 1},
             )
         )
-        # The override's nested ref points at a non-shared namespace.
+        # The override's nested ref points at a non-shareable namespace.
         with pytest.raises(CatalogValidationError) as exc_info:
             populate_refs(
                 {
@@ -657,8 +657,8 @@ class TestCrossNamespaceSiblingOverrides:
                 },
                 repo,
                 "tenant-A",
-                is_namespace_shared=self._shared_set("global"),
+                is_namespace_shareable=self._shareable_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "is not shared" in msg
+        assert "is not shareable" in msg
         assert "other-ns.x" in msg

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -513,12 +513,16 @@ class TestMetaEmitOrderAndRoundTrip:
 class TestDumpWithHeader:
     """``dump_namespace`` extended signature — header projection."""
 
-    def test_header_emits_six_top_level_keys_in_order(self) -> None:
+    def test_header_emits_seven_top_level_keys_in_order(self) -> None:
+        # Story 17.7 / AC8 — header now includes ``shared`` between
+        # ``properties`` and ``entries``. ``properties`` is fully free-form
+        # ``str -> str`` with NO catalog-reserved keys (AC2).
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant A",
             description="primary",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
+            shared=True,
         )
         doc = yaml.safe_load(text)
         assert list(doc.keys()) == [
@@ -527,11 +531,57 @@ class TestDumpWithHeader:
             "name",
             "description",
             "properties",
+            "shared",
             "entries",
         ]
         assert doc["name"] == "Tenant A"
         assert doc["description"] == "primary"
-        assert doc["properties"] == {"shared": "true"}
+        assert doc["properties"] == {"owner_team": "platform"}
+        assert doc["shared"] is True
+
+    def test_default_shared_false_emits_shared_in_header(self) -> None:
+        # Story 17.7 / AC8 — when a header is forced (here by ``name``),
+        # ``shared`` is emitted at its declaration position with the
+        # default value ``False``.
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+        )
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "shared",
+            "entries",
+        ]
+        assert doc["shared"] is False
+
+    def test_shared_true_alone_forces_header(self) -> None:
+        # AC8 — ``shared=True`` widens the ``has_header`` branch even when
+        # ``name`` / ``description`` / ``properties`` / ``external_refs`` are
+        # all empty. A shared namespace is structurally meaningful and must
+        # surface in the wire shape.
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            shared=True,
+        )
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "shared",
+            "entries",
+        ]
+        assert doc["shared"] is True
+        assert doc["name"] == ""
+        assert doc["description"] == ""
+        assert doc["properties"] == {}
 
     def test_no_header_emits_three_keys(self) -> None:
         """Pre-17.5 callers (no kwargs) get the three-key shape verbatim."""
@@ -642,23 +692,27 @@ class TestDumpExternalSections:
 
 
 class TestLoadHeaderProjection:
-    def test_header_present_when_all_three_set(self) -> None:
+    def test_header_present_when_all_four_set(self) -> None:
+        # Story 17.7 — `shared` joins the projected fields.
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant A",
             description="primary",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
+            shared=True,
         )
         _entries, header = load_namespace(text)
         assert header.present is True
         assert header.name == "Tenant A"
         assert header.description == "primary"
-        assert header.properties == {"shared": "true"}
+        assert header.properties == {"owner_team": "platform"}
+        assert header.shared is True
 
     def test_header_absent_for_pre_175_bundle(self) -> None:
         text = dump_namespace([_team(), _agent("a")])
         _entries, header = load_namespace(text)
         assert header.present is False
+        assert header.shared is False
 
     def test_header_present_when_only_name_set(self) -> None:
         """A bundle carrying just `name` (auto-fills the rest) is still a 17.6 bundle."""
@@ -666,6 +720,63 @@ class TestLoadHeaderProjection:
         _entries, header = load_namespace(text)
         assert header.present is True
         assert header.name == "Tenant A"
+        # Default ``shared`` flag.
+        assert header.shared is False
+
+    def test_header_present_when_only_shared_set(self) -> None:
+        """Story 17.7 — ``shared=True`` alone forces ``present=True``."""
+        text = dump_namespace([_team(), _agent("a")], shared=True)
+        _entries, header = load_namespace(text)
+        assert header.present is True
+        assert header.shared is True
+
+    def test_legacy_bundle_without_shared_projects_false(self) -> None:
+        """Story 17.7 / AC9 — pre-17.7 bundles (six top-level keys, no ``shared``)
+        parse identically; ``shared`` defaults to ``False``.
+        """
+        # Hand-craft the legacy six-key shape (no `shared` field).
+        legacy_yaml = (
+            "namespace: ns-1\n"
+            "user_id: null\n"
+            "name: Old Tenant\n"
+            "description: legacy\n"
+            "properties:\n"
+            "  owner_team: platform\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            "      name: T\n"
+        )
+        _entries, header = load_namespace(legacy_yaml)
+        assert header.present is True
+        assert header.name == "Old Tenant"
+        assert header.shared is False
+
+    def test_non_bool_shared_value_projects_false(self) -> None:
+        """Defensive parsing — a non-bool ``shared`` value projects to False."""
+        legacy_yaml = (
+            "namespace: ns-1\n"
+            "user_id: null\n"
+            "name: Old Tenant\n"
+            "shared: 'true'\n"  # string, not bool
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            "      name: T\n"
+        )
+        _entries, header = load_namespace(legacy_yaml)
+        assert header.present is True
+        assert header.shared is False
 
 
 # --- Story 17.6 — round-trip with the new shape -----------------------------
@@ -675,19 +786,22 @@ class TestRoundTripNewShape:
     """Two consecutive dumps of the same input produce byte-identical output."""
 
     def test_byte_identical_two_consecutive_dumps(self) -> None:
+        # Story 17.7 — `properties` is fully free-form `str -> str`.
         external = [_model("id_gpt_41", namespace="global", user_id=None)]
         text_a = dump_namespace(
             [_team(), _agent("a"), _prompt("p1")],
             name="Tenant",
             description="primary",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
+            shared=True,
             external_refs=external,
         )
         text_b = dump_namespace(
             [_team(), _agent("a"), _prompt("p1")],
             name="Tenant",
             description="primary",
-            properties={"shared": "true"},
+            properties={"owner_team": "platform"},
+            shared=True,
             external_refs=external,
         )
         assert text_a == text_b

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -514,7 +514,7 @@ class TestDumpWithHeader:
     """``dump_namespace`` extended signature — header projection."""
 
     def test_header_emits_seven_top_level_keys_in_order(self) -> None:
-        # Story 17.7 / AC8 — header now includes ``shared`` between
+        # Story 17.7 / AC8 — header now includes ``shareable`` between
         # ``properties`` and ``entries``. ``properties`` is fully free-form
         # ``str -> str`` with NO catalog-reserved keys (AC2).
         text = dump_namespace(
@@ -522,7 +522,7 @@ class TestDumpWithHeader:
             name="Tenant A",
             description="primary",
             properties={"owner_team": "platform"},
-            shared=True,
+            shareable=True,
         )
         doc = yaml.safe_load(text)
         assert list(doc.keys()) == [
@@ -531,17 +531,17 @@ class TestDumpWithHeader:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
         assert doc["name"] == "Tenant A"
         assert doc["description"] == "primary"
         assert doc["properties"] == {"owner_team": "platform"}
-        assert doc["shared"] is True
+        assert doc["shareable"] is True
 
-    def test_default_shared_false_emits_shared_in_header(self) -> None:
+    def test_default_shareable_false_emits_shareable_in_header(self) -> None:
         # Story 17.7 / AC8 — when a header is forced (here by ``name``),
-        # ``shared`` is emitted at its declaration position with the
+        # ``shareable`` is emitted at its declaration position with the
         # default value ``False``.
         text = dump_namespace(
             [_team(), _agent("a")],
@@ -554,19 +554,19 @@ class TestDumpWithHeader:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
-        assert doc["shared"] is False
+        assert doc["shareable"] is False
 
-    def test_shared_true_alone_forces_header(self) -> None:
-        # AC8 — ``shared=True`` widens the ``has_header`` branch even when
+    def test_shareable_true_alone_forces_header(self) -> None:
+        # AC8 — ``shareable=True`` widens the ``has_header`` branch even when
         # ``name`` / ``description`` / ``properties`` / ``external_refs`` are
-        # all empty. A shared namespace is structurally meaningful and must
+        # all empty. A shareable namespace is structurally meaningful and must
         # surface in the wire shape.
         text = dump_namespace(
             [_team(), _agent("a")],
-            shared=True,
+            shareable=True,
         )
         doc = yaml.safe_load(text)
         assert list(doc.keys()) == [
@@ -575,10 +575,10 @@ class TestDumpWithHeader:
             "name",
             "description",
             "properties",
-            "shared",
+            "shareable",
             "entries",
         ]
-        assert doc["shared"] is True
+        assert doc["shareable"] is True
         assert doc["name"] == ""
         assert doc["description"] == ""
         assert doc["properties"] == {}
@@ -693,26 +693,26 @@ class TestDumpExternalSections:
 
 class TestLoadHeaderProjection:
     def test_header_present_when_all_four_set(self) -> None:
-        # Story 17.7 — `shared` joins the projected fields.
+        # Story 17.7 — `shareable` joins the projected fields.
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant A",
             description="primary",
             properties={"owner_team": "platform"},
-            shared=True,
+            shareable=True,
         )
         _entries, header = load_namespace(text)
         assert header.present is True
         assert header.name == "Tenant A"
         assert header.description == "primary"
         assert header.properties == {"owner_team": "platform"}
-        assert header.shared is True
+        assert header.shareable is True
 
     def test_header_absent_for_pre_175_bundle(self) -> None:
         text = dump_namespace([_team(), _agent("a")])
         _entries, header = load_namespace(text)
         assert header.present is False
-        assert header.shared is False
+        assert header.shareable is False
 
     def test_header_present_when_only_name_set(self) -> None:
         """A bundle carrying just `name` (auto-fills the rest) is still a 17.6 bundle."""
@@ -720,21 +720,21 @@ class TestLoadHeaderProjection:
         _entries, header = load_namespace(text)
         assert header.present is True
         assert header.name == "Tenant A"
-        # Default ``shared`` flag.
-        assert header.shared is False
+        # Default ``shareable`` flag.
+        assert header.shareable is False
 
-    def test_header_present_when_only_shared_set(self) -> None:
-        """Story 17.7 — ``shared=True`` alone forces ``present=True``."""
-        text = dump_namespace([_team(), _agent("a")], shared=True)
+    def test_header_present_when_only_shareable_set(self) -> None:
+        """Story 17.7 — ``shareable=True`` alone forces ``present=True``."""
+        text = dump_namespace([_team(), _agent("a")], shareable=True)
         _entries, header = load_namespace(text)
         assert header.present is True
-        assert header.shared is True
+        assert header.shareable is True
 
-    def test_legacy_bundle_without_shared_projects_false(self) -> None:
-        """Story 17.7 / AC9 — pre-17.7 bundles (six top-level keys, no ``shared``)
-        parse identically; ``shared`` defaults to ``False``.
+    def test_legacy_bundle_without_shareable_projects_false(self) -> None:
+        """Story 17.7 / AC9 — pre-17.7 bundles (six top-level keys, no ``shareable``)
+        parse identically; ``shareable`` defaults to ``False``.
         """
-        # Hand-craft the legacy six-key shape (no `shared` field).
+        # Hand-craft the legacy six-key shape (no `shareable` field).
         legacy_yaml = (
             "namespace: ns-1\n"
             "user_id: null\n"
@@ -755,15 +755,15 @@ class TestLoadHeaderProjection:
         _entries, header = load_namespace(legacy_yaml)
         assert header.present is True
         assert header.name == "Old Tenant"
-        assert header.shared is False
+        assert header.shareable is False
 
-    def test_non_bool_shared_value_projects_false(self) -> None:
-        """Defensive parsing — a non-bool ``shared`` value projects to False."""
+    def test_non_bool_shareable_value_projects_false(self) -> None:
+        """Defensive parsing — a non-bool ``shareable`` value projects to False."""
         legacy_yaml = (
             "namespace: ns-1\n"
             "user_id: null\n"
             "name: Old Tenant\n"
-            "shared: 'true'\n"  # string, not bool
+            "shareable: 'true'\n"  # string, not bool
             "entries:\n"
             "  team:\n"
             "    kind: team\n"
@@ -776,7 +776,7 @@ class TestLoadHeaderProjection:
         )
         _entries, header = load_namespace(legacy_yaml)
         assert header.present is True
-        assert header.shared is False
+        assert header.shareable is False
 
 
 # --- Story 17.6 — round-trip with the new shape -----------------------------
@@ -793,7 +793,7 @@ class TestRoundTripNewShape:
             name="Tenant",
             description="primary",
             properties={"owner_team": "platform"},
-            shared=True,
+            shareable=True,
             external_refs=external,
         )
         text_b = dump_namespace(
@@ -801,7 +801,7 @@ class TestRoundTripNewShape:
             name="Tenant",
             description="primary",
             properties={"owner_team": "platform"},
-            shared=True,
+            shareable=True,
             external_refs=external,
         )
         assert text_a == text_b


### PR DESCRIPTION
## Summary

Story 17.7 — promote `shared` to a typed-bool root field on `NamespaceMeta` and widen `GET /catalog/namespaces` to surface team-less namespaces with `team: bool` / `shared: bool` flags.

Two coupled design corrections after Stories 17.4 / 17.6:

- `NamespaceMeta.shared` is now a typed `bool` root field (default `False`) — replacing the string-coerced reserved key inside `properties`. The resolver gate, route projection, and export header all read `meta.payload.get("shared") is True` (strict-bool — no truthy-string coercion). `properties` reverts to a fully free-form `str -> str` map with NO catalog-reserved keys.
- `GET /catalog/namespaces` issues a union of `EntryQuery(kind="team")` + `EntryQuery(kind="meta")` round-trips, projects each row from the optional team and meta entries already in memory (no per-row `catalog.get(ns, "_meta")`), and now surfaces team-less library namespaces (e.g. a platform-defined `global` carrying shared models / tools / prompts).
- `NamespaceSummary` carries five pinned fields: `namespace`, `name`, `description`, `team: bool`, `shared: bool`.
- Bundle export header gains `shared:` at the top level (between `properties:` and `entries:`) — seven top-level keys total. `BundleHeader.shared` projects from new bundles; legacy bundles default to `False`. The `_meta.payload["shared"]` flows from the bundle header on import.
- Strict cutover, NOT read-time fallback. Legacy meta entries with `payload["properties"]["shared"] == "true"` (no `payload["shared"]`) are treated as `shared=False`. Operators re-emit each shared namespace's meta entry once via `PUT /catalog/namespace/{ns}/meta`.

Closes #170

## Implementation notes

- 7 source files changed (`models/namespace_meta.py`, `catalog.py`, `resolver.py`, `api/router.py`, `serialization.py` plus stale-docstring refresh in `repositories/base.py` + `api/app.py`).
- 8 test files updated, 1 added (`test_namespace_meta.py`).
- Counting-spy regression guard pins exactly 2 repository round-trips for N=3 namespaces (vs. the per-row `2 + N` shape that the previous handler produced).
- Strict-cutover behaviour pinned: legacy `payload["properties"]["shared"] = "true"` is plain string data and does NOT influence the resolver gate, the route projection, or the export header.
- ADR-008 §D2 carries an in-place "Updated 2026-05-08 (rev 2)" amendment citing this story (in the parent repo's `_bmad-output/`, not in this PR).

## Quality gates

- `ruff check` + `ruff format --check`: clean.
- `mypy --strict`: clean (29 source files).
- `pytest packages/akgentic-catalog/tests/`: 942 passed, 23 skipped (no test failures, no skips introduced by this story).
- Coverage: 91.25% (>= 80% threshold).
- Single-submodule scope: every diff lands inside `packages/akgentic-catalog/` (CLAUDE.md Golden Rule #4).
- No `dict[str, Any]` smuggling — `shared` is a typed Pydantic field (Golden Rule #1).
- No ADR-NNN test assertions (Golden Rule #8).

## Code review (Rex)

Adversarial review found 5 stale-docstring references (MEDIUM severity, no behavioral impact) where Stories 17.4 / 17.6 wording (`properties["shared"] == "true"`) survived in module-level comments and docstrings. All five fixed in `fcf120c`:

- `resolver.py` — `IsNamespaceSharedFn` type alias comment, `NAMESPACE_KEY` sentinel doc, `populate_refs` parameter docstring.
- `catalog.py::_invalidate_shared_flag_cache` docstring.
- `repositories/base.py::find_references_global` docstring.
- `api/app.py::create_app` docstring.

Architecture doc `07-api.md:127` was also stale but lives in the parent repo (`_bmad-output/`) — fixed there in the workspace working tree.
