### PR TITLE
Bootstrap and ownership invariants accept team OR meta (story 17.10)

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -331,8 +331,15 @@ async def put_namespace_meta(namespace: str, request: Request) -> Response:
     ``model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta"``;
     the body's ``NamespaceMeta`` shape does NOT declare those fields, so a
     JSON/YAML payload that accidentally carries them is simply not parsed.
-    The team's ``user_id`` is propagated from the namespace's team entry
-    (ownership invariant).
+
+    Three-rung ``user_id`` derivation chain:
+
+    1. If a team entry exists in the namespace, use ``team.user_id``.
+    2. Else if an existing ``_meta`` entry exists (update path), use its
+       ``user_id``.
+    3. Else (no team, no existing meta — first meta create in a fresh
+       namespace) use ``"anonymous"`` as the ``user_id`` (community-tier
+       convention).
 
     Dispatches to ``Catalog.create`` when no ``_meta`` entry exists (HTTP
     201) or to ``Catalog.update`` otherwise (HTTP 200). Returns the stored
@@ -341,28 +348,32 @@ async def put_namespace_meta(namespace: str, request: Request) -> Response:
     meta = await _parse_body_as(request, NamespaceMeta)
     logger.debug("PUT /catalog/namespace/%s/meta", namespace)
     catalog = _get_catalog()
+
+    # Three-rung user_id derivation: team -> existing meta -> "anonymous"
     teams = catalog.list(EntryQuery(kind="team", namespace=namespace))
-    if not teams:
-        # Lift the bootstrap message up so the 409 surface matches Catalog.create.
-        raise CatalogValidationError(
-            [
-                f"Namespace '{namespace}' has no team entry — create the team "
-                f"entry first (bootstrap invariant)"
-            ]
-        )
-    team = teams[0]
+    existing_meta: Entry | None = None
+    try:
+        existing_meta = catalog.get(namespace, "_meta")
+    except EntryNotFoundError:
+        pass
+
+    if teams:
+        user_id: str | None = teams[0].user_id
+    elif existing_meta is not None:
+        user_id = existing_meta.user_id
+    else:
+        user_id = "anonymous"
+
     entry = Entry(
         id="_meta",
         kind="meta",
         namespace=namespace,
-        user_id=team.user_id,
+        user_id=user_id,
         model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
         description=meta.description,
         payload=meta.model_dump(mode="json"),
     )
-    try:
-        catalog.get(namespace, "_meta")
-    except EntryNotFoundError:
+    if existing_meta is None:
         created = catalog.create(entry)
         return Response(
             content=created.model_dump_json(),

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -775,8 +775,9 @@ class Catalog:
             namespace: The bundle's namespace (already pinned by uniform-
                 namespace invariant on the prepared entries).
             prepared: The prepared bundle entries; consulted to inherit the
-                ``user_id`` from the team entry so the meta entry's
-                ownership matches the rest of the namespace.
+                ``user_id`` from the team entry (preferred) or from the
+                first entry when no team is present (meta-only bundle) so
+                the meta entry's ownership stays consistent with the bundle.
             header: The :class:`BundleHeader` projected by ``load_namespace``.
 
         Returns:
@@ -787,7 +788,15 @@ class Catalog:
                 ``NamespaceMeta`` payload (e.g. empty name).
         """
         team_entry = next((e for e in prepared if e.kind == "team"), None)
-        user_id = team_entry.user_id if team_entry is not None else None
+        if team_entry is not None:
+            user_id = team_entry.user_id
+        elif prepared:
+            # Meta-only bundle: inherit user_id from the first entry so the
+            # upserted meta entry stays ownership-consistent with the bundle
+            # contents (Story 17.10).
+            user_id = prepared[0].user_id
+        else:
+            user_id = None
         try:
             meta_payload = NamespaceMeta(
                 name=header.name,

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -12,8 +12,8 @@ The v1 ``services/`` directory (home of ``TemplateCatalog``, ``ToolCatalog``,
 
 Invariants enforced by the service (not the repository):
 
-* **Namespace bootstrap** — non-team entries in a namespace require a pre-existing
-  team entry in the same namespace (``_check_bootstrap``).
+* **Namespace initialization** — non-team, non-meta entries in a namespace require
+  a pre-existing team OR meta entry (``_check_namespace_initialized``).
 * **Ownership** — sub-entries' ``user_id`` MUST equal the team entry's
   ``user_id`` (``_check_ownership``).
 * **Namespace minting** — a team entry whose ``namespace`` equals the sentinel
@@ -170,9 +170,9 @@ class Catalog:
            ``CatalogValidationError`` if ``(namespace, id)`` already exists.
         3. Reject a second ``kind="meta"`` entry in the same namespace via
            ``_check_meta_singleton`` (ADR-008 §D1). Skipped for ``kind!="meta"``.
-        4. Non-team entries: run ``_check_bootstrap`` then ``_check_ownership``.
-           Team entries skip both (a team entry IS the bootstrap; it is the
-           ``user_id`` authority for its own namespace).
+        4. Non-team, non-meta entries: run ``_check_namespace_initialized`` then
+           ``_check_ownership``. Team and meta entries skip both (they ARE anchor
+           entries that bootstrap the namespace).
         5. Run ``prepare_for_write`` — ref resolution, class load, Pydantic
            validation, dump, reconcile. ``CatalogValidationError`` propagates
            unchanged.
@@ -197,8 +197,8 @@ class Catalog:
         self._check_duplicate(entry.namespace, entry.id)
         self._check_meta_singleton(entry)
 
-        if entry.kind != "team":
-            self._check_bootstrap(entry.namespace)
+        if entry.kind not in ("team", "meta"):
+            self._check_namespace_initialized(entry.namespace)
             self._check_ownership(entry)
 
         prepared = prepare_for_write(
@@ -734,7 +734,7 @@ class Catalog:
             )
             for e in parsed
         ]
-        self._validate_bundle_invariants(prepared)
+        self._validate_bundle_invariants(prepared, has_header_meta=header.present)
         self._check_bundle_refs(prepared)
         namespace = prepared[0].namespace
         ordered = self._order_bundle_for_put(prepared)
@@ -885,51 +885,89 @@ class Catalog:
 
     # --- Private helpers ------------------------------------------------------
 
-    def _validate_bundle_invariants(self, prepared: _list[Entry]) -> None:
-        """Enforce exactly-one-team, uniform user_id, uniform namespace on a parsed bundle.
+    def _validate_bundle_invariants(
+        self,
+        prepared: _list[Entry],
+        *,
+        has_header_meta: bool = False,
+    ) -> None:
+        """Enforce anchor presence, uniform user_id, uniform namespace on a parsed bundle.
 
         Runs after ``prepare_for_write`` so validator-normalised fields are
         honoured. Collects every violation into a single
         ``CatalogValidationError`` so the UI can surface them in one pass.
+
+        Args:
+            prepared: The prepared bundle entries.
+            has_header_meta: ``True`` when the bundle carries a header with
+                ``present=True`` — the meta entry is hoisted to the header
+                and will be upserted separately, so it counts as an anchor
+                even though it is not in ``prepared``.
         """
         errors: list[str] = []
         team_entries = [e for e in prepared if e.kind == "team"]
-        if len(team_entries) == 0:
-            errors.append("bundle has no team entry — exactly one `kind=team` entry is required")
-        elif len(team_entries) > 1:
+        meta_entries = [e for e in prepared if e.kind == "meta"]
+        effective_has_meta = len(meta_entries) > 0 or has_header_meta
+
+        if len(team_entries) == 0 and not effective_has_meta:
+            errors.append(
+                "bundle has no team entry and no meta entry "
+                "— at least one anchor (team or meta) is required"
+            )
+        if len(team_entries) > 1:
             ids = sorted(e.id for e in team_entries)
             errors.append(
                 f"bundle has multiple team entries: {ids} — exactly one `kind=team` entry "
                 f"is required"
             )
 
-        meta_entries = [e for e in prepared if e.kind == "meta"]
         if len(meta_entries) > 1:
             meta_ids = sorted(e.id for e in meta_entries)
-            # ADR-008 §D1 — at most one kind=meta entry per namespace.
-            # Use the same shape as ``validation._check_meta_singleton`` so test
-            # assertions stay grep-stable across the bundle and persisted paths.
             namespace_for_msg = prepared[0].namespace if prepared else ""
             errors.append(
                 f"namespace '{namespace_for_msg}' has multiple meta entries: {meta_ids} — "
                 f"exactly one kind=meta entry is allowed per namespace"
             )
 
+        # Anchor resolution for user_id uniformity: team preferred, meta fallback.
+        # When the bundle has a header meta (has_header_meta=True) but no
+        # team/meta entry in prepared, the anchor is the header meta whose
+        # user_id is derived from the first entry — skip explicit ownership
+        # checks and just verify namespace uniformity.
+        anchor_entry: Entry | None = None
+        anchor_kind = ""
         if team_entries:
-            expected_user = team_entries[0].user_id
-            expected_ns = team_entries[0].namespace
+            anchor_entry = team_entries[0]
+            anchor_kind = "team"
+        elif meta_entries:
+            anchor_entry = meta_entries[0]
+            anchor_kind = "meta"
+
+        if anchor_entry is not None:
+            expected_user = anchor_entry.user_id
+            expected_ns = anchor_entry.namespace
             for e in prepared:
+                if e.kind in ("team", "meta"):
+                    continue
                 if e.user_id != expected_user:
                     errors.append(
                         f"Ownership mismatch in namespace '{expected_ns}': "
                         f"entry '{e.id}' has user_id={e.user_id!r} but "
-                        f"team has user_id={expected_user!r}"
+                        f"anchor ({anchor_kind}) has user_id={expected_user!r}"
                     )
                 if e.namespace != expected_ns:
                     errors.append(
                         f"entry '{e.id}' has namespace={e.namespace!r} but bundle "
                         f"namespace is {expected_ns!r}"
                     )
+            # Also check namespace uniformity for the anchors themselves.
+            for e in prepared:
+                if e.kind in ("team", "meta") and e is not anchor_entry:
+                    if e.namespace != expected_ns:
+                        errors.append(
+                            f"entry '{e.id}' has namespace={e.namespace!r} but bundle "
+                            f"namespace is {expected_ns!r}"
+                        )
         if errors:
             raise CatalogValidationError(errors)
 
@@ -1048,13 +1086,15 @@ class Catalog:
                 ]
             )
 
-    def _check_bootstrap(self, namespace: str) -> None:
-        """Ensure a team entry exists in ``namespace``; raise otherwise."""
-        if self._repository.get_by_kind(namespace, "team") is None:
+    def _check_namespace_initialized(self, namespace: str) -> None:
+        """Ensure at least one anchor (team or meta) exists in ``namespace``; raise otherwise."""
+        team = self._repository.get_by_kind(namespace, "team")
+        meta = self._repository.get_by_kind(namespace, "meta")
+        if team is None and meta is None:
             raise CatalogValidationError(
                 [
-                    f"Namespace '{namespace}' has no team entry — create the team "
-                    f"entry first (bootstrap invariant)"
+                    f"Namespace '{namespace}' has no team entry and no meta entry "
+                    f"— create at least one anchor entry first (team OR meta)"
                 ]
             )
 
@@ -1162,24 +1202,29 @@ class Catalog:
             self._shareable_flag_cache.pop(entry.namespace, None)
 
     def _check_ownership(self, entry: Entry) -> None:
-        """Ensure ``entry.user_id == team_entry.user_id`` within ``entry.namespace``."""
+        """Ensure ``entry.user_id`` matches the namespace anchor (team, then meta fallback)."""
         team = self._repository.get_by_kind(entry.namespace, "team")
