### PR TITLE
feat: tighten Entry.user_id from str | None to str with default 'anonymous'

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -358,7 +358,7 @@ async def put_namespace_meta(namespace: str, request: Request) -> Response:
         pass
 
     if teams:
-        user_id: str | None = teams[0].user_id
+        user_id: str = teams[0].user_id
     elif existing_meta is not None:
         user_id = existing_meta.user_id
     else:

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -302,7 +302,7 @@ class Catalog:
         src_namespace: str,
         src_id: str,
         dst_namespace: str,
-        dst_user_id: str | None,
+        dst_user_id: str = "anonymous",
     ) -> Entry:
         """Deep-copy an entry tree into ``dst_namespace`` with ref rewrite and dedup.
 
@@ -331,8 +331,9 @@ class Catalog:
             src_namespace: Source namespace containing the entry to clone.
             src_id: Id of the source entry within ``src_namespace``.
             dst_namespace: Destination namespace receiving the cloned entries.
-            dst_user_id: ``user_id`` to stamp on every cloned entry; ``None``
-                for enterprise-scoped clones.
+            dst_user_id: ``user_id`` to stamp on every cloned entry. Defaults
+                to ``"anonymous"`` for community-tier deployments; department
+                / enterprise tiers pass the authenticated caller's identifier.
 
         Returns:
             The top-level cloned entry, as freshly re-read from the repository.
@@ -793,10 +794,15 @@ class Catalog:
         elif prepared:
             # Meta-only bundle: inherit user_id from the first entry so the
             # upserted meta entry stays ownership-consistent with the bundle
-            # contents (Story 17.10).
+            # contents (Story 17.10). After Story 18.1, ``prepared[0].user_id``
+            # is always a real string ("anonymous" by default).
             user_id = prepared[0].user_id
         else:
-            user_id = None
+            # Defensive: a header-only bundle with zero prepared entries
+            # cannot reach this branch (load_namespace rejects empty
+            # entries). Fall back to "anonymous" so the constructed meta
+            # entry still satisfies the tightened Entry.user_id field.
+            user_id = "anonymous"
         try:
             meta_payload = NamespaceMeta(
                 name=header.name,
@@ -1245,7 +1251,7 @@ class Catalog:
         cloned: dict[tuple[str, str], str],
         pending_writes: _list[Entry],
         dst_namespace: str,
-        dst_user_id: str | None,
+        dst_user_id: str,
     ) -> str:
         """Clone a single source entry, recursing into its payload refs."""
         key = (src_namespace, src_id)

--- a/src/akgentic/catalog/cli/main.py
+++ b/src/akgentic/catalog/cli/main.py
@@ -625,27 +625,25 @@ def _clone_cmd(
     src_id: str = typer.Option(..., "--src-id", help="Source entry id."),
     dst_namespace: str = typer.Option(..., "--dst-namespace", help="Destination namespace."),
     dst_user_id: str = typer.Option(
-        ...,
+        "anonymous",
         "--dst-user-id",
-        help="Destination user_id; empty string '' targets enterprise (user_id=None).",
+        help="Destination user_id; omit or pass 'anonymous' for community-tier deployments.",
     ),
 ) -> None:
     """Deep-copy an entry tree into ``--dst-namespace`` (ADR-007 ownership semantics).
 
-    The empty-string sentinel ``--dst-user-id ""`` means "clone into
-    enterprise" — normalised to ``None`` before constructing ``CloneRequest``.
+    The destination owner defaults to the literal ``"anonymous"`` string —
+    the community-tier convention. Department / enterprise tier deployments
+    pass the authenticated caller's identifier explicitly.
     """
     catalog = _repo_from_ctx(ctx)
     state = _state_from_ctx(ctx)
-    # Empty string is the canonical "enterprise" sentinel at the CLI boundary;
-    # CloneRequest.dst_user_id is NonEmptyStr | None and rejects empty strings.
-    normalized_user_id: str | None = dst_user_id if dst_user_id != "" else None
     try:
         req = CloneRequest(
             src_namespace=src_namespace,
             src_id=src_id,
             dst_namespace=dst_namespace,
-            dst_user_id=normalized_user_id,
+            dst_user_id=dst_user_id,
         )
     except ValidationError as exc:
         err_console.print(f"validation error: {exc}")

--- a/src/akgentic/catalog/models/entry.py
+++ b/src/akgentic/catalog/models/entry.py
@@ -112,9 +112,15 @@ class Entry(BaseModel):
     namespace: NonEmptyStr = Field(
         description="Namespace this entry belongs to; scopes id uniqueness."
     )
-    user_id: NonEmptyStr | None = Field(
-        default=None,
-        description=("Owner user id for user-scoped entries; None for global/enterprise entries."),
+    user_id: NonEmptyStr = Field(
+        default="anonymous",
+        description=(
+            "Owner user identifier; defaults to 'anonymous' on community tier. "
+            "Always a real string — never null, never empty. The literal "
+            "'anonymous' is the community-tier convention (every entry is "
+            "implicitly trusted), not a sentinel: department / enterprise "
+            "deployments stamp the authenticated caller's user id instead."
+        ),
     )
     parent_namespace: NonEmptyStr | None = Field(
         default=None,

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -46,7 +46,7 @@ class NamespaceMeta(BaseModel):
       referenceability (ADR-008 §D2 as updated 2026-05-08, rev 2). When
       ``True``, the namespace is cross-namespace-referenceable as a target —
       other namespaces may carry refs into this one (subject to the existing
-      ``user_id is None`` ownership gate). When ``False`` (the default), the
+      ``user_id == "anonymous"`` ownership gate). When ``False`` (the default), the
       namespace is not shareable. Pydantic strict-mode rejects non-bool
       inputs so operators must opt in unambiguously with a real boolean.
 
@@ -85,7 +85,7 @@ class NamespaceMeta(BaseModel):
         description=(
             "When True, the namespace is cross-namespace-referenceable as a "
             "target — other namespaces may carry refs into this one (subject "
-            "to the existing ``user_id is None`` ownership gate). Strict-bool "
+            "to the existing ``user_id == 'anonymous'`` ownership gate). Strict-bool "
             '— non-bool inputs (e.g. the string ``"true"``) are rejected by '
             "Pydantic at construction time. ADR-008 §D2 as updated "
             "2026-05-08 (rev 2)."

--- a/src/akgentic/catalog/models/queries.py
+++ b/src/akgentic/catalog/models/queries.py
@@ -26,13 +26,15 @@ class EntryQuery(BaseModel):
     ``user_id_set`` is a tri-state filter layered on top of ``user_id``:
 
     * ``None`` — ignore user_id scoping entirely.
-    * ``True`` — include only entries with any non-``None`` ``user_id``
-      (i.e. user-scoped entries).
-    * ``False`` — include only entries with ``user_id is None``
-      (i.e. global/enterprise entries).
+    * ``True`` — include only entries whose ``user_id != "anonymous"``
+      (i.e. real-user-owned entries on community-tier deployments, or any
+      authenticated-caller-owned entry on department / enterprise tier).
+    * ``False`` — include only entries whose ``user_id == "anonymous"``
+      (i.e. the community-tier default-owner entries).
 
     This is orthogonal to ``user_id``: passing ``user_id="alice"`` narrows to
-    exactly that user, whereas ``user_id_set=True`` narrows to "any user".
+    exactly that user, whereas ``user_id_set=True`` narrows to "any user
+    other than the community-tier default".
     """
 
     model_config = ConfigDict(frozen=True)
@@ -49,7 +51,8 @@ class EntryQuery(BaseModel):
     user_id_set: bool | None = Field(
         default=None,
         description=(
-            "Tri-state user_id scope filter: None=any, True=user_id set, False=user_id is None."
+            "Tri-state user_id scope filter: None=any, "
+            "True=user_id != 'anonymous', False=user_id == 'anonymous'."
         ),
     )
     parent_namespace: NonEmptyStr | None = Field(
@@ -78,7 +81,11 @@ class CloneRequest(BaseModel):
     )
     src_id: NonEmptyStr = Field(description="Id of the source entry to clone.")
     dst_namespace: NonEmptyStr = Field(description="Destination namespace for the clone.")
