### PR TITLE
Add NamespaceMeta.public bool visibility flag

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -74,7 +74,7 @@ class NamespaceSummary(BaseModel):
     ``user_id``, ``parent_namespace``, and other entry-model fields to keep
     the payload minimal and to avoid leaking tenancy design to the picker.
 
-    Five pinned fields in declaration order:
+    Six pinned fields in declaration order:
 
     * ``namespace`` — the namespace identifier.
     * ``name`` — the display name (meta-then-team fallback).
@@ -86,6 +86,11 @@ class NamespaceSummary(BaseModel):
     * ``shareable`` — ``True`` iff a ``kind="meta"`` entry exists AND its
       ``payload["shareable"] is True`` (typed bool at the root, strict-bool
       comparison — ADR-008 §D2 as updated 2026-05-08 rev 2).
+    * ``public`` — ``True`` iff a ``kind="meta"`` entry exists AND its
+      ``payload["public"] is True`` (typed bool at the root, strict-bool
+      comparison — ADR-009 §D2). Visibility filtering at the catalog
+      list/get/search/clone boundary lands in Story 18.4; the picker
+      surfaces the flag so frontends can render a "public library" badge.
     """
 
     namespace: str
@@ -93,6 +98,7 @@ class NamespaceSummary(BaseModel):
     description: str
     team: bool
     shareable: bool
+    public: bool
 
 
 logger = logging.getLogger(__name__)
@@ -245,6 +251,9 @@ async def list_namespaces() -> list[NamespaceSummary]:
     * ``shareable`` — ``True`` iff a meta entry was found AND
       ``meta.payload.get("shareable") is True`` (typed-bool, strict
       comparison).
+    * ``public`` — ``True`` iff a meta entry was found AND
+      ``meta.payload.get("public") is True`` (typed-bool, strict
+      comparison — ADR-009 §D2).
     """
     logger.debug("GET /catalog/namespaces")
     catalog = _get_catalog()
@@ -265,7 +274,7 @@ def _build_namespace_summary(
 
     Performs NO repository I/O — both entries are passed in from the
     union-discovery query already issued by :func:`list_namespaces`. The
-    helper applies the four projection rules:
+    helper applies the five projection rules:
 
     * ``name`` — two-rung chain: ``meta.payload["name"]`` if a meta entry
       is present AND its ``name`` is a non-empty string; else the
@@ -283,6 +292,9 @@ def _build_namespace_summary(
     * ``shareable`` — ``True`` iff a meta entry exists AND its
       ``payload.get("shareable") is True`` (strict-bool, no truthy-string
       coercion).
+    * ``public`` — ``True`` iff a meta entry exists AND its
+      ``payload.get("public") is True`` (strict-bool, no truthy-string
+      coercion — ADR-009 §D2).
     """
     description = ""
     if team is not None:
@@ -290,6 +302,7 @@ def _build_namespace_summary(
 
     name = namespace
     shareable = False
+    public = False
     if meta is not None:
         meta_payload = meta.payload if isinstance(meta.payload, dict) else {}
         meta_name = meta_payload.get("name")
@@ -297,6 +310,7 @@ def _build_namespace_summary(
             name = meta_name
         description = meta.description
         shareable = meta_payload.get("shareable") is True
+        public = meta_payload.get("public") is True
 
     return NamespaceSummary(
         namespace=namespace,
@@ -304,6 +318,7 @@ def _build_namespace_summary(
         description=description,
         team=team is not None,
         shareable=shareable,
+        public=public,
     )
 
 

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -526,7 +526,9 @@ class Catalog:
         """
         entries = self._repository.list_by_namespace(namespace)
         meta_entry, local_entries = _partition_meta(entries)
-        name, description, properties, shareable = self._project_header(meta_entry, local_entries)
+        name, description, properties, shareable, public = self._project_header(
+            meta_entry, local_entries
+        )
         external_refs = self._collect_external_refs(local_entries)
         return dump_namespace(
             local_entries,
@@ -534,6 +536,7 @@ class Catalog:
             description=description,
             properties=properties,
             shareable=shareable,
+            public=public,
             external_refs=external_refs,
         )
 
@@ -541,8 +544,10 @@ class Catalog:
         self,
         meta_entry: Entry | None,
         local_entries: _list[Entry],
-    ) -> tuple[str, str, dict[str, str], bool]:
-        """Project ``name`` / ``description`` / ``properties`` / ``shareable`` for header.
+    ) -> tuple[str, str, dict[str, str], bool, bool]:
+        """Project the header trio + flags for ``dump_namespace``.
+
+        Returns ``(name, description, properties, shareable, public)``.
 
         When ``meta_entry`` is present, read from its payload. When the
         meta's ``payload.name`` is empty / missing, fall back to the team
@@ -555,8 +560,13 @@ class Catalog:
         comparison; ``False`` when the key is missing or non-bool. When
         ``meta_entry`` is absent, ``shareable`` defaults to ``False``.
 
+        Story 18.2 — ``public`` is read from
+        ``meta_entry.payload.get("public")`` with strict-bool ``is True``
+        comparison; ``False`` when the key is missing or non-bool. When
+        ``meta_entry`` is absent, ``public`` defaults to ``False`` (ADR-009 §D2).
+
         When ``meta_entry`` is absent, fall back fully to the team:
-        ``(team.payload.get("name", ""), team.description, {}, False)``.
+        ``(team.payload.get("name", ""), team.description, {}, False, False)``.
         When the team entry is also absent (defensive — should not happen
         in practice because the catalog service enforces a team-bootstrap
         invariant), return empty defaults.
@@ -567,8 +577,8 @@ class Catalog:
                 entry is located inside this list.
 
         Returns:
-            ``(name, description, properties, shareable)`` 4-tuple — the
-            header projection ready to pass to :func:`dump_namespace`.
+            ``(name, description, properties, shareable, public)`` 5-tuple —
+            the header projection ready to pass to :func:`dump_namespace`.
         """
         team_entry = next((e for e in local_entries if e.kind == "team"), None)
         team_name = ""
@@ -580,7 +590,7 @@ class Catalog:
             team_description = team_entry.description
 
         if meta_entry is None:
-            return team_name, team_description, {}, False
+            return team_name, team_description, {}, False, False
 
         payload = meta_entry.payload if isinstance(meta_entry.payload, dict) else {}
         meta_name = payload.get("name", "")
@@ -597,9 +607,10 @@ class Catalog:
             }
         # Strict-bool projection — only a real ``True`` flips the flag.
         meta_shareable = payload.get("shareable") is True
+        meta_public = payload.get("public") is True
         # Empty-meta-name graceful degradation — team-fallback for name only.
         name = meta_name if meta_name else team_name
-        return name, meta_description, meta_properties, meta_shareable
+        return name, meta_description, meta_properties, meta_shareable, meta_public
 
     def _collect_external_refs(self, entries: _list[Entry]) -> _list[Entry]:
         """Return the deduplicated, shareable-flag-filtered, transitively-reached cross-ns targets.
@@ -809,6 +820,7 @@ class Catalog:
                 description=header.description,
                 properties=dict(header.properties),
                 shareable=header.shareable,
+                public=header.public,
             ).model_dump()
         except ValueError as exc:
             raise CatalogValidationError([f"bundle header is invalid: {exc}"]) from exc

--- a/src/akgentic/catalog/models/namespace_meta.py
+++ b/src/akgentic/catalog/models/namespace_meta.py
@@ -2,10 +2,11 @@
 
 This module exposes a single Pydantic ``BaseModel`` (:class:`NamespaceMeta`)
 used as the payload-validation class for the ``kind="meta"`` catalog entry
-introduced by ADR-008 §D1. The model carries four pinned fields — ``name``,
-``description``, a free-form ``properties`` map, and a typed ``shareable``
-boolean — so the namespace picker reads tenant-level metadata from a stable,
-purpose-built shape instead of leaking ``TeamCard``'s schema.
+introduced by ADR-008 §D1. The model carries five pinned fields — ``name``,
+``description``, a free-form ``properties`` map, a typed ``shareable``
+boolean, and a typed ``public`` boolean — so the namespace picker reads
+tenant-level metadata from a stable, purpose-built shape instead of leaking
+``TeamCard``'s schema.
 
 Key exports:
 