-        if team is None:
-            # Bootstrap already guards this for create(); update() uses the same
-            # helper, and an update to a non-team entry that left the team
-            # behind is a corrupted state — reject defensively.
-            raise CatalogValidationError(
-                [
-                    f"Namespace '{entry.namespace}' has no team entry — cannot "
-                    f"verify ownership for '{entry.id}'"
-                ]
-            )
-        if entry.user_id != team.user_id:
+        if team is not None:
+            anchor = team
+            anchor_kind = "team"
+        else:
+            meta = self._repository.get_by_kind(entry.namespace, "meta")
+            if meta is not None:
+                anchor = meta
+                anchor_kind = "meta"
+            else:
+                raise CatalogValidationError(
+                    [
+                        f"Namespace '{entry.namespace}' has no team entry and no "
+                        f"meta entry — cannot verify ownership for '{entry.id}'"
+                    ]
+                )
+        if entry.user_id != anchor.user_id:
             raise CatalogValidationError(
                 [
                     f"Ownership mismatch in namespace '{entry.namespace}': "
                     f"entry '{entry.id}' has user_id={entry.user_id!r} but "
-                    f"team has user_id={team.user_id!r}"
+                    f"anchor ({anchor_kind}) has user_id={anchor.user_id!r}"
                 ]
             )
 

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -205,9 +205,7 @@ def dump_namespace(
             entry's values.
     """
     if not entries:
-        raise CatalogValidationError(
-            ["bundle must declare at least one entry, including a `kind=team` entry"]
-        )
+        raise CatalogValidationError(["bundle must declare at least one entry"])
 
     errors: list[str] = []
     errors.extend(_check_uniform_owner(entries))
@@ -458,9 +456,7 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
 
     entries_map: dict[str, Any] = doc["entries"]
     if not entries_map:
-        raise CatalogValidationError(
-            ["bundle must declare at least one entry, including a `kind=team` entry"]
-        )
+        raise CatalogValidationError(["bundle must declare at least one entry"])
 
     namespace: str = doc["namespace"]
     user_id: str | None = doc["user_id"]
@@ -473,9 +469,7 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
         entries.append(_build_entry(entry_key, entry_map, namespace, user_id))
 
     if not entries:
-        raise CatalogValidationError(
-            ["bundle must declare at least one entry, including a `kind=team` entry"]
-        )
+        raise CatalogValidationError(["bundle must declare at least one entry"])
 
     return entries, header
 

--- a/src/akgentic/catalog/validation.py
+++ b/src/akgentic/catalog/validation.py
@@ -134,7 +134,7 @@ def validate_entries(
 def _global_checks(entries: list[Entry], namespace: str) -> list[str]:
     """Return every bundle-wide error for ``entries`` as a flat list."""
     errors: list[str] = []
-    errors.extend(_check_team_count(entries, namespace))
+    errors.extend(_check_namespace_anchor(entries, namespace))
     errors.extend(_check_meta_singleton(entries, namespace))
     errors.extend(_check_uniform_namespace(entries, namespace))
     errors.extend(_check_uniform_user_id(entries))
@@ -143,15 +143,20 @@ def _global_checks(entries: list[Entry], namespace: str) -> list[str]:
     return errors
 
 
-def _check_team_count(entries: list[Entry], namespace: str) -> list[str]:
-    """Require exactly one ``kind=team`` entry; surface too-many / too-few."""
+def _check_namespace_anchor(entries: list[Entry], namespace: str) -> list[str]:
+    """Require at least one anchor (team or meta); surface too-many teams."""
     teams = [e for e in entries if e.kind == "team"]
-    if len(teams) == 0:
-        return [f"namespace '{namespace}' has no team entry"]
+    metas = [e for e in entries if e.kind == "meta"]
+    errors: list[str] = []
+    if len(teams) == 0 and len(metas) == 0:
+        errors.append(
+            f"namespace '{namespace}' has no team entry and no meta entry "
+            f"— at least one anchor (team or meta) is required"
+        )
     if len(teams) > 1:
         ids = sorted(t.id for t in teams)
-        return [f"namespace '{namespace}' has multiple team entries: {ids}"]
-    return []
+        errors.append(f"namespace '{namespace}' has multiple team entries: {ids}")
+    return errors
 
 
 def _check_meta_singleton(entries: list[Entry], namespace: str) -> list[str]:
@@ -183,15 +188,27 @@ def _check_uniform_namespace(entries: list[Entry], namespace: str) -> list[str]:
 
 
 def _check_uniform_user_id(entries: list[Entry]) -> list[str]:
-    """Anchored-by-the-team ownership check; skipped when team count != 1."""
+    """Anchored-by-the-team (or meta fallback) ownership check.
+
+    Anchor resolution: if exactly one team, use team.user_id; else if exactly
+    one meta, use meta.user_id; else skip (ambiguous or absent anchor — the
+    absent case is caught by ``_check_namespace_anchor``).
+    """
     teams = [e for e in entries if e.kind == "team"]
-    if len(teams) != 1:
-        return []
-    team_user_id = teams[0].user_id
+    if len(teams) == 1:
+        anchor_user_id = teams[0].user_id
+        anchor_kind = "team"
+    else:
+        metas = [e for e in entries if e.kind == "meta"]
+        if len(teams) == 0 and len(metas) == 1:
+            anchor_user_id = metas[0].user_id
+            anchor_kind = "meta"
+        else:
+            return []
     return [
-        f"entry '{e.id}' user_id '{e.user_id}' != team user_id '{team_user_id}'"
+        f"entry '{e.id}' user_id '{e.user_id}' != {anchor_kind} user_id '{anchor_user_id}'"
         for e in entries
-        if e.kind != "team" and e.user_id != team_user_id
+        if e.kind not in ("team", "meta") and e.user_id != anchor_user_id
     ]
 
 

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -804,7 +804,7 @@ class TestNamespaceImport:
             content=_yaml.safe_dump(doc).encode("utf-8"),
         )
         assert response.status_code == 409
-        assert any("no team entry" in e for e in response.json()["errors"])
+        assert any("has no team entry and no meta entry" in e for e in response.json()["errors"])
 
     def test_import_dangling_ref_409(self, api_client: tuple[TestClient, Catalog]) -> None:
         import yaml as _yaml
@@ -1151,7 +1151,7 @@ class TestNamespaceValidatePost:
         assert response.status_code == 200
         body = response.json()
         assert body["ok"] is False
-        assert any("no team entry" in m for m in body["global_errors"])
+        assert any("has no team entry and no meta entry" in m for m in body["global_errors"])
 
     def test_service_vs_http_divergence_on_malformed_yaml(
         self, api_client: tuple[TestClient, Catalog]
@@ -1664,14 +1664,39 @@ class TestPutNamespaceMeta:
         response = client.put("/catalog/namespace/tenant-42/meta", json=body)
         assert response.status_code == 422
 
-    def test_no_team_entry_returns_409(self, api_client: tuple[TestClient, Catalog]) -> None:
-        """When the namespace has no team entry, the handler surfaces 409
-        with the bootstrap-error message.
+    def test_no_team_creates_meta_with_anonymous_user_id(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """When no team exists, PUT meta creates the first anchor entry with
+        user_id == "anonymous" (Story 17.10 — meta-only namespace bootstrap).
         """
         client, _ = api_client
         body = {"name": "ghost", "description": "", "properties": {}}
         response = client.put("/catalog/namespace/ghost-ns/meta", json=body)
-        assert response.status_code == 409
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["user_id"] == "anonymous"
+        assert entry["kind"] == "meta"
+        assert entry["namespace"] == "ghost-ns"
+
+    def test_no_team_update_preserves_user_id(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """Subsequent PUT (update) preserves the _meta.user_id from the first write."""
+        client, _ = api_client
+        body = {"name": "ghost", "description": "", "properties": {}}
+        response = client.put("/catalog/namespace/ghost-ns/meta", json=body)
+        assert response.status_code == 201
+        first_user_id = response.json()["user_id"]
+        assert first_user_id == "anonymous"
+
+        # Update the meta entry
+        body_update = {"name": "ghost-updated", "description": "updated", "properties": {}}
+        response2 = client.put("/catalog/namespace/ghost-ns/meta", json=body_update)
+        assert response2.status_code == 200
+        entry = response2.json()
+        assert entry["user_id"] == first_user_id
+        assert entry["payload"]["name"] == "ghost-updated"
 
 
 # --- Story 17.7 — union discovery (team + meta) for /catalog/namespaces ---

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -277,8 +277,106 @@ class TestCreateBootstrap:
         with pytest.raises(CatalogValidationError) as exc:
             catalog.create(agent)
         msg = str(exc.value)
-        assert "no team entry" in msg
+        assert "has no team entry and no meta entry" in msg
         assert "fresh-ns" in msg
+
+
+# --- Story 17.10 — create in meta-only namespace --------------------------------
+
+
+_NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _seed_meta(
+    catalog: Catalog,
+    namespace: str,
+    user_id: str | None = "anonymous",
+) -> Entry:
+    """Seed a meta entry in ``namespace`` and return the persisted entry."""
+    return catalog.create(
+        Entry(
+            id="_meta",
+            kind="meta",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_NAMESPACE_META_TYPE,
+            description="",
+            payload={"name": namespace, "description": "", "properties": {}, "shareable": False},
+        )
+    )
+
+
+class TestCreateInMetaOnlyNamespace:
+    """Story 17.10 — meta entry bootstraps a namespace; ownership anchors on meta."""
+
+    def test_create_meta_in_fresh_namespace_succeeds(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Create _meta in a fresh namespace — succeeds, user_id == "anonymous"."""
+        catalog, _ = catalog_factory()
+        meta = _seed_meta(catalog, "meta-only-ns", user_id="anonymous")
+        assert meta.kind == "meta"
+        assert meta.namespace == "meta-only-ns"
+        assert meta.user_id == "anonymous"
+
+    def test_create_model_in_meta_only_namespace_succeeds(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Create a kind="model" entry in a meta-only namespace — ownership anchor is meta."""
+        catalog, _ = catalog_factory()
+        _seed_meta(catalog, "meta-only-ns", user_id="anonymous")
+        agent_type = _register_agent_model(monkeypatch)
+        model = Entry(
+            id="shared-model",
+            kind="model",
+            namespace="meta-only-ns",
+            user_id="anonymous",
+            model_type=agent_type,
+            payload={},
+        )
+        stored = catalog.create(model)
+        assert stored.id == "shared-model"
+        assert stored.namespace == "meta-only-ns"
+
+    def test_create_model_with_mismatched_user_id_fails(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Create a kind="model" with user_id != meta.user_id — fails with "anchor (meta)"."""
+        catalog, _ = catalog_factory()
+        _seed_meta(catalog, "meta-only-ns", user_id="anonymous")
+        agent_type = _register_agent_model(monkeypatch)
+        model = Entry(
+            id="rogue-model",
+            kind="model",
+            namespace="meta-only-ns",
+            user_id="eve",
+            model_type=agent_type,
+            payload={},
+        )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.create(model)
+        msg = str(exc.value)
+        assert "Ownership mismatch" in msg
+        assert "anchor (meta)" in msg
+
+    def test_create_non_anchor_in_empty_namespace_fails(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Create any non-team, non-meta entry in a fresh empty namespace — fails."""
+        catalog, _ = catalog_factory()
+        agent_type = _register_agent_model(monkeypatch)
+        model = Entry(
+            id="orphan-model",
+            kind="model",
+            namespace="empty-ns",
+            user_id="alice",
+            model_type=agent_type,
+            payload={},
+        )
+        with pytest.raises(CatalogValidationError) as exc:
+            catalog.create(model)
+        msg = str(exc.value)
+        assert "has no team entry and no meta entry" in msg
 
 
 # --- AC11 + AC40 — ownership ----------------------------------------------------

--- a/tests/v2/test_catalog_meta_only_namespace.py
+++ b/tests/v2/test_catalog_meta_only_namespace.py
@@ -107,8 +107,10 @@ class TestMetaOnlyNamespaceEndToEnd:
         )
         assert resp_import.status_code == 201
 
-        # 10. Verify entries are restored
+        # 10. Verify entries are restored with consistent user_id
         restored = catalog.list_by_namespace(ns)
         restored_ids = {e.id for e in restored}
         assert "_meta" in restored_ids
         assert "shared-model" in restored_ids
+        restored_meta = catalog.get(ns, "_meta")
+        assert restored_meta.user_id == "anonymous"

--- a/tests/v2/test_catalog_meta_only_namespace.py
+++ b/tests/v2/test_catalog_meta_only_namespace.py
@@ -1,0 +1,114 @@
+"""End-to-end tests for meta-only namespaces (Story 17.10).
+
+Proves the full lifecycle of a namespace bootstrapped by a meta entry
+(no team entry): create meta -> create entry -> list -> get -> delete
+-> export -> import. If this test suite passes, the invariant
+relaxation is correct.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from akgentic.catalog.catalog import Catalog  # noqa: E402
+from akgentic.catalog.models.entry import Entry  # noqa: E402
+
+
+_NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+def _model_payload() -> dict[str, Any]:
+    """Return a minimal valid payload for a kind=model entry using AgentCard."""
+    return {
+        "role": "r",
+        "description": "",
+        "skills": [],
+        "agent_class": "akgentic.core.agent.Akgent",
+        "config": {"name": "m", "role": "r"},
+        "routes_to": [],
+        "metadata": {},
+    }
+
+
+class TestMetaOnlyNamespaceEndToEnd:
+    """Full lifecycle of a meta-only namespace through the REST API."""
+
+    def test_full_lifecycle_no_team(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        """Create meta, create model entry, list, get, delete, export/import
+        — all in a team-less namespace.
+        """
+        client, catalog = api_client
+        ns = "global"
+
+        # 1. Create namespace via PUT meta (no team)
+        meta_body = {"name": "Global Library", "description": "Shared assets", "properties": {}}
+        resp = client.put(f"/catalog/namespace/{ns}/meta", json=meta_body)
+        assert resp.status_code == 201
+        meta_entry = resp.json()
+        assert meta_entry["user_id"] == "anonymous"
+        assert meta_entry["kind"] == "meta"
+
+        # 2. Create a kind="model" entry in the meta-only namespace
+        model_entry = Entry(
+            id="shared-model",
+            kind="model",
+            namespace=ns,
+            user_id="anonymous",
+            model_type="akgentic.core.agent_card.AgentCard",
+            description="A shared model",
+            payload=_model_payload(),
+        )
+        created = catalog.create(model_entry)
+        assert created.namespace == ns
+        assert created.id == "shared-model"
+
+        # 3. List entries in namespace
+        entries = catalog.list_by_namespace(ns)
+        ids = {e.id for e in entries}
+        assert "_meta" in ids
+        assert "shared-model" in ids
+
+        # 4. Get the model entry
+        fetched = catalog.get(ns, "shared-model")
+        assert fetched.kind == "model"
+
+        # 5. Delete the model entry
+        catalog.delete(ns, "shared-model")
+        remaining = catalog.list_by_namespace(ns)
+        remaining_ids = {e.id for e in remaining}
+        assert "shared-model" not in remaining_ids
+        assert "_meta" in remaining_ids
+
+        # 6. Re-create the model entry for export
+        catalog.create(model_entry)
+
+        # 7. Export the namespace bundle
+        resp_export = client.get(f"/catalog/namespace/{ns}/export")
+        assert resp_export.status_code == 200
+        yaml_text = resp_export.text
+        assert "shared-model" in yaml_text
+
+        # 8. Delete all entries to prepare for import
+        catalog.delete(ns, "shared-model")
+        catalog.delete(ns, "_meta")
+
+        # 9. Import the bundle back
+        resp_import = client.post(
+            "/catalog/namespace/import",
+            content=yaml_text.encode("utf-8"),
+        )
+        assert resp_import.status_code == 201
+
+        # 10. Verify entries are restored
+        restored = catalog.list_by_namespace(ns)
+        restored_ids = {e.id for e in restored}
+        assert "_meta" in restored_ids
+        assert "shared-model" in restored_ids

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -228,7 +228,7 @@ class TestImportNamespaceYaml:
         yaml_text = dump_namespace(bundle)
         with pytest.raises(CatalogValidationError) as exc_info:
             catalog.import_namespace_yaml(yaml_text)
-        assert any("no team entry" in e for e in exc_info.value.errors)
+        assert any("has no team entry and no meta entry" in e for e in exc_info.value.errors)
 
     def test_import_rejects_multiple_team_entries(self, catalog_factory: CatalogFactory) -> None:
         catalog, _ = catalog_factory()
@@ -1336,3 +1336,70 @@ class TestSnapshotShape:
         ext_tools_pos = text.index(_EXTERNAL_KIND_HEADERS["tool"])
         ext_models_pos = text.index(_EXTERNAL_KIND_HEADERS["model"])
         assert teams_pos < agents_pos < prompts_pos < ext_tools_pos < ext_models_pos
+
+
+# --- Story 17.10 — meta-only bundle round-trip -----------------------------------
+
+
+_NAMESPACE_META_TYPE_BUNDLE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+class TestMetaOnlyBundle:
+    """Round-trip a meta-only bundle (header + meta + library entries, no team)."""
+
+    def test_meta_only_bundle_round_trip(
+        self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Export a meta-only namespace and re-import it — byte-identical entries."""
+        catalog, _ = catalog_factory()
+        agent_type, _leaf_type = _register_agent_models(monkeypatch)
+
+        ns = "meta-only-bundle"
+        # Seed a meta entry (no team) as the namespace anchor.
+        catalog.create(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace=ns,
+                user_id="anonymous",
+                model_type=_NAMESPACE_META_TYPE_BUNDLE,
+                description="Meta-only library",
+                payload={
+                    "name": "Meta Only Lib",
+                    "description": "A library namespace",
+                    "properties": {"tier": "community"},
+                    "shareable": False,
+                },
+            )
+        )
+        # Seed a model entry.
+        catalog.create(
+            Entry(
+                id="model-a",
+                kind="model",
+                namespace=ns,
+                user_id="anonymous",
+                model_type=agent_type,
+                payload={"provider": "openai"},
+            )
+        )
+
+        # Export
+        yaml_text = catalog.export_namespace_yaml(ns)
+        assert "model-a" in yaml_text
+        assert "Meta Only Lib" in yaml_text
+
+        # Delete all entries to prepare for import
+        catalog.delete(ns, "model-a")
+        catalog.delete(ns, "_meta")
+
+        # Import
+        imported = catalog.import_namespace_yaml(yaml_text)
+        imported_ids = {e.id for e in imported}
+        assert "model-a" in imported_ids
+
+        # Verify meta is back
+        meta = catalog.get(ns, "_meta")
+        assert meta.kind == "meta"
+        payload = meta.payload if isinstance(meta.payload, dict) else {}
+        assert payload.get("name") == "Meta Only Lib"

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -1398,8 +1398,9 @@ class TestMetaOnlyBundle:
         imported_ids = {e.id for e in imported}
         assert "model-a" in imported_ids
 
-        # Verify meta is back
+        # Verify meta is back with consistent user_id
         meta = catalog.get(ns, "_meta")
         assert meta.kind == "meta"
+        assert meta.user_id == "anonymous"
         payload = meta.payload if isinstance(meta.payload, dict) else {}
         assert payload.get("name") == "Meta Only Lib"

--- a/tests/v2/test_cli_validate.py
+++ b/tests/v2/test_cli_validate.py
@@ -187,7 +187,7 @@ def _broken_bundles() -> dict[str, tuple[dict[str, Any], str]]:
                     "agent-a": _entry("agent", _AGENT_TYPE, {"linked": {"__ref__": "tool-a"}}),
                 },
             },
-            "no team entry",
+            "has no team entry and no meta entry",
         ),
         # Two team entries under the same namespace.
         "multiple_teams": (
@@ -463,7 +463,7 @@ def _persisted_cases() -> dict[str, tuple[list[Entry], str]]:
                     payload={"linked": {"__ref__": "tool-a"}},
                 ),
             ],