-    dst_user_id: NonEmptyStr | None = Field(
-        default=None,
-        description=("Destination user_id; None targets a global/enterprise clone."),
+    dst_user_id: NonEmptyStr = Field(
+        default="anonymous",
+        description=(
+            "Destination user_id; defaults to 'anonymous' on community tier. "
+            "Department / enterprise deployments pass the authenticated "
+            "caller's identifier."
+        ),
     )

--- a/src/akgentic/catalog/repositories/mongo.py
+++ b/src/akgentic/catalog/repositories/mongo.py
@@ -148,7 +148,7 @@ class MongoEntryRepository:
         "namespace": <ns>,
         "id": <id>,
         "kind": <kind>,
-        "user_id": <str|None>,
+        "user_id": <str>,
         "parent_namespace": <str|None>,
         "parent_id": <str|None>,
         "model_type": <akgentic.* dotted path>,
@@ -379,27 +379,34 @@ class MongoEntryRepository:
 
         * both unset → no ``user_id`` key is added.
         * ``user_id`` only → exact match (``{"user_id": value}``).
-        * ``user_id_set`` only → presence filter
-          (``{"$ne": None}`` / ``None``).
+        * ``user_id_set`` only → comparison against the literal
+          ``"anonymous"`` (``{"$ne": "anonymous"}`` for True, ``"anonymous"``
+          for False).
         * both set → the joint constraint: if ``user_id_set=True`` the exact
-          value already guarantees non-``None``, so the exact match is
-          emitted; if ``user_id_set=False`` the combination is logically
-          impossible (a non-``None`` value cannot also be ``None``), so an
-          unsatisfiable clause (``{"$in": []}``) is emitted so the query
-          returns zero documents — which is exactly what the YAML backend
-          returns for the same contradictory pair.
+          value already guarantees ``user_id != "anonymous"`` (because a
+          caller passing the literal ``"anonymous"`` while also asserting
+          ``user_id_set=True`` is a contradiction — see below); if
+          ``user_id_set=False`` the combination is logically impossible
+          (a non-``"anonymous"`` value cannot also equal ``"anonymous"``),
+          so an unsatisfiable clause (``{"$in": []}``) is emitted so the
+          query returns zero documents — which is exactly what the YAML
+          backend returns for the same contradictory pair.
         """
-        if query.user_id is None and query.user_id_set is None:
+        # query.user_id is the EntryQuery exact-match filter (still
+        # tri-state: a falsy / None value means "no filter"). NonEmptyStr
+        # ensures the only falsy value is None.
+        q_user_id = query.user_id
+        if not q_user_id and query.user_id_set is None:
             return
         if query.user_id_set is None:
-            mongo_filter["user_id"] = query.user_id
+            mongo_filter["user_id"] = q_user_id
             return
-        if query.user_id is None:
-            mongo_filter["user_id"] = {"$ne": None} if query.user_id_set else None
+        if not q_user_id:
+            mongo_filter["user_id"] = {"$ne": "anonymous"} if query.user_id_set else "anonymous"
             return
         if query.user_id_set:
-            # Exact value is already non-None; the exact match satisfies both.
-            mongo_filter["user_id"] = query.user_id
+            # Exact value is already non-"anonymous"; the exact match satisfies both.
+            mongo_filter["user_id"] = q_user_id
             return
         # user_id set but user_id_set is False → contradiction; match nothing.
         mongo_filter["user_id"] = {"$in": []}

--- a/src/akgentic/catalog/repositories/mongo.py
+++ b/src/akgentic/catalog/repositories/mongo.py
@@ -342,8 +342,8 @@ class MongoEntryRepository:
         """Translate an ``EntryQuery`` into a server-side Mongo filter dict.
 
         Each non-``None`` field contributes exactly one clause. ``user_id_set``
-        is tri-state (``None`` = ignore, ``True`` = ``user_id != null``,
-        ``False`` = ``user_id is null``). ``user_id`` and ``user_id_set``
+        is tri-state (``None`` = ignore, ``True`` = ``user_id != "anonymous"``,
+        ``False`` = ``user_id == "anonymous"``). ``user_id`` and ``user_id_set``
         combine with AND semantics — if both are set, the emitted ``user_id``
         clause honours both constraints jointly so the Mongo filter matches
         the YAML backend's ``_matches`` evaluation (conjunctive over both

--- a/src/akgentic/catalog/repositories/postgres/repository.py
+++ b/src/akgentic/catalog/repositories/postgres/repository.py
@@ -343,27 +343,39 @@ def _apply_user_id_clauses(
 
     * both unset → no clause.
     * ``user_id`` only → ``user_id = %s``.
-    * ``user_id_set=True`` only → ``user_id IS NOT NULL``.
-    * ``user_id_set=False`` only → ``user_id IS NULL``.
+    * ``user_id_set=True`` only → ``user_id != 'anonymous'``.
+    * ``user_id_set=False`` only → ``user_id = 'anonymous'``.
     * ``user_id`` set AND ``user_id_set=True`` → exact-match clause (the
-      value is already non-``None``; the single equality satisfies both).
+      value is already non-``"anonymous"``; the single equality satisfies
+      both).
     * ``user_id`` set AND ``user_id_set=False`` → unsatisfiable (a non-
-      ``None`` value cannot also be ``None``); emit ``1 = 0`` so the query
-      matches zero rows — parity with Mongo's ``{"$in": []}`` and YAML's
-      ``_matches`` short-circuit.
+      ``"anonymous"`` value cannot also equal ``"anonymous"``); emit
+      ``1 = 0`` so the query matches zero rows — parity with Mongo's
+      ``{"$in": []}`` and YAML's ``_matches`` short-circuit.
+
+    The column-level NULL constraint on ``user_id`` is unchanged at the
+    schema layer (``user_id TEXT`` stays nullable). The Pydantic non-null
+    guarantee on :class:`Entry.user_id` is the application-layer contract;
+    no equality-against-``"anonymous"`` clause needs to special-case NULL
+    rows because the catalog never writes them.
     """
-    if query.user_id is None and query.user_id_set is None:
+    # query.user_id is the EntryQuery exact-match filter (still tri-state:
+    # a falsy / None value means "no filter"). NonEmptyStr ensures the only
+    # falsy value is None.
+    q_user_id = query.user_id
+    if not q_user_id and query.user_id_set is None:
         return
     if query.user_id_set is None:
         clauses.append("user_id = %s")
-        params.append(query.user_id)
+        params.append(q_user_id)
         return
-    if query.user_id is None:
-        clauses.append("user_id IS NOT NULL" if query.user_id_set else "user_id IS NULL")
+    if not q_user_id:
+        clauses.append("user_id != %s" if query.user_id_set else "user_id = %s")
+        params.append("anonymous")
         return
     if query.user_id_set:
         clauses.append("user_id = %s")
-        params.append(query.user_id)
+        params.append(q_user_id)
         return
     # user_id set AND user_id_set=False → contradiction; match zero rows.
     clauses.append("1 = 0")

--- a/src/akgentic/catalog/repositories/yaml.py
+++ b/src/akgentic/catalog/repositories/yaml.py
@@ -313,19 +313,23 @@ class YamlEntryRepository:
 
         Each filter is a conjunct: a ``None`` filter is ignored, a set filter
         must match. ``user_id_set`` is tri-state — ``None`` means "no filter",
-        ``True`` restricts to ``user_id is not None``, ``False`` restricts to
-        ``user_id is None``. ``description_contains`` is a case-sensitive
-        substring check matching v1 semantics.
+        ``True`` restricts to ``user_id != "anonymous"``, ``False`` restricts
+        to ``user_id == "anonymous"``. ``description_contains`` is a
+        case-sensitive substring check matching v1 semantics.
         """
         if query.kind is not None and entry.kind != query.kind:
             return False
         if query.id is not None and entry.id != query.id:
             return False
-        if query.user_id is not None and entry.user_id != query.user_id:
+        # query.user_id is the EntryQuery exact-match filter (still
+        # tri-state: a falsy / None value means "no filter"). entry.user_id
+        # is always a real string after Story 18.1.
+        query_user_id = query.user_id
+        if query_user_id and entry.user_id != query_user_id:
             return False
-        if query.user_id_set is True and entry.user_id is None:
+        if query.user_id_set is True and entry.user_id == "anonymous":
             return False
-        if query.user_id_set is False and entry.user_id is not None:
+        if query.user_id_set is False and entry.user_id != "anonymous":
             return False
         if query.parent_namespace is not None and entry.parent_namespace != query.parent_namespace:
             return False

--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -99,7 +99,7 @@ may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
 to address an entry in a different namespace; the resolver gates the lookup
 on the data-driven shareable-flag (the target namespace's ``_meta`` entry has
 ``payload["shareable"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2) and
-on the target's ``user_id is None`` privacy constraint. The shorthand
+on the target's ``user_id == "anonymous"`` privacy constraint. The shorthand
 ``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
 the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
 ``__ref__``) bypass both gates entirely.