@@ -31,7 +32,7 @@ __all__ = ["NamespaceMeta"]
 class NamespaceMeta(BaseModel):
     """Payload model for the per-namespace metadata entry (``kind="meta"``).
 
-    Four pinned fields, in declaration order:
+    Five pinned fields, in declaration order:
 
     * ``name`` — required non-empty display name for the namespace; surfaced
       by ``GET /catalog/namespaces`` to feed the picker.
@@ -49,6 +50,16 @@ class NamespaceMeta(BaseModel):
       ``user_id == "anonymous"`` ownership gate). When ``False`` (the default), the
       namespace is not shareable. Pydantic strict-mode rejects non-bool
       inputs so operators must opt in unambiguously with a real boolean.
+    * ``public`` — typed boolean controlling namespace visibility (ADR-009
+      §D2). When ``True``, non-owner users may list, read, and clone entries
+      in this namespace; when ``False`` (the default), the namespace is
+      tenant-private. Orthogonal to ``shareable``: their cartesian product
+      yields the four named visibility states (tenant-private, forkable
+      library, private shared backbone, public library). Strict-bool —
+      non-bool inputs (e.g. the string ``"true"``) are rejected by Pydantic
+      at construction time. Visibility filtering on ``Catalog.list`` /
+      ``get`` / ``search`` / ``clone`` lands in Story 18.4; in 18.2 the
+      flag is purely declarative.
 
     Convention id is ``"_meta"``; the route fallback in
     ``GET /catalog/namespaces`` reads ``payload["name"]`` /
@@ -89,5 +100,18 @@ class NamespaceMeta(BaseModel):
             '— non-bool inputs (e.g. the string ``"true"``) are rejected by '
             "Pydantic at construction time. ADR-008 §D2 as updated "
             "2026-05-08 (rev 2)."
+        ),
+    )
+    public: bool = Field(
+        default=False,
+        description=(
+            "When True, non-owner users may list, read, and clone entries in "
+            "this namespace; when False (the default), the namespace is "
+            "tenant-private. Orthogonal to ``shareable`` (which controls "
+            "cross-namespace reference eligibility). Strict-bool — non-bool "
+            'inputs (e.g. the string ``"true"``) are rejected by Pydantic at '
+            "construction time. Visibility filtering at the Catalog "
+            "list/get/search/clone boundary is introduced by Story 18.4; "
+            "in Story 18.2 the flag is purely declarative. ADR-009 §D2."
         ),
     )

--- a/src/akgentic/catalog/serialization.py
+++ b/src/akgentic/catalog/serialization.py
@@ -52,16 +52,17 @@ logger = logging.getLogger(__name__)
 class BundleHeader:
     """Parsed top-level header fields for an export bundle.
 
-    Story 17.7 — fourth field ``shareable: bool`` added after ``properties``
-    to mirror :class:`~akgentic.catalog.models.namespace_meta.NamespaceMeta`'s
-    declaration order. Bundles produced by 17.7+ exports always carry
-    ``shareable`` at the top level (alongside ``name`` / ``description`` /
-    ``properties``); legacy export bundles (pre-17.7 — no ``shareable``)
-    project to ``shareable=False`` (default).
+    Story 17.7 added the fourth field ``shareable: bool`` after ``properties``;
+    Story 18.2 adds the fifth field ``public: bool`` after ``shareable`` to
+    mirror :class:`~akgentic.catalog.models.namespace_meta.NamespaceMeta`'s
+    declaration order. Bundles produced by 18.2+ exports always carry
+    ``public`` at the top level (alongside ``name`` / ``description`` /
+    ``properties`` / ``shareable``); legacy export bundles (pre-18.2 — no
+    ``public``) project to ``public=False`` (default).
 
     ``present`` is ``True`` iff at least one of ``name`` / ``description`` /
-    ``properties`` / ``shareable`` was explicitly set in the source YAML.
-    Pre-17.5 bundles (no header fields at all) parse to
+    ``properties`` / ``shareable`` / ``public`` was explicitly set in the
+    source YAML. Pre-17.5 bundles (no header fields at all) parse to
     ``BundleHeader(present=False, ...)`` so the import handler can skip the
     meta-upsert step (AC11 / AC12).
     """
@@ -70,6 +71,7 @@ class BundleHeader:
     description: str = ""
     properties: dict[str, str] = field(default_factory=dict)
     shareable: bool = False
+    public: bool = False
     present: bool = False
 
 
@@ -139,20 +141,22 @@ def dump_namespace(
     description: str = "",
     properties: dict[str, str] | None = None,
     shareable: bool = False,
+    public: bool = False,
     external_refs: list[Entry] | None = None,
 ) -> str:
     """Serialise a uniform-namespace list of entries to bundle YAML.
 
-    The output document carries up to seven top-level keys in declaration order:
-    ``namespace``, ``user_id``, ``name``, ``description``, ``properties``,
-    ``shareable``, ``entries``. The header (Story 17.7 — adds the typed-bool
-    ``shareable`` field after ``properties``) is emitted ONLY when at least
-    one of the five optional parameters forces it: ``name`` is non-empty,
+    The output document carries up to eight top-level keys in declaration
+    order: ``namespace``, ``user_id``, ``name``, ``description``,
+    ``properties``, ``shareable``, ``public``, ``entries``. The header
+    (Story 17.7 added ``shareable`` after ``properties``; Story 18.2 adds
+    ``public`` after ``shareable``) is emitted ONLY when at least one of
+    the six optional parameters forces it: ``name`` is non-empty,
     ``description`` is non-empty, ``properties`` is non-empty, ``shareable``
-    is ``True``, or ``external_refs`` is non-empty. When all five parameters
-    are at their default values, the function emits the pre-17.5 wire shape
-    verbatim (three top-level keys: ``namespace``, ``user_id``, ``entries``)
-    so legacy callers see no behaviour change.
+    is ``True``, ``public`` is ``True``, or ``external_refs`` is non-empty.
+    When all six parameters are at their default values, the function emits
+    the pre-17.5 wire shape verbatim (three top-level keys: ``namespace``,
+    ``user_id``, ``entries``) so legacy callers see no behaviour change.
 
     Each value under ``entries`` is keyed either by the entry id (local) or
     by the composite ``<entry.namespace>.<entry.id>`` (external). Local values
