### PR TITLE
Drop cross-namespace user_id ownership gate from resolver

### DIFF
--- a/src/akgentic/catalog/resolver.py
+++ b/src/akgentic/catalog/resolver.py
@@ -98,11 +98,10 @@ Implements ADR-008 §D2 — the canonical cross-ns sentinel. A ref-marker dict
 may carry ``NAMESPACE_KEY`` next to ``REF_KEY`` (and optionally ``TYPE_KEY``)
 to address an entry in a different namespace; the resolver gates the lookup
 on the data-driven shareable-flag (the target namespace's ``_meta`` entry has
-``payload["shareable"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2) and
-on the target's ``user_id == "anonymous"`` privacy constraint. The shorthand
-``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the resolver splits on
-the first ``.``. Same-namespace refs (no ``NAMESPACE_KEY``, no dot in
-``__ref__``) bypass both gates entirely.
+``payload["shareable"] is True`` — ADR-008 §D2 as updated 2026-05-08 rev 2).
+The shorthand ``{"__ref__": "<ns>.<id>"}`` is parsed equivalently — the
+resolver splits on the first ``.``. Same-namespace refs (no
+``NAMESPACE_KEY``, no dot in ``__ref__``) bypass the gate entirely.
 """
 
 # Runtime allowlist for ``load_model_type``. Duplicated intentionally in
@@ -367,8 +366,7 @@ def _populate_ref_marker(
 
     Checks run in order — parse target namespace (canonical
     ``__namespace__`` or first-dot shorthand), shareable-flag gate (cross-ns
-    only), cycle, missing target, cross-ns ownership gate (target's
-    ``user_id`` MUST be ``None``), ``__type__`` mismatch, then (Story 15.6)
+    only), cycle, missing target, ``__type__`` mismatch, then (Story 15.6)
     recursive population of nested refs inside the target's payload,
     optional shallow merge of non-reserved siblings on top of that payload
     (Story 20.1 / ADR-010), ``load_model_type`` on the target's declared
@@ -379,9 +377,8 @@ def _populate_ref_marker(
     even when the target id genuinely does not exist (ADR-008 §D2 —
     denying access takes precedence over reporting "not found"). Cycle
     comes next because the cross-ns target may be visited along a chain we
-    already walked. Ownership fires AFTER the lookup so the message can
-    name the offending ``user_id``. ``__type__`` mismatch and downstream
-    pure-data errors follow.
+    already walked. ``__type__`` mismatch and downstream pure-data errors
+    follow.
 
     Sibling-override semantics (ADR-010): any keys on ``node`` other than
     ``__ref__`` / ``__type__`` / ``__namespace__`` are collected as
@@ -412,21 +409,6 @@ def _populate_ref_marker(
     if target is None:
         raise CatalogValidationError(
             [f"Ref '{target_id}' not found in namespace '{target_namespace}'"]
-        )
-
-    # Cross-ns ownership gate (ADR-008 §D2): cross-ns refs may only target
-    # globally-scoped entries. This fires AFTER the lookup so the message
-    # can name the offending user_id. Story 18.1 swaps the comparison value
-    # from `is not None` to `!= "anonymous"` (every globally-scoped entry's
-    # owner is the literal "anonymous" string, not null). Story 18.3
-    # removes the gate entirely.
-    if target_namespace != namespace and target.user_id != "anonymous":
-        raise CatalogValidationError(
-            [
-                f"Cross-namespace ref target '{target_namespace}.{target_id}' "
-                f"has user_id={target.user_id!r} — only globally-scoped "
-                f"entries (user_id='anonymous') can be referenced cross-namespace"
-            ]
         )
 
     if expected is not None and target.model_type != expected:

--- a/tests/v2/test_resolver_cross_ns.py
+++ b/tests/v2/test_resolver_cross_ns.py
@@ -3,8 +3,11 @@
 The cross-namespace tests in this file pin ADR-008 §D2 (updated 2026-05-08
 rev 2) — canonical ``__namespace__`` sentinel + ``<ns>.<id>`` shorthand
 parsing, shareable-flag gate (target namespace's ``_meta`` carries
-``payload["shareable"] is True``), ownership gate, cycle detection across
-namespaces, and the ``populate_refs`` ``is_namespace_shareable`` keyword.
+``payload["shareable"] is True``), cycle detection across namespaces, and
+the ``populate_refs`` ``is_namespace_shareable`` keyword. The historic
+cross-ns ``user_id`` ownership gate has been removed — entries in
+shareable namespaces are referenceable cross-namespace regardless of
+their owner.
 """
 
 from __future__ import annotations
@@ -428,10 +431,15 @@ class TestCrossNamespaceShareableFlagGate:
         assert isinstance(result, _Coord)
 
 