@@ -416,13 +416,16 @@ def _populate_ref_marker(
 
     # Cross-ns ownership gate (ADR-008 §D2): cross-ns refs may only target
     # globally-scoped entries. This fires AFTER the lookup so the message
-    # can name the offending user_id.
-    if target_namespace != namespace and target.user_id is not None:
+    # can name the offending user_id. Story 18.1 swaps the comparison value
+    # from `is not None` to `!= "anonymous"` (every globally-scoped entry's
+    # owner is the literal "anonymous" string, not null). Story 18.3
+    # removes the gate entirely.
+    if target_namespace != namespace and target.user_id != "anonymous":
         raise CatalogValidationError(
             [
                 f"Cross-namespace ref target '{target_namespace}.{target_id}' "
                 f"has user_id={target.user_id!r} — only globally-scoped "
-                f"entries (user_id=None) can be referenced cross-namespace"
+                f"entries (user_id='anonymous') can be referenced cross-namespace"
             ]
         )
 

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -163,7 +163,9 @@ def dump_namespace(
     outer key.
 
     Ownership invariant: every entry in ``entries`` MUST share the same
-    ``user_id`` (including the ``None`` case for enterprise bundles).
+    ``user_id`` (a real string after Story 18.1 — ``"anonymous"`` for
+    community-tier exports; the authenticated caller's identifier on
+    department / enterprise tier).
     Namespace invariant: every entry MUST share the same ``namespace``.
     Both invariants are checked together before emit; violations raise
     ``CatalogValidationError`` with one message per offender.
@@ -408,8 +410,10 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
     """Parse a bundle YAML document and return ``(entries, header)``.
 
     Story 17.6 — the parser is structurally strict: the root must be a
-    ``dict`` with ``namespace`` (non-empty ``str``), ``user_id`` (``str | None``),
-    and ``entries`` (non-empty ``dict``). Optional top-level fields ``name``
+    ``dict`` with ``namespace`` (non-empty ``str``), ``user_id`` (non-empty
+    ``str``; legacy ``null`` is accepted on read and rewritten to
+    ``"anonymous"`` per Story 18.1), and ``entries`` (non-empty ``dict``).
+    Optional top-level fields ``name``
     (``str``), ``description`` (``str``), and ``properties`` (``dict[str, str]``)
     are projected into the returned :class:`BundleHeader`. Any missing or
     wrong-typed required key accumulates into a single
@@ -459,7 +463,13 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
         raise CatalogValidationError(["bundle must declare at least one entry"])
 
     namespace: str = doc["namespace"]
-    user_id: str | None = doc["user_id"]
+    raw_user_id = doc["user_id"]
+    # Legacy-bundle migration: pre-Story-18.1 bundles emitted ``user_id: null``
+    # at the document root for community-tier exports. Rewrite to the literal
+    # ``"anonymous"`` before any ``Entry`` is built so the tightened
+    # :class:`Entry.user_id: NonEmptyStr` field accepts the value. The catalog
+    # never writes ``user_id: null`` again — see ``dump_namespace``.
+    user_id: str = raw_user_id if isinstance(raw_user_id, str) else "anonymous"
     header = _project_header(doc)
     entries: list[Entry] = []
     for entry_key, entry_map in entries_map.items():
@@ -547,8 +557,19 @@ def _validate_root_shape(doc: Any) -> list[str]:
 
     if "user_id" not in doc:
         errors.append("bundle root missing required key 'user_id'")
-    elif doc["user_id"] is not None and not isinstance(doc["user_id"], str):
-        errors.append("bundle 'user_id' must be a string or null")
+    else:
+        user_id_val = doc["user_id"]
+        # Story 18.1: ``null`` continues to pass structural validation
+        # (legacy-bundle read path — ``load_namespace`` rewrites it to
+        # ``"anonymous"`` before constructing any ``Entry``). Empty strings
+        # are bugs, not legacy shapes — reject explicitly. The ``"must be a"``
+        # substring is preserved for tests that already assert on it.
+        if user_id_val is None:
+            pass
+        elif not isinstance(user_id_val, str):
+            errors.append("bundle 'user_id' must be a non-empty string or null")
+        elif user_id_val == "":
+            errors.append("bundle 'user_id' must be a non-empty string or null")
 
     if "entries" not in doc:
         errors.append("bundle root missing required key 'entries'")
@@ -570,7 +591,7 @@ def _build_entry(
     entry_id: str,
     entry_map: Any,
     namespace: str,
-    user_id: str | None,
+    user_id: str,
 ) -> Entry:
     """Build a single ``Entry`` from a per-entry YAML map.
 

--- a/tests/api/test_router_body_formats.py
+++ b/tests/api/test_router_body_formats.py
@@ -71,7 +71,7 @@ def _prompt_payload() -> dict[str, Any]:
 def _team_entry(
     namespace: str = "ns-body",
     entry_id: str = "team",
-    user_id: str | None = None,
+    user_id: str = "anonymous",
 ) -> Entry:
     """Build an ``Entry`` of kind ``team`` with a valid payload."""
     return Entry(
@@ -87,7 +87,7 @@ def _team_entry(
 def _prompt_entry(
     namespace: str = "ns-body",
     entry_id: str = "prompt-1",
-    user_id: str | None = None,
+    user_id: str = "anonymous",
 ) -> Entry:
     """Build an ``Entry`` of kind ``prompt`` with a valid payload."""
     return Entry(

--- a/tests/fixtures/agent-team-v1/agent/assistant.yaml
+++ b/tests/fixtures/agent-team-v1/agent/assistant.yaml
@@ -1,7 +1,7 @@
 id: assistant
 kind: agent
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/agent-team-v1/agent/expert.yaml
+++ b/tests/fixtures/agent-team-v1/agent/expert.yaml
@@ -1,7 +1,7 @@
 id: expert
 kind: agent
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/agent-team-v1/agent/human_proxy.yaml
+++ b/tests/fixtures/agent-team-v1/agent/human_proxy.yaml
@@ -1,7 +1,7 @@
 id: human_proxy
 kind: agent
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/agent-team-v1/agent/human_support.yaml
+++ b/tests/fixtures/agent-team-v1/agent/human_support.yaml
@@ -1,7 +1,7 @@
 id: human_support
 kind: agent
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/agent-team-v1/agent/manager.yaml
+++ b/tests/fixtures/agent-team-v1/agent/manager.yaml
@@ -1,7 +1,7 @@
 id: manager
 kind: agent
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/agent-team-v1/model/id_gpt_41.yaml
+++ b/tests/fixtures/agent-team-v1/model/id_gpt_41.yaml
@@ -1,7 +1,7 @@
 id: id_gpt_41
 kind: model
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.llm.ModelConfig

--- a/tests/fixtures/agent-team-v1/team/team.yaml
+++ b/tests/fixtures/agent-team-v1/team/team.yaml
@@ -1,7 +1,7 @@
 id: team
 kind: team
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.team.TeamCard

--- a/tests/fixtures/agent-team-v1/tool/id_planning.yaml
+++ b/tests/fixtures/agent-team-v1/tool/id_planning.yaml
@@ -1,7 +1,7 @@
 id: id_planning
 kind: tool
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.tool.planning.PlanningTool

--- a/tests/fixtures/agent-team-v1/tool/id_web_search.yaml
+++ b/tests/fixtures/agent-team-v1/tool/id_web_search.yaml
@@ -1,7 +1,7 @@
 id: id_web_search
 kind: tool
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.tool.search.SearchTool

--- a/tests/fixtures/agent-team-v1/tool/id_workspace.yaml
+++ b/tests/fixtures/agent-team-v1/tool/id_workspace.yaml
@@ -1,7 +1,7 @@
 id: id_workspace
 kind: tool
 namespace: agent-team-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.tool.workspace.WorkspaceTool

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/assistant.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/assistant.yaml
@@ -1,7 +1,7 @@
 id: assistant
 kind: agent
 namespace: sibling-overrides-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/manager.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/agent/manager.yaml
@@ -1,7 +1,7 @@
 id: manager
 kind: agent
 namespace: sibling-overrides-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.core.AgentCard

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/prompt/id_team_prompt.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/prompt/id_team_prompt.yaml
@@ -1,7 +1,7 @@
 id: id_team_prompt
 kind: prompt
 namespace: sibling-overrides-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.llm.prompts.PromptTemplate

--- a/tests/fixtures/sibling_overrides/sibling-overrides-v1/team/team.yaml
+++ b/tests/fixtures/sibling_overrides/sibling-overrides-v1/team/team.yaml
@@ -1,7 +1,7 @@
 id: team
 kind: team
 namespace: sibling-overrides-v1
-user_id: null
+user_id: anonymous
 parent_namespace: null
 parent_id: null
 model_type: akgentic.team.TeamCard

--- a/tests/repositories/postgres/test_query_translator.py
+++ b/tests/repositories/postgres/test_query_translator.py
@@ -99,21 +99,21 @@ def test_user_id_only_sets_equality() -> None:
 
 
 def test_user_id_set_true_only() -> None:
-    """AC21: user_id_set=True only → ``user_id IS NOT NULL``."""
+    """Story 18.1: user_id_set=True only → ``user_id != %s`` bound to "anonymous"."""
     where, params = _build_where(EntryQuery(user_id_set=True))
-    assert _normalise(where) == "user_id IS NOT NULL"
-    assert params == []
+    assert _normalise(where) == "user_id != %s"
+    assert params == ["anonymous"]
 
 
 def test_user_id_set_false_only() -> None:
-    """AC21: user_id_set=False only → ``user_id IS NULL``."""
+    """Story 18.1: user_id_set=False only → ``user_id = %s`` bound to "anonymous"."""
     where, params = _build_where(EntryQuery(user_id_set=False))
-    assert _normalise(where) == "user_id IS NULL"
-    assert params == []
+    assert _normalise(where) == "user_id = %s"
+    assert params == ["anonymous"]
 
 
 def test_user_id_and_user_id_set_true() -> None:
-    """AC21: user_id + user_id_set=True → equality (value guarantees non-null)."""
+    """AC21: user_id + user_id_set=True → equality (value guarantees user_id != "anonymous")."""
     where, params = _build_where(EntryQuery(user_id="alice", user_id_set=True))
     assert _normalise(where) == "user_id = %s"
     assert params == ["alice"]

--- a/tests/repositories/test_entry_repository_contract.py
+++ b/tests/repositories/test_entry_repository_contract.py
@@ -290,7 +290,9 @@ class TestEntryRepositoryContract:
         backend.put(
             make_entry(id="alice", kind="agent", namespace="ns-1", user_id="alice", payload={})
         )
-        backend.put(make_entry(id="bob", kind="agent", namespace="ns-1", user_id=None, payload={}))
+        backend.put(
+            make_entry(id="bob", kind="agent", namespace="ns-1", user_id="anonymous", payload={})
+        )
 
         # user_id="alice" AND user_id_set=True → alice satisfies both.
         got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=True))
@@ -425,3 +427,26 @@ class TestPostgresSpecific:
             row = cur.fetchone()
             assert row is not None
             assert row[0] == 1, f"expected exactly one row after upsert, got {row[0]}"
+
+    def test_default_user_id_writes_anonymous_string_not_null(
+        self,
+        postgres_clean_dsn: str,
+    ) -> None:
+        """Story 18.1 / AC6 — entries with the default ``user_id`` persist as
+        the literal string ``"anonymous"`` in the ``user_id`` column, not NULL.
+        """
+        import psycopg
+
+        from akgentic.catalog.repositories.postgres import PostgresEntryRepository
+
+        repo = PostgresEntryRepository(postgres_clean_dsn)
+        repo.put(make_entry(id="anon-row", kind="tool", namespace="ns-anon-pg"))
+        with psycopg.connect(postgres_clean_dsn) as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT user_id FROM catalog_entries WHERE namespace = %s AND id = %s",
+                ("ns-anon-pg", "anon-row"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            assert row[0] == "anonymous"
+            assert row[0] is not None

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -50,7 +50,7 @@ def make_meta_entry(
     name: str | None = None,
     description: str = "",
     extra_properties: dict[str, str] | None = None,
-    user_id: str | None = None,
+    user_id: str = "anonymous",
 ) -> Entry:
     """Build a ``kind="meta"`` Entry with the canonical id ``"_meta"``.
 
@@ -83,9 +83,10 @@ def make_meta_entry(
 def make_entry(**overrides: Any) -> Entry:
     """Build a minimal valid ``Entry`` with sensible defaults, overridable by kwargs.
 
-    Defaults model a fresh, global (no user_id), freshly minted (no lineage)
-    entry of kind ``tool`` pointing at a known-valid ``akgentic.*`` class.
-    Tests pass keyword overrides for the attribute under test.
+    Defaults model a fresh, community-tier (``user_id="anonymous"``),
+    freshly minted (no lineage) entry of kind ``tool`` pointing at a
+    known-valid ``akgentic.*`` class. Tests pass keyword overrides for the
+    attribute under test.
     """
     base: dict[str, Any] = {
         "id": "entry-1",
@@ -178,12 +179,12 @@ class FakeEntryRepository:
             out = [e for e in out if e.kind == query.kind]
         if query.id is not None:
             out = [e for e in out if e.id == query.id]
-        if query.user_id is not None:
+        if query.user_id:
             out = [e for e in out if e.user_id == query.user_id]
         if query.user_id_set is True:
-            out = [e for e in out if e.user_id is not None]
+            out = [e for e in out if e.user_id != "anonymous"]
         elif query.user_id_set is False:
-            out = [e for e in out if e.user_id is None]
+            out = [e for e in out if e.user_id == "anonymous"]
         if query.parent_namespace is not None:
             out = [e for e in out if e.parent_namespace == query.parent_namespace]
         if query.parent_id is not None:

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -58,7 +58,7 @@ def _agent_payload(name: str = "a") -> dict[str, Any]:
     }
 
 
-def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = None) -> Entry:
+def _seed_team(catalog: Catalog, namespace: str, user_id: str = "anonymous") -> Entry:
     """Seed a team entry in ``namespace``."""
     return catalog.create(
         Entry(
@@ -76,7 +76,7 @@ def _seed_agent(
     catalog: Catalog,
     namespace: str,
     id: str = "agent-a",
-    user_id: str | None = None,
+    user_id: str = "anonymous",
     payload: dict[str, Any] | None = None,
 ) -> Entry:
     """Seed a minimal agent entry sharing the team's ownership."""
@@ -374,7 +374,7 @@ class TestClone:
                 "src_namespace": "nope",
                 "src_id": "team",
                 "dst_namespace": "dst",
-                "dst_user_id": None,
+                "dst_user_id": "anonymous",
             },
         )
         assert response.status_code == 404
@@ -945,7 +945,7 @@ class TestNamespaceBundleRoundTrip:
 
 def _validation_bundle(
     namespace: str = "ns-v",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     extra_entries: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     """Build a minimal valid bundle YAML, optionally appending extra entries."""
@@ -1352,12 +1352,12 @@ class TestListNamespaces:
     def test_includes_entries_across_user_ids(self, api_client: tuple[TestClient, Catalog]) -> None:
         """AC #4 — the endpoint does not filter by ``user_id``.
 
-        Community-tier (``user_id=None``) and multi-tenant
+        Community-tier (``user_id="anonymous"``) and multi-tenant
         (``user_id="alice"``, ``user_id="bob"``) namespaces must all appear.
         Tenancy filtering is a caller concern.
         """
         client, catalog = api_client
-        _seed_team(catalog, "ns-public", user_id=None)
+        _seed_team(catalog, "ns-public", user_id="anonymous")
         _seed_team(catalog, "ns-alice", user_id="alice")
         _seed_team(catalog, "ns-bob", user_id="bob")
         response = client.get("/catalog/namespaces")
@@ -1429,7 +1429,7 @@ _NAMESPACE_META_TYPE_ROUTER = "akgentic.catalog.models.namespace_meta.NamespaceM
 def _seed_meta_entry(
     catalog: Catalog,
     namespace: str,
-    user_id: str | None = None,
+    user_id: str = "anonymous",
     name: str = "Tenant 42",
     description: str = "primary tenant",
 ) -> Entry:
@@ -1469,7 +1469,7 @@ class TestListNamespacesMetaFallback:
         _seed_meta_entry(
             catalog,
             namespace="tenant-42",
-            user_id=None,
+            user_id="anonymous",
             name="Friendly Display",
             description="meta description",
         )
@@ -1679,9 +1679,7 @@ class TestPutNamespaceMeta:
         assert entry["kind"] == "meta"
         assert entry["namespace"] == "ghost-ns"
 
-    def test_no_team_update_preserves_user_id(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_no_team_update_preserves_user_id(self, api_client: tuple[TestClient, Catalog]) -> None:
         """Subsequent PUT (update) preserves the _meta.user_id from the first write."""
         client, _ = api_client
         body = {"name": "ghost", "description": "", "properties": {}}
@@ -1712,7 +1710,7 @@ def _seed_meta(
     name: str = "Display",
     description: str = "",
     shareable: bool = False,
-    user_id: str | None = None,
+    user_id: str = "anonymous",
 ) -> Entry:
     """Seed a kind=meta entry directly through the catalog (typed-bool shape)."""
     return catalog.create(
@@ -1796,7 +1794,7 @@ class TestListNamespacesUnionDiscovery:
                 id="_meta",
                 kind="meta",
                 namespace="ns-meta-only",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_NAMESPACE_META_TYPE_17_7,
                 description="meta-only desc",
                 payload={

--- a/tests/v2/test_api_router_kind_crud_gating.py
+++ b/tests/v2/test_api_router_kind_crud_gating.py
@@ -388,7 +388,7 @@ class TestNamespaceRoutesUnaffected:
                 "src_namespace": "nope",
                 "src_id": "team",
                 "dst_namespace": "dst",
-                "dst_user_id": None,
+                "dst_user_id": "anonymous",
             },
         )
         # 404 from the service layer, not from the route being absent —

--- a/tests/v2/test_catalog_clone.py
+++ b/tests/v2/test_catalog_clone.py
@@ -79,7 +79,7 @@ def _register_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str, str]:
     )
 
 
-def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = None) -> None:
+def _seed_team(catalog: Catalog, namespace: str, user_id: str = "anonymous") -> None:
     """Seed a minimal team entry to satisfy the bootstrap invariant."""
     catalog.create(
         Entry(
@@ -99,7 +99,7 @@ def _seed_three_level_graph(
     leaf_type: str,
     sub_type: str,
     root_type: str,
-    user_id: str | None = None,
+    user_id: str = "anonymous",
 ) -> None:
     """Seed a 3-level ref graph: root→id_mgr→id_gpt_41 (leaf)."""
     _seed_team(catalog, namespace=namespace, user_id=user_id)
@@ -143,7 +143,7 @@ class TestCloneIdPolicy:
     ) -> None:
         catalog, _ = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
         _seed_team(catalog, namespace="dst-ns", user_id="alice")
         stored = catalog.clone(
             src_namespace="src-ns",
@@ -201,7 +201,7 @@ class TestCloneDeepCopy:
     ) -> None:
         catalog, repo = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
         _seed_team(catalog, namespace="dst-ns", user_id="alice")
         catalog.clone(
             src_namespace="src-ns",
@@ -225,7 +225,7 @@ class TestCloneDedup:
     ) -> None:
         catalog, repo = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_team(catalog, namespace="src-ns", user_id=None)
+        _seed_team(catalog, namespace="src-ns", user_id="anonymous")
         catalog.create(
             Entry(
                 id="id_gpt_41",
@@ -285,7 +285,7 @@ class TestCloneLineage:
     ) -> None:
         catalog, repo = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
         _seed_team(catalog, namespace="dst-ns", user_id="alice")
         catalog.clone(
             src_namespace="src-ns",
@@ -312,7 +312,7 @@ class TestCloneUserIdPropagation:
     ) -> None:
         catalog, repo = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
         _seed_team(catalog, namespace="dst-ns", user_id="alice")
         catalog.clone(
             src_namespace="src-ns",
@@ -330,18 +330,18 @@ class TestCloneUserIdPropagation:
     ) -> None:
         catalog, repo = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
-        _seed_team(catalog, namespace="dst-ns", user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
+        _seed_team(catalog, namespace="dst-ns", user_id="anonymous")
         catalog.clone(
             src_namespace="src-ns",
             src_id="root",
             dst_namespace="dst-ns",
-            dst_user_id=None,
+            dst_user_id="anonymous",
         )
         for eid in ("root", "id_mgr", "id_gpt_41"):
             entry = repo.get("dst-ns", eid)
             assert entry is not None
-            assert entry.user_id is None
+            assert entry.user_id == "anonymous"
 
 
 class TestCloneAtomicity:
@@ -419,7 +419,7 @@ class TestCloneSkipsPrepareForWrite:
     ) -> None:
         catalog, _ = catalog_factory()
         leaf, sub, root = _register_models(monkeypatch)
-        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id=None)
+        _seed_three_level_graph(catalog, "src-ns", leaf, sub, root, user_id="anonymous")
         _seed_team(catalog, namespace="dst-ns", user_id="alice")
 
         import akgentic.catalog.catalog as catalog_module
@@ -453,14 +453,14 @@ class TestCloneCrossNs:
         root_type: str,
     ) -> None:
         """Persist a team + a root entry whose payload carries a cross-ns ref."""
-        _seed_team(catalog, namespace=src_namespace, user_id=None)
+        _seed_team(catalog, namespace=src_namespace, user_id="anonymous")
         # Use a permissive root model — _RootModel.manager accepts any subkeys.
         catalog.create(
             Entry(
                 id="root",
                 kind="agent",
                 namespace=src_namespace,
-                user_id=None,
+                user_id="anonymous",
                 model_type=root_type,
                 payload={"manager": cross_ns_marker, "name": "root"},
             )
@@ -477,14 +477,14 @@ class TestCloneCrossNs:
         repo = YamlEntryRepository(tmp_path)
         catalog = Catalog(repo)
         # Seed the cross-ns target.
-        _seed_team(catalog, namespace="global", user_id=None)
+        _seed_team(catalog, namespace="global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -501,12 +501,12 @@ class TestCloneCrossNs:
             cross_ns_marker=cross_ns_marker,
             root_type=root,
         )
-        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        _seed_team(catalog, namespace="tenant-B", user_id="anonymous")
         cloned = catalog.clone(
             src_namespace="tenant-A",
             src_id="root",
             dst_namespace="tenant-B",
-            dst_user_id=None,
+            dst_user_id="anonymous",
         )
         # The cross-ns marker survives verbatim.
         marker = cloned.payload["manager"]["model_cfg"]
@@ -523,14 +523,14 @@ class TestCloneCrossNs:
         leaf, _sub, root = _register_models(monkeypatch)
         repo = YamlEntryRepository(tmp_path)
         catalog = Catalog(repo)
-        _seed_team(catalog, namespace="global", user_id=None)
+        _seed_team(catalog, namespace="global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -544,12 +544,12 @@ class TestCloneCrossNs:
             cross_ns_marker=cross_ns_marker,
             root_type=root,
         )
-        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        _seed_team(catalog, namespace="tenant-B", user_id="anonymous")
         cloned = catalog.clone(
             src_namespace="tenant-A",
             src_id="root",
             dst_namespace="tenant-B",
-            dst_user_id=None,
+            dst_user_id="anonymous",
         )
         # Shorthand survives verbatim — not rewritten.
         assert cloned.payload["manager"]["model_cfg"] == {"__ref__": "global.shared-prompt"}
@@ -565,27 +565,27 @@ class TestCloneCrossNs:
         catalog = Catalog(repo)
 
         # Seed global cross-ns target with a shareable meta entry.
-        _seed_team(catalog, namespace="global", user_id=None)
+        _seed_team(catalog, namespace="global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="global-leaf",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "global"},
             )
         )
 
         # Seed tenant-A: a local sub-entry + a root with a local ref + a cross-ns ref.
-        _seed_team(catalog, namespace="tenant-A", user_id=None)
+        _seed_team(catalog, namespace="tenant-A", user_id="anonymous")
         catalog.create(
             Entry(
                 id="local-sub",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=sub,
                 payload={"model_cfg": {"provider": "local"}},
             )
@@ -595,7 +595,7 @@ class TestCloneCrossNs:
                 id="root",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=root,
                 payload={
                     "manager": {"__ref__": "local-sub"},
@@ -608,12 +608,12 @@ class TestCloneCrossNs:
         )
 
         # Same-namespace clone: local-sub gets a numeric suffix; cross-ns survives.
-        _seed_team(catalog, namespace="tenant-B", user_id=None)
+        _seed_team(catalog, namespace="tenant-B", user_id="anonymous")
         cloned = catalog.clone(
             src_namespace="tenant-A",
             src_id="root",
             dst_namespace="tenant-B",
-            dst_user_id=None,
+            dst_user_id="anonymous",
         )
         # Cross-ns ref survives verbatim.
         assert cloned.payload["assistant"]["model_cfg"] == {"__ref__": "global.global-leaf"}

--- a/tests/v2/test_catalog_crud.py
+++ b/tests/v2/test_catalog_crud.py
@@ -58,7 +58,7 @@ def _team_payload() -> dict[str, Any]:
 def _seed_team(
     catalog: Catalog,
     namespace: str,
-    user_id: str | None = None,
+    user_id: str = "anonymous",
     team_id: str = "team",
 ) -> Entry:
     """Seed a team entry in ``namespace`` and return the persisted entry."""
@@ -290,7 +290,7 @@ _NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 def _seed_meta(
     catalog: Catalog,
     namespace: str,
-    user_id: str | None = "anonymous",
+    user_id: str = "anonymous",
 ) -> Entry:
     """Seed a meta entry in ``namespace`` and return the persisted entry."""
     return catalog.create(
@@ -309,9 +309,7 @@ def _seed_meta(
 class TestCreateInMetaOnlyNamespace:
     """Story 17.10 — meta entry bootstraps a namespace; ownership anchors on meta."""
 
-    def test_create_meta_in_fresh_namespace_succeeds(
-        self, catalog_factory: CatalogFactory
-    ) -> None:
+    def test_create_meta_in_fresh_namespace_succeeds(self, catalog_factory: CatalogFactory) -> None:
         """Create _meta in a fresh namespace — succeeds, user_id == "anonymous"."""
         catalog, _ = catalog_factory()
         meta = _seed_meta(catalog, "meta-only-ns", user_id="anonymous")
@@ -433,7 +431,7 @@ class TestCreateOwnership:
             id="assistant",
             kind="agent",
             namespace="ns-own",
-            user_id=None,
+            user_id="anonymous",
             model_type=agent_type,
             payload={},
         )
@@ -441,24 +439,24 @@ class TestCreateOwnership:
             catalog.create(agent)
         msg = str(exc.value)
         assert "alice" in msg
-        assert "None" in msg
+        assert "anonymous" in msg
 
     def test_enterprise_none_none_accepted(
         self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         catalog, _ = catalog_factory()
-        _seed_team(catalog, namespace="ns-ent", user_id=None)
+        _seed_team(catalog, namespace="ns-ent", user_id="anonymous")
         agent_type = _register_agent_model(monkeypatch)
         agent = Entry(
             id="assistant",
             kind="agent",
             namespace="ns-ent",
-            user_id=None,
+            user_id="anonymous",
             model_type=agent_type,
             payload={},
         )
         stored = catalog.create(agent)
-        assert stored.user_id is None
+        assert stored.user_id == "anonymous"
 
 
 # --- AC12 — prepare_for_write is invoked ---------------------------------------
@@ -503,14 +501,14 @@ class TestCreateRunsPrepareForWrite:
 
 
 class TestCreateTeamSkipsInvariants:
-    """AC13 — team entry in a fresh namespace with user_id=None is accepted."""
+    """AC13 — team entry in a fresh namespace with user_id="anonymous" is accepted."""
 
     def test_enterprise_team_in_fresh_namespace_accepted(
         self, catalog_factory: CatalogFactory
     ) -> None:
         catalog, repo = catalog_factory()
-        stored = _seed_team(catalog, namespace="fresh-ent", user_id=None)
-        assert stored.user_id is None
+        stored = _seed_team(catalog, namespace="fresh-ent", user_id="anonymous")
+        assert stored.user_id == "anonymous"
         assert repo.get("fresh-ent", stored.id) is not None
 
 
@@ -619,7 +617,7 @@ class TestDeleteInboundRefs:
         self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         catalog, _ = catalog_factory()
-        _seed_team(catalog, namespace="ns-del", user_id=None)
+        _seed_team(catalog, namespace="ns-del", user_id="anonymous")
         # Register agent and leaf models.
         agent_type = _register_agent_model(monkeypatch)
         leaf_type = _register_leaf_model(monkeypatch)
@@ -666,7 +664,7 @@ class TestDeleteClean:
 
     def test_delete_removes_entry(self, catalog_factory: CatalogFactory) -> None:
         catalog, repo = catalog_factory()
-        team = _seed_team(catalog, namespace="ns-clean", user_id=None)
+        team = _seed_team(catalog, namespace="ns-clean", user_id="anonymous")
         # The team entry has no inbound refs (no other entries exist).
         catalog.delete("ns-clean", team.id)
         assert repo.get("ns-clean", team.id) is None
@@ -679,7 +677,7 @@ def _seed_agent_with_lineage(
     catalog: Catalog,
     repo: EntryRepository,
     namespace: str,
-    user_id: str | None,
+    user_id: str,
     agent_type: str,
     parent_namespace: str | None,
     parent_id: str | None,
@@ -871,7 +869,7 @@ class TestUpdateLineageGuard:
 _NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 
 
-def _meta_entry(namespace: str, user_id: str | None, entry_id: str = "_meta") -> Entry:
+def _meta_entry(namespace: str, user_id: str, entry_id: str = "_meta") -> Entry:
     """Build a valid ``kind="meta"`` ``Entry`` for the singleton tests."""
     return Entry(
         id=entry_id,

--- a/tests/v2/test_catalog_delete_global.py
+++ b/tests/v2/test_catalog_delete_global.py
@@ -81,7 +81,7 @@ def _seed_team(catalog: Catalog, namespace: str) -> None:
             id="team",
             kind="team",
             namespace=namespace,
-            user_id=None,
+            user_id="anonymous",
             model_type=_TEAM_TYPE,
             payload=_team_payload(),
         )
@@ -109,7 +109,7 @@ class TestGlobalScopeBlocksDelete:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -121,7 +121,7 @@ class TestGlobalScopeBlocksDelete:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {
@@ -155,7 +155,7 @@ class TestNonShareableNamespaceShortCircuits:
                 id="leaf-1",
                 kind="prompt",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "x"},
             )
@@ -177,7 +177,7 @@ class TestNonShareableNamespaceShortCircuits:
                 id="leaf-1",
                 kind="prompt",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "x"},
             )
@@ -202,7 +202,7 @@ class TestNoMetaEntryByteIdentical:
                 id="leaf-1",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "x"},
             )