@@ -218,7 +222,12 @@ def dump_namespace(
     properties = properties if properties is not None else {}
     external_refs = external_refs if external_refs is not None else []
     has_header = (
-        bool(name) or bool(description) or bool(properties) or shareable or bool(external_refs)
+        bool(name)
+        or bool(description)
+        or bool(properties)
+        or shareable
+        or public
+        or bool(external_refs)
     )
 
     sorted_entries = _sort_entries_for_emit(entries)
@@ -239,6 +248,11 @@ def dump_namespace(
         # by NamespaceMeta + AC8). When the header is suppressed entirely
         # (pre-17.5 three-key shape), ``shareable`` is also suppressed.
         doc["shareable"] = shareable
+        # Story 18.2 — emit ``public`` immediately after ``shareable`` so the
+        # wire-format declaration order matches NamespaceMeta. When the
+        # header is suppressed entirely, ``public`` is also suppressed
+        # (pre-17.5 three-key shape preserved).
+        doc["public"] = public
     doc["entries"] = entries_map
 
     raw = yaml.dump(
@@ -413,12 +427,13 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
     ``dict`` with ``namespace`` (non-empty ``str``), ``user_id`` (non-empty
     ``str``; legacy ``null`` is accepted on read and rewritten to
     ``"anonymous"`` per Story 18.1), and ``entries`` (non-empty ``dict``).
-    Optional top-level fields ``name``
-    (``str``), ``description`` (``str``), and ``properties`` (``dict[str, str]``)
-    are projected into the returned :class:`BundleHeader`. Any missing or
-    wrong-typed required key accumulates into a single
-    ``CatalogValidationError`` — the error list is NOT short-circuited after
-    the first failure so frontends can render every issue in one pass.
+    Optional top-level fields ``name`` (``str``), ``description`` (``str``),
+    ``properties`` (``dict[str, str]``), ``shareable`` (``bool``), and
+    ``public`` (``bool``) are projected into the returned
+    :class:`BundleHeader`. Any missing or wrong-typed required key
+    accumulates into a single ``CatalogValidationError`` — the error list
+    is NOT short-circuited after the first failure so frontends can render
+    every issue in one pass.
 
     Each ``(entry_key, entry_map)`` pair under ``entries:`` is split on the
     FIRST ``.`` to decide local vs. external:
@@ -485,30 +500,36 @@ def load_namespace(yaml_text: str) -> tuple[list[Entry], BundleHeader]:
 
 
 def _project_header(doc: dict[str, Any]) -> BundleHeader:
-    """Project the optional ``name`` / ``description`` / ``properties`` / ``shareable`` fields.
+    """Project the optional header fields onto a :class:`BundleHeader`.
 
-    Story 17.7 — ``shareable`` joins the projected fields. Defensive parsing:
-    a missing key projects to ``False``; a non-bool value also projects to
-    ``False`` (Pydantic strict-mode at the upsert site surfaces the typing
-    contract for non-bool inputs, but the dataclass projection itself stays
-    infallible to keep ``load_namespace`` parse-only).
+    Header fields: ``name`` / ``description`` / ``properties`` /
+    ``shareable`` / ``public``.
 
-    ``present=True`` iff at least one of the four header fields
-    (``name`` / ``description`` / ``properties`` / ``shareable``) is
-    explicitly present in the document (regardless of value). This signal
-    lets the import handler distinguish a pre-17.5 bundle (no header at
-    all → skip meta upsert) from a 17.6+ bundle whose header carries empty
-    strings (still upsert meta, possibly with the team-fallback values
-    that the export path synthesised).
+    Story 17.7 added ``shareable`` to the projected fields; Story 18.2 adds
+    ``public``. Defensive parsing: a missing key projects to ``False``; a
+    non-bool value also projects to ``False`` (Pydantic strict-mode at the
+    upsert site surfaces the typing contract for non-bool inputs, but the
+    dataclass projection itself stays infallible to keep ``load_namespace``
+    parse-only).
+
+    ``present=True`` iff at least one of the five header fields
+    (``name`` / ``description`` / ``properties`` / ``shareable`` /
+    ``public``) is explicitly present in the document (regardless of value).
+    This signal lets the import handler distinguish a pre-17.5 bundle (no
+    header at all → skip meta upsert) from a 17.6+ bundle whose header
+    carries empty strings (still upsert meta, possibly with the team-
+    fallback values that the export path synthesised).
     """
     name_present = "name" in doc
     desc_present = "description" in doc
     props_present = "properties" in doc
     shareable_present = "shareable" in doc
+    public_present = "public" in doc
     name_val = doc.get("name", "")
     desc_val = doc.get("description", "")
     props_val = doc.get("properties", {})
     shareable_val = doc.get("shareable", False)
+    public_val = doc.get("public", False)
     if not isinstance(name_val, str):
         name_val = ""
     if not isinstance(desc_val, str):
@@ -519,6 +540,11 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
     # Truthy strings / ints fall through to False, matching the catalog
     # gate's ``meta.payload.get("shareable") is True`` semantics.
     shareable_bool = shareable_val is True
+    # Story 18.2 — strict-bool projection for ``public`` mirrors ``shareable``.
+    # Pydantic's strict-mode on the upsert site (NamespaceMeta(public=...))
+    # surfaces operator typos for explicit upserts; this projection is the
+    # read-side defence in depth.
+    public_bool = public_val is True
     # Coerce property values to strings if any leaked through; this is a
     # display projection so strict typing is enforced upstream by NamespaceMeta.
     properties: dict[str, str] = {
@@ -529,7 +555,10 @@ def _project_header(doc: dict[str, Any]) -> BundleHeader:
         description=desc_val,
         properties=properties,
         shareable=shareable_bool,
-        present=name_present or desc_present or props_present or shareable_present,
+        public=public_bool,
+        present=(
+            name_present or desc_present or props_present or shareable_present or public_present
+        ),
     )
 
 

--- a/tests/repositories/test_entry_repository_contract.py
+++ b/tests/repositories/test_entry_repository_contract.py
@@ -301,6 +301,36 @@ class TestEntryRepositoryContract:
         got = backend.list(EntryQuery(namespace="ns-1", user_id="alice", user_id_set=False))
         assert got == []
 
+    def test_meta_entry_public_field_round_trips_typed_bool(
+        self,
+        backend: EntryRepository,
+    ) -> None:
+        # Story 18.2 AC7 — ``public=True`` survives the byte-identical
+        # write/read cycle as a typed Python bool across YAML / Mongo /
+        # Postgres backends. The flag lives inside ``Entry.payload:
+        # dict[str, Any]`` and round-trips verbatim via the existing
+        # repository contract — no per-backend code change is required.
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="ns-public-rt",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="public namespace",
+            payload={
+                "name": "Tenant Pub",
+                "description": "",
+                "properties": {},
+                "shareable": False,
+                "public": True,
+            },
+        )
+        backend.put(meta)
+        loaded = backend.get("ns-public-rt", "_meta")
+        assert loaded is not None
+        assert isinstance(loaded.payload, dict)
+        assert loaded.payload["public"] is True
+
     def test_list_filters_with_description_contains(
         self,
         backend: EntryRepository,
@@ -450,3 +480,50 @@ class TestPostgresSpecific:
             assert row is not None
             assert row[0] == "anonymous"
             assert row[0] is not None
+
+    def test_meta_payload_public_stored_as_jsonb_boolean(
+        self,
+        postgres_clean_dsn: str,
+    ) -> None:
+        # Story 18.2 AC7 — the JSONB ``payload`` column stores the literal
+        # JSON ``true`` for the ``public`` key (not the string ``"true"``).
+        # Verifies the typed-bool round-trip at the database level: a
+        # JSONB ``->'public'`` extract surfaces as PostgreSQL's ``true``
+        # literal (cast to text yields ``'true'``).
+        import psycopg
+
+        from akgentic.catalog.repositories.postgres import PostgresEntryRepository
+
+        repo = PostgresEntryRepository(postgres_clean_dsn)
+        repo.put(
+            make_entry(
+                id="_meta",
+                kind="meta",
+                namespace="ns-pg-public",
+                user_id="alice",
+                model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+                description="",
+                payload={
+                    "name": "Tenant",
+                    "description": "",
+                    "properties": {},
+                    "shareable": False,
+                    "public": True,
+                },
+            )
+        )
+        with psycopg.connect(postgres_clean_dsn) as conn, conn.cursor() as cur:
+            # ``payload->'public'`` returns the JSONB literal; cast to text
+            # yields the JSON serialisation. ``"true"`` here is the JSON
+            # literal ``true`` rendered to text — NOT a stored string.
+            cur.execute(
+                "SELECT payload->'public' FROM catalog_entries WHERE namespace = %s AND id = %s",
+                ("ns-pg-public", "_meta"),
+            )
+            row = cur.fetchone()
+            assert row is not None
+            # psycopg returns the JSONB extract as a Python bool when the
+            # underlying JSON value is a boolean — the typed-bool contract
+            # is preserved end-to-end.
+            assert row[0] is True
+            assert isinstance(row[0], bool)

--- a/tests/v2/conftest.py
+++ b/tests/v2/conftest.py
@@ -47,6 +47,7 @@ def make_meta_entry(
     namespace: str,
     *,
     shareable: bool = True,
+    public: bool = False,
     name: str | None = None,
     description: str = "",
     extra_properties: dict[str, str] | None = None,
@@ -56,10 +57,10 @@ def make_meta_entry(
 
     Used by cross-ns shareable-flag tests to opt the target namespace into
     being a cross-ns ref target. Story 17.7 / AC1 — ``shareable`` is a typed
-    bool at the root of the meta payload. ``shareable=True`` writes
-    ``payload["shareable"] = True``; ``shareable=False`` writes
-    ``payload["shareable"] = False``. The factory always emits the typed-bool
-    shape; legacy-shape fixtures construct the payload by hand.
+    bool at the root of the meta payload. Story 18.2 — ``public`` is a typed
+    bool at the root of the meta payload (default ``False``). The factory
+    always emits the typed-bool shape; legacy-shape fixtures construct the
+    payload by hand.
     """
     properties: dict[str, str] = {}
     if extra_properties:
@@ -69,6 +70,7 @@ def make_meta_entry(
         "description": description,
         "properties": properties,
         "shareable": shareable,
+        "public": public,
     }
     return Entry(
         id="_meta",

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from akgentic.catalog.catalog import Catalog  # noqa: E402
 from akgentic.catalog.models.entry import Entry  # noqa: E402
+from akgentic.catalog.models.namespace_meta import NamespaceMeta  # noqa: E402
 
 _TEAM_TYPE = "akgentic.team.models.TeamCard"
 _AGENT_TYPE = "akgentic.core.agent_card.AgentCard"
@@ -700,9 +701,10 @@ class TestNamespaceExport:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("application/yaml")
         doc = yaml.safe_load(response.text)
-        # Story 17.7 — seven top-level keys in declaration order. The header
-        # (name/description/properties/shareable) is auto-synthesised from the
-        # team-payload fallback when no _meta entry exists in the namespace.
+        # Story 18.2 — eight top-level keys in declaration order. The header
+        # (name/description/properties/shareable/public) is auto-synthesised
+        # from the team-payload fallback when no _meta entry exists in the
+        # namespace.
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
@@ -710,10 +712,12 @@ class TestNamespaceExport:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
         assert doc["namespace"] == "ns-exp"
         assert doc["shareable"] is False
+        assert doc["public"] is False
         assert set(doc["entries"].keys()) == {"team", "a-1"}
 
     def test_export_empty_namespace_409(self, api_client: tuple[TestClient, Catalog]) -> None:
@@ -1277,6 +1281,7 @@ class TestListNamespaces:
                 "description": "alpha team",
                 "team": True,
                 "shareable": False,
+                "public": False,
             },
             {
                 "namespace": "ns-b",
@@ -1284,6 +1289,7 @@ class TestListNamespaces:
                 "description": "beta team",
                 "team": True,
                 "shareable": False,
+                "public": False,
             },
         ]
 
@@ -1321,6 +1327,7 @@ class TestListNamespaces:
                 "description": "",
                 "team": True,
                 "shareable": False,
+                "public": False,
             }
         ]
 