-            "no team entry",
+            "has no team entry and no meta entry",
         ),
         "multiple_teams": (
             [

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -202,7 +202,7 @@ class TestDumpNamespace:
         with pytest.raises(CatalogValidationError) as exc_info:
             dump_namespace([])
         assert exc_info.value.errors == [
-            "bundle must declare at least one entry, including a `kind=team` entry"
+            "bundle must declare at least one entry"
         ]
 
     def test_rejects_mismatched_user_id(self) -> None:
@@ -261,7 +261,7 @@ class TestLoadNamespace:
         with pytest.raises(CatalogValidationError) as exc_info:
             load_namespace(text)
         assert exc_info.value.errors == [
-            "bundle must declare at least one entry, including a `kind=team` entry"
+            "bundle must declare at least one entry"
         ]
 
     def test_rejects_entries_as_list_with_explicit_message(self) -> None:

--- a/tests/v2/test_validation.py
+++ b/tests/v2/test_validation.py
@@ -195,7 +195,7 @@ class TestValidateEntriesGlobalErrors:
         report = validate_entries(entries, repo)
         assert report.ok is False
         assert len(report.global_errors) >= 1
-        assert any("no team entry" in msg for msg in report.global_errors)
+        assert any("has no team entry and no meta entry" in msg for msg in report.global_errors)
 
     def test_multiple_team_entries(self) -> None:
         repo = SpyRepository()
@@ -252,14 +252,15 @@ class TestValidateEntriesGlobalErrors:
         assert "agent-a" in dangling[0] and "ghost" in dangling[0]
 
     def test_ownership_check_skipped_when_no_team(self) -> None:
-        """AC11: ownership check is skipped when team count != 1."""
+        """AC11: ownership check is skipped when team count != 1 and no meta."""
         repo = SpyRepository()
         a1 = _seed_agent(id="agent-a", user_id="alice")
         a2 = _seed_agent(id="agent-b", user_id="bob")
         report = validate_entries([a1, a2], repo)
-        # Must have the no-team-entry message but NOT any user_id-mismatch.
-        assert any("no team entry" in m for m in report.global_errors)
+        # Must have the no-anchor message but NOT any user_id-mismatch.
+        assert any("has no team entry and no meta entry" in m for m in report.global_errors)
         assert not any("!= team user_id" in m for m in report.global_errors)
+        assert not any("!= meta user_id" in m for m in report.global_errors)
 
     # --- AC3 / Story 17.2 — meta singleton invariant in _global_checks ---
 
@@ -494,6 +495,49 @@ class TestValidateEntriesPerEntryErrors:
         issues = [i for i in report.entry_issues if i.entry_id == "offender"]
         assert issues
         assert any("declares reserved ref-sentinel fields" in e for e in issues[0].errors)
+
+
+# --- Story 17.10 — meta-only namespace validation ----------------------------
+
+
+_NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
+
+
+class TestMetaOnlyNamespaceValidation:
+    """Story 17.10 — meta-only entry list passes validation cleanly."""
+
+    def test_meta_only_namespace_passes_validation(self) -> None:
+        """A meta + model entry list (no team) passes validate_entries cleanly."""
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="ns-1",
+            user_id="anonymous",
+            model_type=_NAMESPACE_META_TYPE,
+            payload={"name": "ns-1", "description": "", "properties": {}, "shareable": False},
+        )
+        agent = _seed_agent(id="agent-a", user_id="anonymous")
+        repo = SpyRepository(entries=[agent])
+        report = validate_entries([meta, agent], repo)
+        assert report.ok is True
+        assert report.global_errors == []
+        assert report.namespace == "ns-1"
+
+    def test_meta_only_ownership_mismatch_flagged(self) -> None:
+        """With meta anchor, ownership mismatch is still flagged."""
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="ns-1",
+            user_id="anonymous",
+            model_type=_NAMESPACE_META_TYPE,
+            payload={"name": "ns-1", "description": "", "properties": {}, "shareable": False},
+        )
+        agent = _seed_agent(id="agent-a", user_id="eve")
+        repo = SpyRepository(entries=[agent])
+        report = validate_entries([meta, agent], repo)
+        assert report.ok is False
+        assert any("!= meta user_id" in m for m in report.global_errors)
 
 
 # --- Happy path (AC32) ------------------------------------------------------


### PR DESCRIPTION
## Summary

- Widen bootstrap and ownership invariants to accept team OR meta as the namespace anchor, making meta-only namespaces (e.g. `global` library namespace) fully operationally writable
- Rename `_check_bootstrap` to `_check_namespace_initialized` and `_check_team_count` to `_check_namespace_anchor` to reflect the widened semantics
- Implement three-rung anchor lookup in `_check_ownership` and `_check_uniform_user_id` (team -> meta -> raise/skip)
- Remove fast-path bootstrap check from `PUT /namespace/{ns}/meta` handler; add three-rung user_id derivation (team -> existing_meta -> "anonymous")
- Widen `_validate_bundle_invariants` with `has_header_meta` parameter for hoisted-meta bundles from import path
- Fix meta-only bundle import user_id consistency in `_build_meta_entry_for_upsert` (code review fix)
- Update stale error messages in serialization module (code review fix)
- Full test coverage: end-to-end meta-only namespace lifecycle, CRUD tests, validation tests, bundle round-trip, API router tests

Closes #176