--- a/tests/v2/test_catalog_meta_only_namespace.py
+++ b/tests/v2/test_catalog_meta_only_namespace.py
@@ -19,7 +19,6 @@ from fastapi.testclient import TestClient  # noqa: E402
 from akgentic.catalog.catalog import Catalog  # noqa: E402
 from akgentic.catalog.models.entry import Entry  # noqa: E402
 
-
 _NAMESPACE_META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 
 
@@ -39,9 +38,7 @@ def _model_payload() -> dict[str, Any]:
 class TestMetaOnlyNamespaceEndToEnd:
     """Full lifecycle of a meta-only namespace through the REST API."""
 
-    def test_full_lifecycle_no_team(
-        self, api_client: tuple[TestClient, Catalog]
-    ) -> None:
+    def test_full_lifecycle_no_team(self, api_client: tuple[TestClient, Catalog]) -> None:
         """Create meta, create model entry, list, get, delete, export/import
         — all in a team-less namespace.
         """

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -74,7 +74,7 @@ def _register_agent_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
 def _seed_team(
     catalog: Catalog,
     namespace: str,
-    user_id: str | None = "alice",
+    user_id: str = "alice",
 ) -> Entry:
     return catalog.create(
         Entry(
@@ -92,7 +92,7 @@ def _seed_agent(
     catalog: Catalog,
     namespace: str,
     id: str,
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     payload: dict[str, Any] | None = None,
     model_type: str | None = None,
 ) -> Entry:
@@ -436,7 +436,7 @@ _NAMESPACE_META_TYPE_BUNDLE = "akgentic.catalog.models.namespace_meta.NamespaceM
 
 def _meta_entry_for_bundle(
     namespace: str,
-    user_id: str | None,
+    user_id: str,
     entry_id: str = "_meta",
     name: str = "primary",
 ) -> Entry:
@@ -525,14 +525,14 @@ class TestImportBundleCrossNs:
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, repo = catalog_factory()
         # Seed the global target + meta with shareable=true.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "shared"},
             )
@@ -542,7 +542,7 @@ class TestImportBundleCrossNs:
                 id="team",
                 kind="team",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_TEAM_TYPE,
                 payload=_team_payload(),
             ),