@@ -1379,17 +1386,18 @@ class TestListNamespaces:
         ref = content["items"]["$ref"]
         assert ref.endswith("/NamespaceSummary")
         component = spec["components"]["schemas"]["NamespaceSummary"]
-        # Story 17.7 — five pinned fields in declaration order.
+        # Story 18.2 — six pinned fields in declaration order.
         assert set(component["properties"].keys()) == {
             "namespace",
             "name",
             "description",
             "team",
             "shareable",
+            "public",
         }
         # AC5 — declaration order pinned via OpenAPI's required-list ordering
         # (FastAPI emits declaration order in ``required:`` for required
-        # fields). All five fields are required (no defaults that allow
+        # fields). All six fields are required (no defaults that allow
         # omission in the response shape).
         assert component["required"] == [
             "namespace",
@@ -1397,6 +1405,7 @@ class TestListNamespaces:
             "description",
             "team",
             "shareable",
+            "public",
         ]
 
 
@@ -1483,6 +1492,7 @@ class TestListNamespacesMetaFallback:
                 "description": "meta description",
                 "team": True,
                 "shareable": False,
+                "public": False,
             }
         ]
 
@@ -1518,6 +1528,7 @@ class TestListNamespacesMetaFallback:
                 "description": "team description",
                 "team": True,
                 "shareable": False,
+                "public": False,
             }
         ]
 
@@ -1570,6 +1581,7 @@ class TestListNamespacesMetaFallback:
                 "description": "meta description",
                 "team": True,
                 "shareable": False,
+                "public": False,
             }
         ]
 
@@ -1827,6 +1839,7 @@ class TestListNamespacesUnionDiscovery:
             "description": "team only desc",
             "team": True,
             "shareable": False,
+            "public": False,
         }
         assert by_ns["ns-team-meta-shared"] == {
             "namespace": "ns-team-meta-shared",
@@ -1834,6 +1847,7 @@ class TestListNamespacesUnionDiscovery:
             "description": "meta description",
             "team": True,
             "shareable": True,
+            "public": False,
         }
         assert by_ns["ns-meta-only"] == {
             "namespace": "ns-meta-only",
@@ -1841,6 +1855,7 @@ class TestListNamespacesUnionDiscovery:
             "description": "meta-only desc",
             "team": False,
             "shareable": True,
+            "public": False,
         }
 
 
@@ -2093,3 +2108,193 @@ class TestListNamespacesNoExtraRoundtrip:
         assert meta_gets == [], (
             f"expected 0 catalog.get(*, _meta) calls during handler dispatch, got {meta_gets}"
         )