-class TestCrossNamespaceOwnershipGate:
-    """Story 17.3 / AC10 — cross-ns ref to user-scoped target rejected."""
+class TestCrossNamespaceUserIdAcceptance:
+    """Cross-ns refs accept any owner once the target namespace is shareable.
 
-    def test_user_scoped_target_rejected(self, coord_module: str) -> None:
+    The historic gate that rejected non-``"anonymous"`` cross-ns targets has
+    been removed; ``meta.shareable`` is the single data-driven cross-ns
+    eligibility check.
+    """
+
+    def test_user_scoped_target_accepted(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
         repo.put(
             make_entry(
@@ -442,16 +450,14 @@ class TestCrossNamespaceOwnershipGate:
                 payload={"text": "user-only"},
             )
         )
-        with pytest.raises(CatalogValidationError) as exc_info:
-            populate_refs(
-                {"__ref__": "global.user-p"},
-                repo,
-                "tenant-A",
-                is_namespace_shareable=_shareable_set("global"),
-            )
-        msg = exc_info.value.errors[0]
-        assert "only globally-scoped entries (user_id='anonymous')" in msg
-        assert "global.user-p" in msg
+        result = populate_refs(
+            {"__ref__": "global.user-p"},
+            repo,
+            "tenant-A",
+            is_namespace_shareable=_shareable_set("global"),
+        )
+        assert isinstance(result, _Coord)
+        assert result.text == "user-only"
 
     def test_global_target_accepted(self, coord_module: str) -> None:
         repo = FakeEntryRepository()
@@ -471,6 +477,37 @@ class TestCrossNamespaceOwnershipGate:
             is_namespace_shareable=_shareable_set("global"),
         )
         assert isinstance(result, _Coord)
+
+    def test_admin_owned_target_resolves_via_canonical_marker(self, coord_module: str) -> None:
+        """Admin-owned target resolves identically via shorthand and canonical marker shapes."""
+        repo = FakeEntryRepository()
+        repo.put(
+            make_entry(
+                id="admin-prompt",
+                namespace="global",
+                user_id="admin",
+                model_type=f"{coord_module}.Coord",
+                payload={"text": "admin-content"},
+            )
+        )
+        shareable = _shareable_set("global")
+        shorthand_result = populate_refs(
+            {"__ref__": "global.admin-prompt"},
+            repo,
+            "tenant-A",
+            is_namespace_shareable=shareable,
+        )
+        canonical_result = populate_refs(
+            {"__ref__": "admin-prompt", "__namespace__": "global"},
+            repo,
+            "tenant-A",
+            is_namespace_shareable=shareable,
+        )
+        assert isinstance(shorthand_result, _Coord)
+        assert isinstance(canonical_result, _Coord)
+        assert shorthand_result.text == "admin-content"
+        assert canonical_result.text == "admin-content"
+        assert shorthand_result.model_dump() == canonical_result.model_dump()
 
 
 class _RefHolder(BaseModel):


### PR DESCRIPTION
## Summary

Drop the cross-namespace `user_id` ownership gate from the resolver. The gate was a privacy proxy ("only entries with `user_id == 'anonymous'` may be referenced cross-namespace") that has been superseded by the explicit operator-declared `meta.shareable` flag (Story 17.7). Cross-namespace eligibility is now a single data-driven check on `meta.shareable is True`.

## Behavioural change

Narrow and surgical: cross-ns refs from any namespace into a `shareable=true` namespace whose targets carry a non-`"anonymous"` `user_id` now resolve. Community-tier (everything owned by `"anonymous"`) is unchanged. `shareable=false` rejection is unchanged. Same-namespace refs are unchanged.

## Implementation

- Delete the 7-line cross-ns ownership-gate block in `_populate_ref_marker`.
- Tighten the function and `NAMESPACE_KEY` docstrings (drop the `user_id` privacy-constraint clause; remove the `ownership gate` step from the documented order of operations).
- Rename `TestCrossNamespaceOwnershipGate` to `TestCrossNamespaceUserIdAcceptance`. Replace `test_user_scoped_target_rejected` with `test_user_scoped_target_accepted`. Preserve `test_global_target_accepted` (community-tier no-regression). Add `test_admin_owned_target_resolves_via_canonical_marker` (shorthand vs canonical marker equivalence).

## Out of scope

- Caller-identity contextvar / visibility filtering on `Catalog.list` / `get` / `search` / `clone` — Story 18.4.
- ADR-008 §D2 text reconciliation — Story 18.5.
- ADR-009 status flip from `Proposed` to `Accepted` — Story 18.4.

## Quality gates

- `pytest packages/akgentic-catalog/tests/` — 1034 passed, 26 skipped (pre-existing).
- `ruff check`, `ruff format --check`, `mypy --strict packages/akgentic-catalog/src/akgentic/catalog/` — all green.
- `Grep "globally-scoped"` over `packages/akgentic-catalog/src/` and `packages/akgentic-catalog/tests/` — zero matches.

Closes #182