@@ -550,7 +550,7 @@ class TestImportBundleCrossNs:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={
                     "model_cfg": {
@@ -579,7 +579,7 @@ class TestImportBundleCrossNs:
                 id="team",
                 kind="team",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_TEAM_TYPE,
                 payload=_team_payload(),
             ),
@@ -587,7 +587,7 @@ class TestImportBundleCrossNs:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={"model_cfg": {"__ref__": "global.shared-prompt"}},
             ),
@@ -607,14 +607,14 @@ class TestImportBundleCrossNs:
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
         # Mark global shareable but seed no target id.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         bundle = [
             Entry(
                 id="team",
                 kind="team",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_TEAM_TYPE,
                 payload=_team_payload(),
             ),
@@ -622,7 +622,7 @@ class TestImportBundleCrossNs:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={"model_cfg": {"__ref__": "global.does-not-exist"}},
             ),
@@ -646,7 +646,7 @@ def _seed_meta(
     description: str = "primary tenant",
     properties: dict[str, str] | None = None,
     shareable: bool = False,
-    user_id: str | None = "alice",
+    user_id: str = "alice",
 ) -> Entry:
     """Create a `_meta` entry in ``namespace`` and return it.
 
@@ -794,7 +794,7 @@ class TestImportHeaderUpsert:
     def _build_bundle_with_header(
         self,
         namespace: str = "tenant-X",
-        user_id: str | None = "alice",
+        user_id: str = "alice",
         name: str = "Tenant X",
         description: str = "imported tenant",
         properties: dict[str, str] | None = None,
@@ -981,14 +981,14 @@ class TestExportExternalRefs:
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, _repo = catalog_factory()
         # Seed a shareable global namespace + a target.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared-model",
                 kind="model",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "shared", "temperature": 0.0},
             )
@@ -997,12 +997,12 @@ class TestExportExternalRefs:
         # _AgentPayloadModel shape (provider/temperature/model_cfg) so
         # prepare_for_write succeeds — the cross-ns walker reads `model_cfg`
         # as a dict and finds the marker.
-        _seed_team(catalog, "tenant-S", user_id=None)
+        _seed_team(catalog, "tenant-S", user_id="anonymous")
         _seed_agent(
             catalog,
             "tenant-S",
             "agent-1",
-            user_id=None,
+            user_id="anonymous",
             payload={
                 "provider": "openai",
                 "temperature": 0.0,
@@ -1024,13 +1024,13 @@ class TestExportExternalRefs:
         agent_type, leaf_type = _register_agent_models(monkeypatch)
         catalog, _ = catalog_factory()
         # Seed global with a target but NO shareable-flag.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(
             Entry(
                 id="hidden-model",
                 kind="model",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "hidden", "temperature": 0.0},
             )
@@ -1038,13 +1038,13 @@ class TestExportExternalRefs:
         # We cannot create a tenant entry with a cross-ns ref to a
         # non-shareable target through Catalog.create (the shareable-flag
         # gate rejects). Bypass by writing directly to the repo.
-        _seed_team(catalog, "tenant-N", user_id=None)
+        _seed_team(catalog, "tenant-N", user_id="anonymous")
         catalog._repository.put(
             Entry(
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-N",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={
                     "model_cfg": {"__ref__": "global.hidden-model"},
@@ -1064,16 +1064,16 @@ class TestExportExternalRefs:
         agent_type, _leaf = _register_agent_models(monkeypatch)
         catalog, _ = catalog_factory()
         # Mark global shareable but seed no target id.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         # Bypass the catalog gate by writing the bad ref directly.
-        _seed_team(catalog, "tenant-M", user_id=None)
+        _seed_team(catalog, "tenant-M", user_id="anonymous")
         catalog._repository.put(
             Entry(
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-M",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={
                     "model_cfg": {"__ref__": "global.does-not-exist"},
@@ -1222,14 +1222,14 @@ class TestSnapshotShape:
         # Build a representative namespace:
         # - 3 local kinds: team + agent + prompt (and meta hoisted to header).
         # - 2 external kinds: model + tool (in shared global namespace).
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="m1",
                 kind="model",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "openai", "temperature": 0.0},
             )
@@ -1239,27 +1239,27 @@ class TestSnapshotShape:
                 id="t1",
                 kind="tool",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "shared", "temperature": 0.0},
             )
         )
 
-        _seed_team(catalog, "tenant-Snap", user_id=None)
+        _seed_team(catalog, "tenant-Snap", user_id="anonymous")
         _seed_meta(
             catalog,
             "tenant-Snap",
             name="Snap Tenant",
             description="snap",
             shareable=False,
-            user_id=None,
+            user_id="anonymous",
         )
         catalog.create(
             Entry(
                 id="prompt-1",
                 kind="prompt",
                 namespace="tenant-Snap",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf_type,
                 payload={"provider": "p", "temperature": 0.0},
             )
@@ -1269,7 +1269,7 @@ class TestSnapshotShape:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-Snap",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={
                     "provider": "openai",
@@ -1285,7 +1285,7 @@ class TestSnapshotShape:
                 id="agent-2",
                 kind="agent",
                 namespace="tenant-Snap",
-                user_id=None,
+                user_id="anonymous",
                 model_type=agent_type,
                 payload={
                     "provider": "openai",
@@ -1404,3 +1404,79 @@ class TestMetaOnlyBundle:
         assert meta.user_id == "anonymous"
         payload = meta.payload if isinstance(meta.payload, dict) else {}
         assert payload.get("name") == "Meta Only Lib"
+
+
+# --- Story 18.1 — bundle wire-format with anonymous default ----------------------
+
+
+class TestAnonymousBundleWireShape:
+    """Story 18.1 / AC7 + AC11 — bundle export emits ``user_id: anonymous``;
+    bundle import accepts legacy ``user_id: null`` and rewrites to ``"anonymous"``.
+    """
+
+    def test_export_emits_anonymous_not_null(self, catalog_factory: CatalogFactory) -> None:
+        """Community-tier export of a default-owner namespace yields ``user_id: anonymous``."""
+        catalog, _ = catalog_factory()
+        ns = "anon-export"
+        catalog.create(
+            Entry(
+                id="t",
+                kind="team",
+                namespace=ns,
+                model_type=_TEAM_TYPE,
+                payload=_team_payload(),
+            )
+        )
+        yaml_text = catalog.export_namespace_yaml(ns)
+        assert "user_id: anonymous" in yaml_text
+        assert "user_id: null" not in yaml_text
+
+    def test_legacy_bundle_with_user_id_null_round_trips(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """A legacy bundle whose root ``user_id: null`` parses cleanly; resulting
+        entries all have ``user_id == "anonymous"``; re-export emits ``anonymous``.
+        """
+        catalog, _ = catalog_factory()
+        legacy_yaml = (
+            "namespace: legacy-anon\n"
+            "user_id: null\n"
+            "entries:\n"
+            "  t:\n"
+            "    kind: team\n"
+            f"    model_type: {_TEAM_TYPE}\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            f"      name: {_team_payload()['name']}\n"
+            f"      description: '{_team_payload()['description']}'\n"
+            f"      members: {_team_payload()['members']!r}\n"
+        )
+        # The rendered ``members`` list literal is invalid YAML for an empty
+        # list; simplify by hand-rolling a legacy bundle through dump_namespace
+        # with a None-user_id sentinel rewritten via a string substitution.
+        # Build the modern bundle then swap the root user_id back to null to
+        # simulate a pre-Story-18.1 export.
+        modern = dump_namespace(
+            [
+                Entry(
+                    id="t",
+                    kind="team",
+                    namespace="legacy-anon",
+                    user_id="anonymous",
+                    model_type=_TEAM_TYPE,
+                    payload=_team_payload(),
+                )
+            ]
+        )
+        legacy_yaml = modern.replace("user_id: anonymous", "user_id: null", 1)
+        imported = catalog.import_namespace_yaml(legacy_yaml)
+        # Every imported entry has user_id == "anonymous" — the legacy null was
+        # silently rewritten before any Entry was constructed.
+        assert all(e.user_id == "anonymous" for e in imported)
+        # Re-export the namespace and confirm the wire shape now uses
+        # ``anonymous`` (the catalog never writes ``null`` again).
+        re_exported = catalog.export_namespace_yaml("legacy-anon")
+        assert "user_id: anonymous" in re_exported
+        assert "user_id: null" not in re_exported

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -53,7 +53,7 @@ def _agent_payload(name: str = "a") -> dict[str, Any]:
     }
 
 
-def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = "alice") -> Entry:
+def _seed_team(catalog: Catalog, namespace: str, user_id: str = "alice") -> Entry:
     return catalog.create(
         Entry(
             id="team",
@@ -70,7 +70,7 @@ def _seed_agent(
     catalog: Catalog,
     namespace: str,
     id: str,
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     payload: dict[str, Any] | None = None,
 ) -> Entry:
     return catalog.create(
@@ -87,7 +87,7 @@ def _seed_agent(
 
 def _build_bundle_yaml(
     namespace: str,
-    user_id: str | None,
+    user_id: str,
     entries_map: dict[str, dict[str, Any]],
 ) -> str:
     doc = {"namespace": namespace, "user_id": user_id, "entries": entries_map}
@@ -96,7 +96,7 @@ def _build_bundle_yaml(
 
 def _default_bundle_yaml(
     namespace: str = "ns-b",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     agents: dict[str, dict[str, Any]] | None = None,
 ) -> str:
     entries_map: dict[str, dict[str, Any]] = {
@@ -338,14 +338,14 @@ class TestValidateNamespaceCrossNs:
     ) -> None:
         catalog, repo = catalog_factory()
         # Seed global target via shareable-flag-enabled global namespace.
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_AGENT_TYPE,
                 payload=_agent_payload("shared"),
             )
@@ -390,14 +390,14 @@ class TestValidateNamespaceCrossNs:
         missing from the bundle (regardless of shareable-flag state).
         """
         catalog, _repo = catalog_factory()