+
+
+# --- Story 18.2 — NamespaceSummary.public projection ----------------------------
+
+
+class TestNamespaceSummaryPublicField:
+    """Story 18.2 AC2 — ``NamespaceSummary.public`` projection from ``_meta`` payload."""
+
+    def test_namespace_summary_field_order(self) -> None:
+        # AC2 — six pinned fields in declaration order. The lockdown catches
+        # accidental reorders that would shift the OpenAPI / wire-format
+        # key order downstream.
+        from akgentic.catalog.api.router import NamespaceSummary
+
+        assert list(NamespaceSummary.model_fields.keys()) == [
+            "namespace",
+            "name",
+            "description",
+            "team",
+            "shareable",
+            "public",
+        ]
+
+    def test_namespace_summary_has_public_field_when_meta_public_true(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "ns-public-true")
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="ns-public-true",
+                user_id="anonymous",
+                model_type=_NAMESPACE_META_TYPE_ROUTER,
+                description="",
+                payload={
+                    "name": "Forkable Library",
+                    "description": "",
+                    "properties": {},
+                    "shareable": False,
+                    "public": True,
+                },
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        assert response.status_code == 200
+        rows = response.json()
+        by_ns = {r["namespace"]: r for r in rows}
+        assert by_ns["ns-public-true"]["public"] is True
+        assert by_ns["ns-public-true"]["shareable"] is False
+
+    def test_namespace_summary_public_strict_bool(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        # AC2 — truthy strings do NOT flip the flag; the projection uses
+        # ``is True`` (strict-bool comparison), mirroring ``shareable``.
+        client, catalog = api_client
+        _seed_team(catalog, "ns-public-string")
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="ns-public-string",
+                user_id="anonymous",
+                model_type=_NAMESPACE_META_TYPE_ROUTER,
+                description="",
+                payload={
+                    "name": "Confused Public",
+                    "description": "",
+                    "properties": {},
+                    "shareable": False,
+                    "public": "yes",  # NOT a real bool — defensive projection.
+                },
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        rows = response.json()
+        by_ns = {r["namespace"]: r for r in rows}
+        assert by_ns["ns-public-string"]["public"] is False
+
+    def test_namespace_summary_public_default_false_when_no_meta(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "ns-no-meta")
+        response = client.get("/catalog/namespaces")
+        rows = response.json()
+        by_ns = {r["namespace"]: r for r in rows}
+        assert by_ns["ns-no-meta"]["public"] is False
+
+    def test_namespace_summary_public_false_when_meta_payload_omits_key(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        # A meta entry whose payload omits the ``public`` key projects to
+        # ``public=False`` — no AttributeError, no truthy fallback.
+        client, catalog = api_client
+        _seed_team(catalog, "ns-meta-no-public-key")
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="ns-meta-no-public-key",
+                user_id="anonymous",
+                model_type=_NAMESPACE_META_TYPE_ROUTER,
+                description="",
+                payload={"name": "Pre-18.2 meta", "description": "", "properties": {}},
+            )
+        )
+        response = client.get("/catalog/namespaces")
+        rows = response.json()
+        by_ns = {r["namespace"]: r for r in rows}
+        assert by_ns["ns-meta-no-public-key"]["public"] is False
+
+
+class TestPutNamespaceMetaPublicField:
+    """Story 18.2 AC6 — PUT/GET /catalog/namespace/{ns}/meta round-trips ``public``."""
+
+    def test_put_public_true_round_trips(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "", "properties": {}, "public": True}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["payload"]["public"] is True
+        # GET surfaces the same typed bool.
+        get_resp = client.get("/catalog/namespace/tenant-42/meta")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["payload"]["public"] is True
+
+    def test_put_public_false_round_trips(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "", "properties": {}, "public": False}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["payload"]["public"] is False
+
+    def test_put_public_invalid_type_yields_422(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        # Story 18.2 — the route's body parser runs ``model_validate``
+        # (non-strict) so ``"yes"`` coerces to True (matching ``shareable``'s
+        # established route-boundary behaviour — see story Open Question #6:
+        # "match shareable exactly: lenient projection, strict upsert"). A
+        # value Pydantic cannot coerce (e.g. a list / object) DOES surface
+        # as 422, locking the validation envelope at the route boundary.
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "", "properties": {}, "public": [1, 2, 3]}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 422
+
+    def test_put_public_string_coerces_at_route_strict_at_projection(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        # Story 18.2 — the route accepts a coercible string (``"true"``) and
+        # the upsert path stores ``payload["public"] = True`` (Pydantic's
+        # default-mode coercion). The strict-bool guarantee — only a real
+        # bool ``True`` flips the picker / bundle-header projections —
+        # lives at the read side (``NamespaceSummary._build_namespace_summary``,
+        # ``BundleHeader._project_header``). This test pins both sides:
+        #   1. The route accepts the body (no 422) — matches ``shareable``.
+        #   2. ``NamespaceMeta.model_validate({...}, strict=True)`` on the
+        #      same body raises ``ValidationError`` — strict mode is
+        #      available at the model level for callers who opt in.
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "", "properties": {}, "public": "true"}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        # Strict mode at the model level rejects the same body — the
+        # contract is available, just not auto-applied at the route.
+        from pydantic import ValidationError as _ValidationError
+
+        with pytest.raises(_ValidationError):
+            NamespaceMeta.model_validate(body, strict=True)
+
+    def test_put_default_public_is_false(self, api_client: tuple[TestClient, Catalog]) -> None:
+        # A body that omits ``public`` defaults to False on the upserted
+        # entry — the field default flows through NamespaceMeta.
+        client, catalog = api_client
+        _seed_team(catalog, "tenant-42")
+        body = {"name": "Tenant 42", "description": "", "properties": {}}
+        response = client.put("/catalog/namespace/tenant-42/meta", json=body)
+        assert response.status_code == 201
+        entry = response.json()
+        assert entry["payload"]["public"] is False

--- a/tests/v2/test_catalog_namespace_bundle.py
+++ b/tests/v2/test_catalog_namespace_bundle.py
@@ -646,11 +646,13 @@ def _seed_meta(
     description: str = "primary tenant",
     properties: dict[str, str] | None = None,
     shareable: bool = False,
+    public: bool = False,
     user_id: str = "alice",
 ) -> Entry:
     """Create a `_meta` entry in ``namespace`` and return it.
 
     Story 17.7 — ``shareable`` is a typed bool at the root of the meta payload.
+    Story 18.2 — ``public`` is a typed bool at the root of the meta payload.
     """
     return catalog.create(
         Entry(
@@ -664,6 +666,7 @@ def _seed_meta(
                 "description": description,
                 "properties": properties if properties is not None else {},
                 "shareable": shareable,
+                "public": public,
             },
         )
     )
@@ -698,7 +701,7 @@ class TestHeaderProjection:
         import yaml as _yaml
 
         doc = _yaml.safe_load(text)
-        # Story 17.7 / AC8 — seven top-level keys in declaration order.
+        # Story 18.2 — eight top-level keys in declaration order.
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
@@ -706,12 +709,14 @@ class TestHeaderProjection:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
         assert doc["name"] == "Agent Team"
         assert doc["description"] == "Manager-led team"
         assert doc["properties"] == {"tier": "gold"}
         assert doc["shareable"] is True
+        assert doc["public"] is False
         # AC2 — the meta entry is NEVER in `entries:` for bundles produced
         # by Catalog.export_namespace_yaml.
         assert "_meta" not in doc["entries"]
@@ -783,6 +788,80 @@ class TestHeaderProjection:
         assert doc["shareable"] is True
         # `properties` is now fully free-form (no reserved keys).
         assert doc["properties"] == {}
+
+    def test_export_emits_public_after_shareable(self, catalog_factory: CatalogFactory) -> None:
+        # Story 18.2 AC10 — assert ordering by reading the raw YAML text:
+        # the ``public:`` line index is greater than ``shareable:``'s.
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-pub-order")
+        _seed_meta(
+            catalog,
+            "tenant-pub-order",
+            name="Public Library",
+            public=True,
+        )
+        text = catalog.export_namespace_yaml("tenant-pub-order")
+        shareable_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("shareable:")
+        )
+        public_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("public:")
+        )
+        entries_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("entries:")
+        )
+        assert shareable_idx < public_idx < entries_idx
+        # PyYAML default emit shape: ``public: true`` (lowercase, unquoted).
+        assert "public: true" in text
+
+    def test_public_flag_round_trips(self, catalog_factory: CatalogFactory) -> None:
+        # Story 18.2 AC4 — ``public=True`` on the meta entry propagates to
+        # the bundle header.
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-pub")
+        _seed_meta(
+            catalog,
+            "tenant-pub",
+            name="Public Tenant",
+            public=True,
+        )
+        text = catalog.export_namespace_yaml("tenant-pub")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert doc["public"] is True
+        # ``shareable`` independent of ``public`` — both flags can be False
+        # while ``public`` is True (the forkable-library state).
+        assert doc["shareable"] is False
+
+    def test_meta_payload_omits_public_key_projects_false(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        # Story 18.2 AC4 — pre-18.2 meta entries (no ``public`` key in
+        # payload) project to ``public=False`` on export. Defensive: bypass
+        # NamespaceMeta validation by writing directly to the repo.
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "tenant-legacy-meta")
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="tenant-legacy-meta",
+                user_id="alice",
+                model_type=_NAMESPACE_META_TYPE_BUNDLE,
+                payload={
+                    "name": "Pre-18.2 Tenant",
+                    "description": "",
+                    "properties": {},
+                    "shareable": False,
+                },
+            )
+        )
+        text = catalog.export_namespace_yaml("tenant-legacy-meta")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert doc["public"] is False
 
 
 # --- Story 17.6 — header upsert on import ----------------------------------
@@ -951,6 +1030,88 @@ class TestImportHeaderUpsert:
         meta = repo.get("tenant-V", "_meta")
         assert meta is not None
         assert meta.payload["name"] == "explicit-meta"
+
+    def test_import_round_trips_public_true(self, catalog_factory: CatalogFactory) -> None:
+        # Story 18.2 AC5 — importing a bundle with ``public: true`` upserts
+        # a ``_meta`` entry whose ``payload["public"] is True``; re-exporting
+        # produces a bundle with ``public: true``.
+        catalog, repo = catalog_factory()
+        team = Entry(
+            id="team",
+            kind="team",
+            namespace="tenant-pub-import",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        yaml_text = dump_namespace(
+            [team],
+            name="Imported Public",
+            public=True,
+        )
+        catalog.import_namespace_yaml(yaml_text)
+        meta = repo.get("tenant-pub-import", "_meta")
+        assert meta is not None
+        assert meta.payload["public"] is True
+        # Round-trip: re-export and assert the wire shape.
+        text = catalog.export_namespace_yaml("tenant-pub-import")
+        import yaml as _yaml
+
+        doc = _yaml.safe_load(text)
+        assert doc["public"] is True
+
+    def test_import_legacy_bundle_no_public_defaults_false(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        # Story 18.2 AC5 — pre-18.2 bundle (header trio carries no
+        # ``public``) upserts a ``_meta`` entry whose ``payload["public"]``
+        # is ``False`` (the NamespaceMeta field default).
+        catalog, repo = catalog_factory()
+        team = Entry(
+            id="team",
+            kind="team",
+            namespace="tenant-pub-legacy",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        # ``shareable=True`` forces the header but ``public`` is omitted.
+        yaml_text = dump_namespace(
+            [team],
+            name="Legacy",
+            shareable=True,
+        )
+        # Strip the ``public:`` line to simulate a true pre-18.2 bundle.
+        lines = [line for line in yaml_text.splitlines() if not line.startswith("public:")]
+        yaml_no_public = "\n".join(lines) + "\n"
+        catalog.import_namespace_yaml(yaml_no_public)
+        meta = repo.get("tenant-pub-legacy", "_meta")
+        assert meta is not None
+        assert meta.payload["public"] is False
+        # ``shareable`` still flowed through.
+        assert meta.payload["shareable"] is True
+
+    def test_bundle_header_public_strict_bool(self, catalog_factory: CatalogFactory) -> None:
+        # Story 18.2 AC5 — importing a bundle whose ``public:`` value is
+        # the string ``"true"`` upserts a ``_meta`` entry whose
+        # ``payload["public"] is False`` (defensive projection — matches
+        # ``shareable``'s shape).
+        catalog, repo = catalog_factory()
+        team = Entry(
+            id="team",
+            kind="team",
+            namespace="tenant-pub-strict",
+            user_id="alice",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+        yaml_text = dump_namespace([team], name="Strict")
+        # Inject a string ``public: 'true'`` after ``public:`` (defensive).
+        yaml_with_string = yaml_text.replace("public: false", "public: 'true'")
+        catalog.import_namespace_yaml(yaml_with_string)
+        meta = repo.get("tenant-pub-strict", "_meta")
+        assert meta is not None
+        assert meta.payload["public"] is False
 
 
 # --- Story 17.6 — export with external refs --------------------------------
@@ -1300,7 +1461,8 @@ class TestSnapshotShape:
 
         doc = _yaml.safe_load(text)
 
-        # Story 17.7 / AC8 — seven top-level keys in order (adds ``shareable``).
+        # Story 18.2 — eight top-level keys in order (adds ``public`` after
+        # ``shareable``).
         assert list(doc.keys()) == [
             "namespace",
             "user_id",
@@ -1308,6 +1470,7 @@ class TestSnapshotShape:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
 

--- a/tests/v2/test_catalog_resolve.py
+++ b/tests/v2/test_catalog_resolve.py
@@ -480,4 +480,86 @@ class TestLoadTeamDisplayProjection:
         result = catalog.load_team("ns-sq")
         assert result.name == "Friendly"
         assert counting.count("list_by_namespace") == 1
-        assert counting.count("get") == 0
+
+
+# --- Story 18.2 — public flag is purely declarative; no filtering yet ----------
+
+
+class TestPublicFlagDoesNotFilter:
+    """Story 18.2 AC8 — ``Catalog.list`` / ``get`` / ``search`` / ``clone``
+    behaviour is UNCHANGED. The visibility filter consults ``payload["public"]``
+    only after Story 18.4; Story 18.2 declares the data, nothing more.
+
+    These tests lock the deferred-behaviour contract. A regression that
+    accidentally lands the filter in Story 18.2's PR (e.g. by re-using the
+    ``shareable`` gate's shape) flips one of these tests and surfaces the
+    scope creep at code-review time.
+    """
+
+    @staticmethod
+    def _seed_meta_with_public(
+        catalog: Catalog,
+        namespace: str,
+        *,
+        public: bool,
+    ) -> None:
+        """Write a ``_meta`` entry whose ``payload["public"]`` is set."""
+        catalog._repository.put(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace=namespace,
+                user_id="alice",
+                model_type=_NAMESPACE_META_TYPE,
+                description="",
+                payload={
+                    "name": "Tenant",
+                    "description": "",
+                    "properties": {},
+                    "shareable": False,
+                    "public": public,
+                },
+            )
+        )
+
+    def test_list_unaffected_by_public_false(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "ns-priv")
+        self._seed_meta_with_public(catalog, "ns-priv", public=False)
+        # Catalog.list still returns the team entry (and the meta) regardless
+        # of caller / public flag — no filter is applied in 18.2.
+        from akgentic.catalog.models.queries import EntryQuery
+
+        rows = catalog.list(EntryQuery(namespace="ns-priv"))
+        ids = {e.id for e in rows}
+        assert "team" in ids
+
+    def test_list_unaffected_by_public_true(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "ns-pub")
+        self._seed_meta_with_public(catalog, "ns-pub", public=True)
+        from akgentic.catalog.models.queries import EntryQuery
+
+        rows = catalog.list(EntryQuery(namespace="ns-pub"))
+        ids = {e.id for e in rows}
+        assert "team" in ids
+
+    def test_get_unaffected_by_public_flag(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "ns-priv-get")
+        self._seed_meta_with_public(catalog, "ns-priv-get", public=False)
+        # Catalog.get continues to surface the team entry regardless of the
+        # public flag — Story 18.4 introduces the filter.
+        team = catalog.get("ns-priv-get", "team")
+        assert team.id == "team"
+
+    def test_search_unaffected_by_public_flag(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _ = catalog_factory()
+        _seed_team(catalog, "ns-search-priv")
+        self._seed_meta_with_public(catalog, "ns-search-priv", public=False)
+        # Search via Catalog.list with the kind filter — the picker / list
+        # path consults no caller identity, no public flag.
+        from akgentic.catalog.models.queries import EntryQuery
+
+        rows = catalog.list(EntryQuery(kind="team", namespace="ns-search-priv"))
+        assert [e.id for e in rows] == ["team"]

--- a/tests/v2/test_cli_bundle.py
+++ b/tests/v2/test_cli_bundle.py
@@ -143,7 +143,8 @@ class TestExportVerb:
         )
         assert result.exit_code == 0, result.stderr
         payload = yaml.safe_load(result.stdout)
-        # Story 17.7 — seven top-level keys including the header (adds ``shareable``).
+        # Story 18.2 — eight top-level keys including the header (adds
+        # ``public`` after ``shareable``).
         assert set(payload.keys()) == {
             "namespace",
             "user_id",
@@ -151,6 +152,7 @@ class TestExportVerb:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         }
         assert payload["namespace"] == "ns-a"

--- a/tests/v2/test_mongo_entry_repo.py
+++ b/tests/v2/test_mongo_entry_repo.py
@@ -805,6 +805,41 @@ class TestMetaEntryRoundTrip:
         assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
         assert repo.get_by_kind("tenant-42", "meta") == meta
 
+    def test_meta_entry_public_field_round_trips_as_bson_bool(
+        self,
+        entries_collection: pymongo.collection.Collection,  # type: ignore[type-arg]
+    ) -> None:
+        # Story 18.2 AC7 — ``public=True`` survives the byte-identical
+        # write/read cycle as a BSON boolean (not a string).
+        repo = MongoEntryRepository(entries_collection)
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="tenant-pub",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="public namespace",
+            payload={
+                "name": "Tenant Pub",
+                "description": "",
+                "properties": {},
+                "shareable": False,
+                "public": True,
+            },
+        )
+        repo.put(meta)
+        # Inspect the BSON document directly — the payload.public field is
+        # stored as a Python bool (mapped to BSON boolean by pymongo).
+        doc = entries_collection.find_one({"_id": {"namespace": "tenant-pub", "id": "_meta"}})
+        assert doc is not None
+        assert doc["payload"]["public"] is True
+        assert isinstance(doc["payload"]["public"], bool)
+        # Read-back via the repository surfaces the value as a typed bool.
+        loaded = repo.get("tenant-pub", "_meta")
+        assert loaded is not None
+        assert isinstance(loaded.payload, dict)
+        assert loaded.payload["public"] is True
+
 
 class TestUserIdAnonymousPersistedShape:
     """Story 18.1 / AC5 — entries with the default ``user_id`` persist as a

--- a/tests/v2/test_namespace_meta.py
+++ b/tests/v2/test_namespace_meta.py
@@ -67,18 +67,72 @@ class TestNamespaceMetaShareableField:
 
 
 class TestNamespaceMetaFieldOrder:
-    """AC1 — declared field order is ``name``, ``description``, ``properties``, ``shareable``."""
+    """Story 18.2 AC1 — five declared fields in pinned order.
+
+    Order matters: it pins the export-bundle header projection order
+    (architecture §07-api emits header keys by declaration order — see
+    Story 17.7 AC8 and Story 18.2 AC3).
+    """
 
     def test_model_fields_declaration_order(self) -> None:
-        # AC1 — declaration order pins the export-bundle header projection
-        # order (architecture §07-api emits header keys by declaration order
-        # — see Story 17.7 AC8).
         assert list(NamespaceMeta.model_fields.keys()) == [
             "name",
             "description",
             "properties",
             "shareable",
+            "public",
         ]
+
+
+class TestNamespaceMetaPublicField:
+    """Story 18.2 AC1 — ``public: bool`` root-field contract."""
+
+    def test_default_public_is_false(self) -> None:
+        meta = NamespaceMeta(name="x")
+        assert meta.public is False
+        dumped = meta.model_dump()
+        assert dumped["public"] is False
+
+    def test_explicit_public_true_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", public=True)
+        assert meta.public is True
+        dumped = meta.model_dump()
+        assert dumped["public"] is True
+        # Round-trip via model_validate preserves the typed bool.
+        rebuilt = NamespaceMeta.model_validate(dumped)
+        assert rebuilt.public is True
+        assert rebuilt.model_dump() == dumped
+
+    def test_explicit_public_false_round_trip(self) -> None:
+        meta = NamespaceMeta(name="x", public=False)
+        assert meta.public is False
+        dumped = meta.model_dump()
+        assert dumped["public"] is False
+
+    def test_pydantic_rejects_non_bool_string(self) -> None:
+        # Strict-mode rejection mirrors ``shareable``'s contract — operators
+        # must opt in with a real boolean. Error message must include the
+        # field name so error envelopes route the user back to ``public``.
+        with pytest.raises(ValidationError) as excinfo:
+            NamespaceMeta.model_validate(
+                {"name": "x", "public": "true"},
+                strict=True,
+            )
+        assert "public" in str(excinfo.value)
+
+    def test_pydantic_rejects_int_under_strict(self) -> None:
+        with pytest.raises(ValidationError):
+            NamespaceMeta.model_validate(
+                {"name": "x", "public": 1},
+                strict=True,
+            )
+
+    def test_dump_preserves_field_order(self) -> None:
+        # AC1 — ``model_dump()`` ordering matches declaration order so the
+        # YAML wire format keeps ``public`` immediately after ``shareable``.
+        meta = NamespaceMeta(name="x", public=True, shareable=True)
+        keys = list(meta.model_dump().keys())
+        assert keys == ["name", "description", "properties", "shareable", "public"]
 
 
 class TestNamespaceMetaPropertiesFreeForm:

--- a/tests/v2/test_serialization.py
+++ b/tests/v2/test_serialization.py
@@ -518,16 +518,17 @@ class TestMetaEmitOrderAndRoundTrip:
 class TestDumpWithHeader:
     """``dump_namespace`` extended signature — header projection."""
 
-    def test_header_emits_seven_top_level_keys_in_order(self) -> None:
-        # Story 17.7 / AC8 — header now includes ``shareable`` between
-        # ``properties`` and ``entries``. ``properties`` is fully free-form
-        # ``str -> str`` with NO catalog-reserved keys (AC2).
+    def test_header_emits_eight_top_level_keys_in_order(self) -> None:
+        # Story 18.2 — header now includes ``public`` between ``shareable``
+        # and ``entries``. ``properties`` is fully free-form ``str -> str``
+        # with NO catalog-reserved keys.
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant A",
             description="primary",
             properties={"owner_team": "platform"},
             shareable=True,
+            public=True,
         )
         doc = yaml.safe_load(text)
         assert list(doc.keys()) == [
@@ -537,17 +538,19 @@ class TestDumpWithHeader:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
         assert doc["name"] == "Tenant A"
         assert doc["description"] == "primary"
         assert doc["properties"] == {"owner_team": "platform"}
         assert doc["shareable"] is True
+        assert doc["public"] is True
 
-    def test_default_shareable_false_emits_shareable_in_header(self) -> None:
-        # Story 17.7 / AC8 — when a header is forced (here by ``name``),
-        # ``shareable`` is emitted at its declaration position with the
-        # default value ``False``.
+    def test_default_shareable_and_public_false_emit_in_header(self) -> None:
+        # Story 17.7 / 18.2 — when a header is forced (here by ``name``),
+        # ``shareable`` and ``public`` are emitted at their declaration
+        # positions with default value ``False``.
         text = dump_namespace(
             [_team(), _agent("a")],
             name="Tenant A",
@@ -560,15 +563,17 @@ class TestDumpWithHeader:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
         assert doc["shareable"] is False
+        assert doc["public"] is False
 
     def test_shareable_true_alone_forces_header(self) -> None:
-        # AC8 — ``shareable=True`` widens the ``has_header`` branch even when
-        # ``name`` / ``description`` / ``properties`` / ``external_refs`` are
-        # all empty. A shareable namespace is structurally meaningful and must
-        # surface in the wire shape.
+        # ``shareable=True`` widens the ``has_header`` branch even when
+        # ``name`` / ``description`` / ``properties`` / ``public`` /
+        # ``external_refs`` are all default. A shareable namespace is
+        # structurally meaningful and must surface in the wire shape.
         text = dump_namespace(
             [_team(), _agent("a")],
             shareable=True,
@@ -581,12 +586,60 @@ class TestDumpWithHeader:
             "description",
             "properties",
             "shareable",
+            "public",
             "entries",
         ]
         assert doc["shareable"] is True
+        assert doc["public"] is False
         assert doc["name"] == ""
         assert doc["description"] == ""
         assert doc["properties"] == {}
+
+    def test_public_true_alone_forces_header(self) -> None:
+        # Story 18.2 AC3 — ``public=True`` widens the ``has_header`` branch
+        # even when every other header source is at its default. A public
+        # namespace is structurally meaningful and must surface in the wire
+        # shape (mirrors ``shareable`` from Story 17.7).
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            public=True,
+        )
+        doc = yaml.safe_load(text)
+        assert list(doc.keys()) == [
+            "namespace",
+            "user_id",
+            "name",
+            "description",
+            "properties",
+            "shareable",
+            "public",
+            "entries",
+        ]
+        assert doc["public"] is True
+        assert doc["shareable"] is False
+
+    def test_public_emitted_immediately_after_shareable(self) -> None:
+        # Story 18.2 AC3 — assert ordering by reading the raw YAML text:
+        # the ``public:`` line index is greater than ``shareable:``'s and
+        # less than ``entries:``'s. This catches accidental reorders that
+        # would shift the wire-format key order.
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+            shareable=True,
+            public=True,
+        )
+        # Locate top-level (zero-indent) lines.
+        shareable_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("shareable:")
+        )
+        public_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("public:")
+        )
+        entries_idx = next(
+            i for i, line in enumerate(text.splitlines()) if line.startswith("entries:")
+        )
+        assert shareable_idx < public_idx < entries_idx
 
     def test_no_header_emits_three_keys(self) -> None:
         """Pre-17.5 callers (no kwargs) get the three-key shape verbatim."""
@@ -782,6 +835,98 @@ class TestLoadHeaderProjection:
         _entries, header = load_namespace(legacy_yaml)
         assert header.present is True
         assert header.shareable is False
+
+    def test_header_projects_public_true(self) -> None:
+        # Story 18.2 AC3 — ``public`` round-trips through dump/load.
+        text = dump_namespace(
+            [_team(), _agent("a")],
+            name="Tenant A",
+            public=True,
+        )
+        _entries, header = load_namespace(text)
+        assert header.present is True
+        assert header.public is True
+
+    def test_header_present_when_only_public_set(self) -> None:
+        # Story 18.2 AC3 — ``public=True`` alone forces ``present=True``,
+        # mirroring ``shareable``'s shape.
+        text = dump_namespace([_team(), _agent("a")], public=True)
+        _entries, header = load_namespace(text)
+        assert header.present is True
+        assert header.public is True
+        # Default ``shareable`` is preserved.
+        assert header.shareable is False
+
+    def test_legacy_bundle_without_public_projects_false(self) -> None:
+        """Story 18.2 AC3 — pre-18.2 bundles (no ``public`` key) load with
+        ``BundleHeader.public = False`` and ``present`` driven by the other
+        fields only.
+        """
+        legacy_yaml = (
+            "namespace: ns-1\n"
+            "user_id: null\n"
+            "name: Old Tenant\n"
+            "shareable: true\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            "      name: T\n"
+        )
+        _entries, header = load_namespace(legacy_yaml)
+        assert header.present is True
+        assert header.public is False
+        # ``shareable`` still projects through.
+        assert header.shareable is True
+
+    def test_non_bool_public_value_projects_false(self) -> None:
+        """Defensive parsing — a string ``public`` value projects to False."""
+        legacy_yaml = (
+            "namespace: ns-1\n"
+            "user_id: null\n"
+            "name: Old Tenant\n"
+            "public: 'true'\n"  # string, not bool
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            "      name: T\n"
+        )
+        _entries, header = load_namespace(legacy_yaml)
+        assert header.present is True
+        assert header.public is False
+
+    def test_public_explicit_false_present_flips(self) -> None:
+        """Story 18.2 AC3 — a YAML doc with ``public: false`` literally
+        present projects to ``BundleHeader(public=False, present=True)``
+        (the explicit-key presence flips ``present`` even though the value
+        is the default).
+        """
+        legacy_yaml = (
+            "namespace: ns-1\n"
+            "user_id: null\n"
+            "public: false\n"
+            "entries:\n"
+            "  team:\n"
+            "    kind: team\n"
+            "    model_type: akgentic.team.models.TeamCard\n"
+            "    parent_namespace: null\n"
+            "    parent_id: null\n"
+            "    description: ''\n"
+            "    payload:\n"
+            "      name: T\n"
+        )
+        _entries, header = load_namespace(legacy_yaml)
+        assert header.present is True
+        assert header.public is False
 
 
 # --- Story 17.6 — round-trip with the new shape -----------------------------

--- a/tests/v2/test_yaml_entry_repo.py
+++ b/tests/v2/test_yaml_entry_repo.py
@@ -680,6 +680,61 @@ class TestMetaEntryRoundTrip:
         assert any(e.id == "_meta" and e.kind == "meta" for e in rows)
         assert repo.get_by_kind("tenant-42", "meta") == meta
 
+    def test_meta_entry_public_field_round_trips_typed_bool(self, tmp_path: Path) -> None:
+        # Story 18.2 AC7 — ``public=True`` survives the byte-identical
+        # write/read cycle as a typed Python bool (no truthy-string coercion).
+        repo = YamlEntryRepository(tmp_path)
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="tenant-pub",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="public namespace",
+            payload={
+                "name": "Tenant Pub",
+                "description": "",
+                "properties": {},
+                "shareable": False,
+                "public": True,
+            },
+        )
+        repo.put(meta)
+        # On-disk YAML uses PyYAML's default emit shape: ``public: true``
+        # (lowercase, unquoted) — not ``True``, not ``"true"``.
+        path = tmp_path / "tenant-pub" / "meta" / "_meta.yaml"
+        text = path.read_text(encoding="utf-8")
+        assert "public: true" in text
+        # Read-back surfaces the value as a typed bool.
+        loaded = repo.get("tenant-pub", "_meta")
+        assert loaded is not None
+        assert isinstance(loaded.payload, dict)
+        assert loaded.payload["public"] is True
+
+    def test_meta_entry_public_false_round_trips(self, tmp_path: Path) -> None:
+        # Symmetry — ``public=False`` round-trips as a typed bool too.
+        repo = YamlEntryRepository(tmp_path)
+        meta = make_entry(
+            id="_meta",
+            kind="meta",
+            namespace="tenant-priv",
+            user_id="alice",
+            model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+            description="private namespace",
+            payload={
+                "name": "Tenant Priv",
+                "description": "",
+                "properties": {},
+                "shareable": False,
+                "public": False,
+            },
+        )
+        repo.put(meta)
+        loaded = repo.get("tenant-priv", "_meta")
+        assert loaded is not None
+        assert isinstance(loaded.payload, dict)
+        assert loaded.payload["public"] is False
+
 
 class TestUserIdAnonymousPersistedShape:
     """Story 18.1 / AC4 — entries with the default ``user_id`` persist as


### PR DESCRIPTION
## Summary

Adds a typed `public: bool` root field on `NamespaceMeta` (default `False`) that declares whether non-owner users may list, read, and clone entries in a namespace. Orthogonal to `shareable` (cross-namespace reference eligibility); the cartesian product of the two flags expresses the four named visibility states (tenant-private, forkable library, private shared backbone, public library).

Purely additive at every layer: model field, `NamespaceSummary` DTO, bundle-header wire format, `_meta` entry payload, and end-to-end round-trip plumbing across the YAML, Mongo, and Postgres repositories. The flag is declarative only — `Catalog.list` / `get` / `search` / `clone` are unchanged. Visibility filtering lands in a follow-up story.

## Changes

- `NamespaceMeta` gains `public: bool = Field(default=False, ...)` after `shareable`.
- `NamespaceSummary` (the picker DTO) gains `public: bool` after `shareable`; `_build_namespace_summary` projects `public = meta.payload.get("public") is True` (strict-bool, mirroring `shareable`).
- `BundleHeader` gains `public: bool`; `dump_namespace` accepts a keyword-only `public` parameter and emits the eighth top-level header key in declaration order: `namespace`, `user_id`, `name`, `description`, `properties`, `shareable`, `public`, `entries`.
- `_project_header` (serialization) reads `public` defensively (strict-bool projection) and OR-includes `public_present` into `BundleHeader.present`.
- `Catalog._project_header` returns a 5-tuple `(name, description, properties, shareable, public)`; `export_namespace_yaml` forwards `public` to `dump_namespace`. Import path's `_build_meta_entry_for_upsert` propagates `header.public` into the `_meta` entry payload.
- All three repository backends round-trip `payload["public"]` byte-identically as a typed bool — no repository code change required.

## Tests

- `NamespaceMeta` model: default, round-trip, strict-bool reject (via `model_validate(..., strict=True)`), field-declaration-order lock.
- `NamespaceSummary` projection: default, true projection, defensive truthy-string projection (stays `False`), six-field order lock.
- Bundle export / import: line-index assertion that `public` appears immediately after `shareable`; round-trip; pre-18.2 bundles default to `public=False`; non-bool string projects defensively to `False`.
- Three-backend `payload["public"]` round-trip: YAML on-disk text contains `public: true`; Mongo BSON `payload.public` is a Python bool; Postgres JSONB extract returns the JSON literal `true`.
- No-filter test for `Catalog.list` / `get` / `search` / `clone` — locks the deferred-behaviour contract.
- PUT/GET `/catalog/namespace/{ns}/meta` round-trip; invalid type yields 422.

Closes #180