-        _seed_team(catalog, "global", user_id=None)
+        _seed_team(catalog, "global", user_id="anonymous")
         catalog.create(make_meta_entry("global", shareable=True))
         catalog.create(
             Entry(
                 id="shared",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=_AGENT_TYPE,
                 payload=_agent_payload("shared"),
             )

--- a/tests/v2/test_catalog_resolve.py
+++ b/tests/v2/test_catalog_resolve.py
@@ -97,7 +97,7 @@ def _register_models(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
     return f"{module_name}._LeafModel", f"{module_name}._ParentModel"
 
 
-def _seed_team(catalog: Catalog, namespace: str, user_id: str | None = None) -> Entry:
+def _seed_team(catalog: Catalog, namespace: str, user_id: str = "anonymous") -> Entry:
     """Seed a minimal team entry; return the stored Entry."""
     return catalog.create(
         Entry(
@@ -136,7 +136,7 @@ class TestResolve:
         self, catalog_factory: CatalogFactory, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         catalog, _ = catalog_factory()
-        _seed_team(catalog, namespace="ns-rr", user_id=None)
+        _seed_team(catalog, namespace="ns-rr", user_id="anonymous")
         leaf_type, parent_type = _register_models(monkeypatch)
         catalog.create(
             Entry(
@@ -199,7 +199,7 @@ class TestLoadTeamOneListCall:
         fake = FakeEntryRepository()
         counting = CountingEntryRepository(fake)
         catalog = Catalog(counting)
-        _seed_team(catalog, namespace="ns-lt", user_id=None)
+        _seed_team(catalog, namespace="ns-lt", user_id="anonymous")
         leaf_type, parent_type = _register_models(monkeypatch)
         # Add a sub-entry with a ref, so load_team's populate_refs would issue
         # a get() call if the in-memory wrapper were missing.

--- a/tests/v2/test_catalog_shared_flag_cache.py
+++ b/tests/v2/test_catalog_shared_flag_cache.py
@@ -71,7 +71,7 @@ def _seed_team(catalog: Catalog, namespace: str) -> None:
             id="team",
             kind="team",
             namespace=namespace,
-            user_id=None,
+            user_id="anonymous",
             model_type=_TEAM_TYPE,
             payload=_team_payload(),
         )
@@ -95,7 +95,7 @@ class TestShareableFlagCacheHit:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -106,7 +106,7 @@ class TestShareableFlagCacheHit:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {
@@ -143,7 +143,7 @@ class TestShareableFlagCacheInvalidation:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -154,7 +154,7 @@ class TestShareableFlagCacheInvalidation:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {
@@ -185,7 +185,7 @@ class TestShareableFlagCacheInvalidation:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -196,7 +196,7 @@ class TestShareableFlagCacheInvalidation:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {
@@ -226,7 +226,7 @@ class TestShareableFlagCacheInvalidation:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -260,7 +260,7 @@ class TestShareableFlagCacheInvalidation:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {
@@ -335,7 +335,7 @@ class TestShareableFlagStrictBoolSemantics:
                 id="_meta",
                 kind="meta",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
                 payload=meta_payload,
             )
@@ -345,7 +345,7 @@ class TestShareableFlagStrictBoolSemantics:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -357,7 +357,7 @@ class TestShareableFlagStrictBoolSemantics:
                     id="agent-1",
                     kind="agent",
                     namespace="tenant-A",
-                    user_id=None,
+                    user_id="anonymous",
                     model_type=holder,
                     payload={
                         "model_cfg": {
@@ -381,7 +381,7 @@ class TestShareableFlagStrictBoolSemantics:
                 id="shared-prompt",
                 kind="prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=leaf,
                 payload={"provider": "shared"},
             )
@@ -394,7 +394,7 @@ class TestShareableFlagStrictBoolSemantics:
                 id="agent-1",
                 kind="agent",
                 namespace="tenant-A",
-                user_id=None,
+                user_id="anonymous",
                 model_type=holder,
                 payload={
                     "model_cfg": {

--- a/tests/v2/test_cli_graph_schema.py
+++ b/tests/v2/test_cli_graph_schema.py
@@ -276,10 +276,16 @@ class TestCloneVerb:
         assert agent.parent_namespace == "ns-src"
         assert agent.parent_id == "agent-1"
 
-    def test_clone_empty_string_user_id_is_enterprise(
+    def test_clone_empty_string_user_id_rejected(
         self, runner: CliRunner, catalog_root: Path
     ) -> None:
-        """AC28 — empty-string dst-user-id sentinel becomes None in the persisted clone."""
+        """Story 18.1 / AC8 — the CLI no longer accepts the empty-string sentinel.
+
+        The empty string fails Pydantic's ``NonEmptyStr`` validation on
+        ``CloneRequest.dst_user_id``; the CLI exits with code 2 and prints a
+        clear validation error. To clone into a community-tier deployment
+        the caller passes ``"anonymous"`` (or omits the flag).
+        """
         result = runner.invoke(
             cli_main.app,
             _base_args(catalog_root)
@@ -297,9 +303,33 @@ class TestCloneVerb:
                 "",
             ],
         )
+        assert result.exit_code == 2
+        assert "validation error" in result.stderr
+
+    def test_clone_anonymous_user_id_is_community_tier(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        """Story 18.1 / AC8 — passing ``"anonymous"`` clones into the community-tier default."""
+        result = runner.invoke(
+            cli_main.app,
+            _base_args(catalog_root)
+            + [
+                "--format",
+                "json",
+                "clone",
+                "--src-namespace",
+                "ns-a",
+                "--src-id",
+                "agent-a",
+                "--dst-namespace",
+                "ns-ent",
+                "--dst-user-id",
+                "anonymous",
+            ],
+        )
         assert result.exit_code == 0, result.stderr
         payload = json.loads(result.stdout)
-        assert payload["user_id"] is None
+        assert payload["user_id"] == "anonymous"
 
     def test_clone_src_not_found(self, runner: CliRunner, catalog_root: Path) -> None:
         result = runner.invoke(
@@ -336,11 +366,18 @@ class TestCloneVerb:
         )
         assert result.exit_code == 2
 
-    def test_clone_missing_dst_user_id(self, runner: CliRunner, catalog_root: Path) -> None:
+    def test_clone_omitting_dst_user_id_defaults_to_anonymous(
+        self, runner: CliRunner, catalog_root: Path
+    ) -> None:
+        """Story 18.1 / AC8 — omitting ``--dst-user-id`` clones into the
+        community-tier default ``"anonymous"`` rather than rejecting the call.
+        """
         result = runner.invoke(
             cli_main.app,
             _base_args(catalog_root)
             + [
+                "--format",
+                "json",
                 "clone",
                 "--src-namespace",
                 "ns-a",
@@ -350,7 +387,9 @@ class TestCloneVerb:
                 "ns-b",
             ],
         )
-        assert result.exit_code == 2
+        assert result.exit_code == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["user_id"] == "anonymous"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/v2/test_entry.py
+++ b/tests/v2/test_entry.py
@@ -82,7 +82,7 @@ class TestEntryFields:
     @pytest.mark.parametrize(
         ("field_name", "expected_default"),
         [
-            ("user_id", None),
+            ("user_id", "anonymous"),
             ("parent_namespace", None),
             ("parent_id", None),
             ("description", ""),
@@ -194,3 +194,25 @@ class TestNamespaceDotForbidden:
         entry = make_entry(namespace="ok-ns", id="x.y.z")
         assert entry.id == "x.y.z"
         assert entry.namespace == "ok-ns"
+
+
+class TestUserIdAnonymousDefault:
+    """Story 18.1 / AC1 — ``Entry.user_id`` is required ``str`` defaulting to ``"anonymous"``."""
+
+    def test_user_id_default_is_anonymous(self) -> None:
+        entry = make_entry()
+        assert entry.user_id == "anonymous"
+
+    def test_user_id_none_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            make_entry(user_id=None)
+        assert "user_id" in str(exc_info.value)
+
+    def test_user_id_empty_string_rejected(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            make_entry(user_id="")
+        assert "user_id" in str(exc_info.value)
+
+    def test_user_id_real_value_preserved(self) -> None:
+        entry = make_entry(user_id="alice")
+        assert entry.user_id == "alice"

--- a/tests/v2/test_entry_repo_parity.py
+++ b/tests/v2/test_entry_repo_parity.py
@@ -177,7 +177,9 @@ class TestEntryRepositoryParity:
         backend.put(
             make_entry(id="alice", kind="agent", namespace="ns-1", user_id="alice", payload={})
         )
-        backend.put(make_entry(id="bob", kind="agent", namespace="ns-1", user_id=None, payload={}))
+        backend.put(
+            make_entry(id="bob", kind="agent", namespace="ns-1", user_id="anonymous", payload={})
+        )
 
         # user_id="alice" AND user_id_set=True → alice satisfies both.
         got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=True))

--- a/tests/v2/test_mongo_entry_repo.py
+++ b/tests/v2/test_mongo_entry_repo.py
@@ -111,7 +111,7 @@ class TestPutWrites:
         assert doc["namespace"] == "team-abc"
         assert doc["id"] == "assistant"
         assert doc["kind"] == "agent"
-        assert doc["user_id"] is None
+        assert doc["user_id"] == "anonymous"
         assert doc["parent_namespace"] is None
         assert doc["parent_id"] is None
         assert doc["model_type"] == "akgentic.core.agent_card.AgentCard"
@@ -338,7 +338,7 @@ class TestList:
                 id="bob",
                 kind="agent",
                 namespace="ns-1",
-                user_id=None,
+                user_id="anonymous",
                 description="second agent",
                 payload={},
             )
@@ -348,7 +348,7 @@ class TestList:
                 id="hammer",
                 kind="tool",
                 namespace="ns-1",
-                user_id=None,
+                user_id="anonymous",
                 description="a tool for striking",
                 payload={},
             )
@@ -406,9 +406,9 @@ class TestList:
         repo = self._seed(entries_collection)
         # None = no filter — all 4 entries.
         assert len(repo.list(EntryQuery(user_id_set=None))) == 4
-        # True = user_id set — alice, carol.
+        # True = user_id != "anonymous" — alice, carol.
         assert {e.id for e in repo.list(EntryQuery(user_id_set=True))} == {"alice", "carol"}
-        # False = user_id is None — bob, hammer.
+        # False = user_id == "anonymous" — bob, hammer.
         assert {e.id for e in repo.list(EntryQuery(user_id_set=False))} == {"bob", "hammer"}
 
     def test_list_filters_by_parent_namespace_and_id(
@@ -471,7 +471,7 @@ class TestList:
         got = repo.list(
             EntryQuery(namespace="ns-1", kind="agent", user_id_set=False),
         )
-        # ns-1 AND agent AND user_id=None → only bob.
+        # ns-1 AND agent AND user_id="anonymous" → only bob.
         assert [e.id for e in got] == ["bob"]
 
     def test_list_user_id_and_user_id_set_combine_with_and(
@@ -804,3 +804,20 @@ class TestMetaEntryRoundTrip:
         rows = repo.list_by_namespace("tenant-42")
         assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
         assert repo.get_by_kind("tenant-42", "meta") == meta
+
+
+class TestUserIdAnonymousPersistedShape:
+    """Story 18.1 / AC5 — entries with the default ``user_id`` persist as a
+    BSON string ``"anonymous"`` (not BSON null) in the Mongo document.
+    """
+
+    def test_default_user_id_writes_anonymous_to_mongo_document(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        repo = MongoEntryRepository(entries_collection)
+        repo.put(make_entry(id="e1", kind="tool", namespace="ns-anon"))
+        doc = entries_collection.find_one({"_id": {"namespace": "ns-anon", "id": "e1"}})
+        assert doc is not None
+        assert doc["user_id"] == "anonymous"
+        assert isinstance(doc["user_id"], str)

--- a/tests/v2/test_queries.py
+++ b/tests/v2/test_queries.py
@@ -63,7 +63,7 @@ class TestCloneRequestImport:
         assert req.src_namespace == "ns-a"
         assert req.src_id == "entry-1"
         assert req.dst_namespace == "ns-b"
-        assert req.dst_user_id is None
+        assert req.dst_user_id == "anonymous"
 
     def test_dst_user_id_accepts_value(self) -> None:
         req = CloneRequest(

--- a/tests/v2/test_resolver_cross_ns.py
+++ b/tests/v2/test_resolver_cross_ns.py
@@ -450,7 +450,7 @@ class TestCrossNamespaceOwnershipGate:
                 is_namespace_shareable=_shareable_set("global"),
             )
         msg = exc_info.value.errors[0]
-        assert "only globally-scoped entries (user_id=None)" in msg
+        assert "only globally-scoped entries (user_id='anonymous')" in msg
         assert "global.user-p" in msg
 
     def test_global_target_accepted(self, coord_module: str) -> None:
@@ -459,7 +459,7 @@ class TestCrossNamespaceOwnershipGate:
             make_entry(
                 id="global-p",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=f"{coord_module}.Coord",
                 payload={"text": "shared"},
             )

--- a/tests/v2/test_resolver_sibling_overrides.py
+++ b/tests/v2/test_resolver_sibling_overrides.py
@@ -611,7 +611,7 @@ class TestCrossNamespaceSiblingOverrides:
             make_entry(
                 id="shared-prompt",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=f"{module_name}.Target",
                 payload={"role": "Helper", "tone": "calm"},
             )
@@ -643,7 +643,7 @@ class TestCrossNamespaceSiblingOverrides:
             make_entry(
                 id="shared",
                 namespace="global",
-                user_id=None,
+                user_id="anonymous",
                 model_type=f"{module_name}.Target",
                 payload={"x": 1},
             )

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -25,7 +25,7 @@ _MODEL_TYPE = "akgentic.llm.model_config.ModelConfig"
 _META_TYPE = "akgentic.catalog.models.namespace_meta.NamespaceMeta"
 
 
-def _team(namespace: str = "ns-1", user_id: str | None = "alice") -> Entry:
+def _team(namespace: str = "ns-1", user_id: str = "alice") -> Entry:
     return Entry(
         id="team",
         kind="team",
@@ -39,7 +39,7 @@ def _team(namespace: str = "ns-1", user_id: str | None = "alice") -> Entry:
 def _agent(
     id: str,
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     payload: dict[str, Any] | None = None,
 ) -> Entry:
     return Entry(
@@ -55,7 +55,7 @@ def _agent(
 def _prompt(
     id: str,
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
 ) -> Entry:
     return Entry(
         id=id,
@@ -70,7 +70,7 @@ def _prompt(
 def _tool(
     id: str,
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
 ) -> Entry:
     return Entry(
         id=id,
@@ -85,7 +85,7 @@ def _tool(
 def _model(
     id: str,
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
 ) -> Entry:
     return Entry(
         id=id,
@@ -99,7 +99,7 @@ def _model(
 
 def _meta(
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     entry_id: str = "_meta",
     name: str = "Tenant",
     description: str = "primary tenant",
@@ -146,11 +146,14 @@ class TestDumpNamespace:
         assert doc["namespace"] == "ns-1"
         assert doc["user_id"] == "alice"
 
-    def test_enterprise_user_id_is_null(self) -> None:
-        text = dump_namespace([_team(user_id=None), _agent("a", user_id=None)])
+    def test_community_tier_user_id_is_anonymous(self) -> None:
+        # Story 18.1 — community-tier exports emit ``user_id: anonymous``
+        # (not ``null``). The catalog never writes ``user_id: null`` again.
+        text = dump_namespace([_team(user_id="anonymous"), _agent("a", user_id="anonymous")])
         doc = yaml.safe_load(text)
-        assert doc["user_id"] is None
-        assert "user_id: null" in text
+        assert doc["user_id"] == "anonymous"
+        assert "user_id: anonymous" in text
+        assert "user_id: null" not in text
 
     def test_entry_keys_and_order(self) -> None:
         text = dump_namespace([_team(), _agent("a")])
@@ -201,9 +204,7 @@ class TestDumpNamespace:
     def test_rejects_empty_list(self) -> None:
         with pytest.raises(CatalogValidationError) as exc_info:
             dump_namespace([])
-        assert exc_info.value.errors == [
-            "bundle must declare at least one entry"
-        ]
+        assert exc_info.value.errors == ["bundle must declare at least one entry"]
 
     def test_rejects_mismatched_user_id(self) -> None:
         entries = [
@@ -260,9 +261,7 @@ class TestLoadNamespace:
         text = "namespace: ns-1\nuser_id: alice\nentries: {}\n"
         with pytest.raises(CatalogValidationError) as exc_info:
             load_namespace(text)
-        assert exc_info.value.errors == [
-            "bundle must declare at least one entry"
-        ]
+        assert exc_info.value.errors == ["bundle must declare at least one entry"]
 
     def test_rejects_entries_as_list_with_explicit_message(self) -> None:
         """Story 17.6 — the rejected 17.5 wire shape (list-of-items) raises explicitly."""
@@ -459,8 +458,14 @@ class TestSectionHeadersAndSpacing:
         parsed_doc = yaml.safe_load(text)
         assert set(parsed_doc["entries"].keys()) == {e.id for e in entries}
 
-    def test_round_trip_enterprise_bundle(self) -> None:
-        entries = [_team(user_id=None), _agent("a1", user_id=None), _prompt("p1", user_id=None)]
+    def test_round_trip_anonymous_bundle(self) -> None:
+        # Story 18.1 — community-tier exports carry ``user_id: anonymous`` at
+        # the bundle root; round-trip preserves it.
+        entries = [
+            _team(user_id="anonymous"),
+            _agent("a1", user_id="anonymous"),
+            _prompt("p1", user_id="anonymous"),
+        ]
         text = dump_namespace(entries)
         recovered, _header = load_namespace(text)
         sort_key = lambda e: (e.kind, e.id)  # noqa: E731
@@ -468,7 +473,7 @@ class TestSectionHeadersAndSpacing:
             e.model_dump() for e in sorted(entries, key=sort_key)
         ]
         doc = yaml.safe_load(text)
-        assert doc["user_id"] is None
+        assert doc["user_id"] == "anonymous"
 
 
 # --- Story 17.2 — meta entry emit order via legacy dump (no header trio) -----
@@ -610,8 +615,8 @@ class TestDumpExternalSections:
 
     def test_external_section_uses_composite_keys(self) -> None:
         external = [
-            _model("id_gpt_41", namespace="global", user_id=None),
-            _model("id_gpt_52", namespace="global", user_id=None),
+            _model("id_gpt_41", namespace="global", user_id="anonymous"),
+            _model("id_gpt_52", namespace="global", user_id="anonymous"),
         ]
         text = dump_namespace(
             [_team(), _agent("a")],
@@ -624,7 +629,7 @@ class TestDumpExternalSections:
         assert "global.id_gpt_52" in doc["entries"]
 
     def test_external_section_header_emitted(self) -> None:
-        external = [_model("m1", namespace="global", user_id=None)]
+        external = [_model("m1", namespace="global", user_id="anonymous")]
         text = dump_namespace([_team()], name="X", external_refs=external)
         # The External-ref Models header appears.
         assert _EXTERNAL_KIND_HEADERS["model"] in text
@@ -632,11 +637,11 @@ class TestDumpExternalSections:
     def test_external_kinds_in_pre_175_order(self) -> None:
         """AC5 — external sections emit team → agent → prompt → tool → model."""
         external = [
-            _model("m1", namespace="global", user_id=None),
-            _tool("t1", namespace="global", user_id=None),
-            _agent("ext_a", namespace="global", user_id=None),
-            _prompt("p1", namespace="global", user_id=None),
-            _team(namespace="global", user_id=None),
+            _model("m1", namespace="global", user_id="anonymous"),
+            _tool("t1", namespace="global", user_id="anonymous"),
+            _agent("ext_a", namespace="global", user_id="anonymous"),
+            _prompt("p1", namespace="global", user_id="anonymous"),
+            _team(namespace="global", user_id="anonymous"),
         ]
         text = dump_namespace([_team()], name="X", external_refs=external)
         ext_team_pos = text.index(_EXTERNAL_KIND_HEADERS["team"])
@@ -649,10 +654,10 @@ class TestDumpExternalSections:
     def test_external_entries_sorted_by_namespace_then_id(self) -> None:
         """AC7 — within an external section, sort by (namespace, id) ascending."""
         external = [
-            _model("zeta", namespace="bbb", user_id=None),
-            _model("alpha", namespace="aaa", user_id=None),
-            _model("alpha", namespace="bbb", user_id=None),
-            _model("zeta", namespace="aaa", user_id=None),
+            _model("zeta", namespace="bbb", user_id="anonymous"),
+            _model("alpha", namespace="aaa", user_id="anonymous"),
+            _model("alpha", namespace="bbb", user_id="anonymous"),
+            _model("zeta", namespace="aaa", user_id="anonymous"),
         ]
         text = dump_namespace([_team()], name="X", external_refs=external)
         doc = yaml.safe_load(text)
@@ -662,7 +667,7 @@ class TestDumpExternalSections:
 
     def test_external_section_header_preceded_by_blank_line(self) -> None:
         """AC5 — every section header is surrounded by a blank line above and below."""
-        external = [_model("m1", namespace="global", user_id=None)]
+        external = [_model("m1", namespace="global", user_id="anonymous")]
         text = dump_namespace([_team()], name="X", external_refs=external)
         header = _EXTERNAL_KIND_HEADERS["model"]
         idx = text.index(header)
@@ -680,7 +685,7 @@ class TestDumpExternalSections:
         text = dump_namespace(
             [_team()],
             name="X",
-            external_refs=[_model("m1", namespace="global", user_id=None)],
+            external_refs=[_model("m1", namespace="global", user_id="anonymous")],
         )
         # The local Teams header appears BEFORE the external Models header.
         teams_pos = text.index(_KIND_HEADERS["team"])
@@ -787,7 +792,7 @@ class TestRoundTripNewShape:
 
     def test_byte_identical_two_consecutive_dumps(self) -> None:
         # Story 17.7 — `properties` is fully free-form `str -> str`.
-        external = [_model("id_gpt_41", namespace="global", user_id=None)]
+        external = [_model("id_gpt_41", namespace="global", user_id="anonymous")]
         text_a = dump_namespace(
             [_team(), _agent("a"), _prompt("p1")],
             name="Tenant",
@@ -813,7 +818,7 @@ class TestRoundTripNewShape:
         round-trips its LOCAL entries verbatim; externals are display
         projection only.
         """
-        external = [_model("ext", namespace="global", user_id=None)]
+        external = [_model("ext", namespace="global", user_id="anonymous")]
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant",

--- a/tests/v2/test_validate_delete.py
+++ b/tests/v2/test_validate_delete.py
@@ -89,9 +89,11 @@ class TestUniformRule:
     """AC29 — no branching on ``user_id``, ``parent_namespace``, or ``kind``."""
 
     def test_enterprise_target_with_user_inbound_blocks(self) -> None:
-        """Enterprise entry (user_id=None) with a user-owned inbound ref is blocked."""
+        """Enterprise entry (user_id="anonymous") with a user-owned inbound ref is blocked."""
         repo = FakeEntryRepository()
-        repo.put(make_entry(id="target", namespace="ns-shared", user_id=None, payload={"v": 1}))
+        repo.put(
+            make_entry(id="target", namespace="ns-shared", user_id="anonymous", payload={"v": 1})
+        )
         repo.put(
             make_entry(
                 id="user-ref",

--- a/tests/v2/test_validation.py
+++ b/tests/v2/test_validation.py
@@ -118,7 +118,7 @@ class SpyRepository:
         return sum(1 for name, _ in self.calls if name == method_name)
 
 
-def _seed_team(namespace: str = "ns-1", user_id: str | None = "alice") -> Entry:
+def _seed_team(namespace: str = "ns-1", user_id: str = "alice") -> Entry:
     return make_entry(
         id="team",
         kind="team",
@@ -132,7 +132,7 @@ def _seed_team(namespace: str = "ns-1", user_id: str | None = "alice") -> Entry:
 def _seed_agent(
     id: str = "agent-a",
     namespace: str = "ns-1",
-    user_id: str | None = "alice",
+    user_id: str = "alice",
     payload: dict[str, Any] | None = None,
 ) -> Entry:
     return make_entry(

--- a/tests/v2/test_yaml_entry_repo.py
+++ b/tests/v2/test_yaml_entry_repo.py
@@ -227,7 +227,7 @@ class TestList:
                 namespace="ns-a",
                 id="a2",
                 kind="tool",
-                user_id=None,
+                user_id="anonymous",
                 description="alpha two",
             )
         )
@@ -679,3 +679,18 @@ class TestMetaEntryRoundTrip:
         rows = repo.list_by_namespace("tenant-42")
         assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
         assert repo.get_by_kind("tenant-42", "meta") == meta
+
+
+class TestUserIdAnonymousPersistedShape:
+    """Story 18.1 / AC4 — entries with the default ``user_id`` persist as
+    ``user_id: anonymous`` (a bare string), not ``null`` or ``~``.
+    """
+
+    def test_default_user_id_writes_anonymous_to_yaml_file(self, tmp_path: Path) -> None:
+        repo = YamlEntryRepository(tmp_path)
+        repo.put(make_entry(id="e1", kind="tool", namespace="ns-anon"))
+        path = tmp_path / "ns-anon" / "tool" / "e1.yaml"
+        text = path.read_text(encoding="utf-8")
+        assert "user_id: anonymous" in text
+        assert "user_id: null" not in text
+        assert "user_id: ~" not in text


### PR DESCRIPTION
## Summary

Story 18.1 — foundational story of Epic 18 (visibility / ownership decoupling).

Tightens `Entry.user_id` from `NonEmptyStr | None` (default `None`) to `NonEmptyStr` (default `"anonymous"`). The literal `"anonymous"` is the community-tier convention — every entry has a real owner identity, never null. `EntryQuery.user_id_set` semantics shift from `None`-compare to `"anonymous"`-compare while the tri-state shape is preserved.

### Changes

- **Models** — `Entry.user_id`, `CloneRequest.dst_user_id` tightened to `NonEmptyStr` with `"anonymous"` default. `EntryQuery.user_id_set` docstring rewritten.
- **Repositories** — YAML / Mongo / Postgres `_apply_user_id_clauses` swap `IS NULL` / `IS NOT NULL` / BSON-null for equality against the literal string `"anonymous"`. The Postgres column-level NULL constraint is preserved at the schema layer (operational, deferred).
- **Bundle export** — emits `user_id: anonymous` instead of `user_id: null`. Bundle import accepts legacy `user_id: null` and silently rewrites it to `"anonymous"` (one-way migration; the catalog never writes null again).
- **Catalog / API / CLI** — `Catalog.clone(dst_user_id=...)` signature tightens. The CLI `--dst-user-id` flag drops the empty-string-as-null shorthand. `put_namespace_meta` local typing tightens.
- **Tests** — every fixture / inline `Entry(...)` using `user_id=None` migrated to `user_id="anonymous"`. New model-tightening, legacy-bundle round-trip, and per-repository default-value tests added. 985 tests pass; 24 postgres-testcontainer skips run in CI.
- **Architecture shards 03 / 05 / 06** — updated to reflect the new declaration, `EntryQuery.user_id_set` bullets, and cross-ns ownership-gate comparison value. ADR-008 / ADR-009 untouched (per epic sequencing).

### Code review (Rex)

Two fixes applied during review:

| Severity | Issue | Fix |
|---|---|---|
| HIGH | Original commit message contained a planning-doc identifier reference (Golden Rule 8 forbids it in commit messages). | Commit message rewritten; no content change. |
| MEDIUM | `MongoEntryRepository._build_filter` class docstring still described `user_id_set` as `True = user_id != null` / `False = user_id is null` — a missed sweep relative to AC5 (the neighbouring `_apply_user_id_clauses` was already correct). | Docstring aligned to the new `"anonymous"`-compare semantics. |

### Quality gates

- `ruff check` — pass
- `ruff format --check` — pass
- `mypy --strict` — pass
- `pytest packages/akgentic-catalog/tests/` — 985 passed, 24 skipped (postgres testcontainer)
- Coverage: 91.28% (gate 80%)
- Submodule CI green on the head commit.

Closes #178
