### PR TITLE
feat(akgentic-catalog): 26.2 bundle dry-run validation resolves same-bundle sibling refs

### DIFF
--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -1028,6 +1028,15 @@ class Catalog:
         references an id present in the persisted namespace but absent from
         the bundle will be flagged by the bundle walker, not by
         ``populate_refs``.
+
+        Transient validation resolves refs through a ``_BundleOverlayRepository``
+        staging the parsed bundle on top of the live repository — identical to
+        the overlay :meth:`import_namespace_yaml` uses. Without it, a bundle
+        entry referencing a NEW sibling entry declared in the same bundle (e.g.
+        a prompt referencing a freshly-added ``NativeValue``) would fail dry-run
+        validation with a spurious "Ref not found", because the sibling is not
+        yet persisted — even though the very same bundle would import cleanly.
+        Staging the overlay keeps the dry-run and import paths consistent.
         """
         try:
             entries, _header = load_namespace(yaml_text)
@@ -1038,9 +1047,10 @@ class Catalog:
                 global_errors=list(exc.errors),
                 entry_issues=[],
             )
+        overlay = _BundleOverlayRepository(self._repository, entries)
         return validate_entries(
             entries,
-            self._repository,
+            overlay,
             is_namespace_shareable=self._is_namespace_shareable,
         )
 

--- a/tests/v2/test_catalog_namespace_validate.py
+++ b/tests/v2/test_catalog_namespace_validate.py
@@ -236,6 +236,99 @@ class TestValidateNamespaceYaml:
         # allowlisted-path check) into the load_namespace errors list.
         assert any("outside allowlist" in m for m in report.global_errors)
 
+    def test_new_sibling_ref_resolves_against_bundle_overlay(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Dry-run validates a NEW entry referencing a NEW sibling in the same bundle.
+
+        Reproduces the import/validate inconsistency: a prompt entry whose
+        ``params.framework`` references a brand-new ``NativeValue`` sibling
+        declared in the same bundle. Neither entry is persisted yet, so before
+        the overlay fix the dry-run resolved the ref against the live
+        repository, found nothing, and reported a spurious "Ref not found".
+        With the bundle staged into a ``_BundleOverlayRepository`` — mirroring
+        ``import_namespace_yaml`` — the sibling resolves and the bundle reports
+        ``ok=True``, consistent with what a real import would do.
+        """
+        catalog, _ = catalog_factory()
+        doc = {
+            "namespace": "ns-sib",
+            "user_id": "alice",
+            "entries": {
+                "team": {
+                    "kind": "team",
+                    "model_type": _TEAM_TYPE,
+                    "description": "",
+                    "payload": _team_payload(),
+                },
+                "prompt": {
+                    "kind": "prompt",
+                    "model_type": "akgentic.llm.PromptTemplate",
+                    "description": "",
+                    "payload": {
+                        "template": "Apply the framework:\n{framework}",
+                        "params": {"framework": {REF_KEY: "framework"}},
+                    },
+                },
+                "framework": {
+                    "kind": "model",
+                    "model_type": "akgentic.catalog.NativeValue",
+                    "description": "",
+                    "payload": {"value": "FRAMEWORK BODY"},
+                },
+            },
+        }
+        yaml_text = yaml.safe_dump(doc, sort_keys=False)
+        report = catalog.validate_namespace_yaml(yaml_text)
+        assert report.ok is True, (
+            f"expected ok, got entry_issues={report.entry_issues!r} "
+            f"global_errors={report.global_errors!r}"
+        )
+
+    def test_cross_ns_ref_to_persisted_target_resolves_via_overlay_fallthrough(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Dry-run ref whose target is persisted (not in the bundle) still resolves.
+
+        The bundle stages only its own same-namespace entries into the overlay.
+        A cross-ns ``{__ref__: id, __namespace__: ns}`` marker pointing at a
+        target that lives in a *shareable* namespace already persisted in the
+        live repository — and absent from the bundle — must resolve through the
+        overlay's fall-through to the inner repository (overlay reads
+        bundle-first, then the inner repo). The overlay must not regress the
+        previously-working persisted-target case. Cross-ns markers are exempt
+        from the bundle dangling-ref walker, so the only resolution path is the
+        transient (per-entry) check against the overlay.
+        """
+        catalog, _repo = catalog_factory()
+        # Persist a shareable global namespace with a target entry. None of this
+        # is part of the dry-run bundle below.
+        _seed_team(catalog, "global", user_id="anonymous")
+        catalog.create(make_meta_entry("global", shareable=True))
+        catalog.create(
+            Entry(
+                id="shared",
+                kind="prompt",
+                namespace="global",
+                user_id="anonymous",
+                model_type=_AGENT_TYPE,
+                payload=_agent_payload("shared"),
+            )
+        )
+        agent_with_cross_ns = _agent_payload("a")
+        agent_with_cross_ns["metadata"] = {"ptr": {REF_KEY: "shared", "__namespace__": "global"}}
+        yaml_text = _default_bundle_yaml(
+            namespace="tenant-A",
+            user_id="alice",
+            agents={"a": {"payload": agent_with_cross_ns}},
+        )
+        report = catalog.validate_namespace_yaml(yaml_text)
+        assert report.ok is True, (
+            f"expected ok, got entry_issues={report.entry_issues!r} "
+            f"global_errors={report.global_errors!r}"
+        )
+        assert not any("dangling ref" in m for m in report.global_errors)
+
     def test_ownership_mismatch(self, catalog_factory: CatalogFactory) -> None:
         catalog, _ = catalog_factory()
         # Construct a bundle where the doc-level user_id matches the team but
@@ -413,3 +506,47 @@ class TestValidateNamespaceCrossNs:
             f"global_errors={report.global_errors!r}"
         )
         assert not any("dangling ref" in m for m in report.global_errors)
+
+    def test_dry_run_non_shareable_cross_ns_ref_appears_in_entry_issues(
+        self, catalog_factory: CatalogFactory
+    ) -> None:
+        """Dry-run (``validate_namespace_yaml``) keeps the shareable-flag gate.
+
+        The overlay stages only same-namespace bundle entries; cross-ns
+        resolution continues to consult the inner repository and the
+        shareable-flag gate. A dry-run bundle carrying a cross-ns marker to a
+        NON-shareable namespace still surfaces the standard "is not shareable"
+        error per entry — the overlay does not loosen the gate.
+        """
+        catalog, _repo = catalog_factory()
+        # Persist a NON-shareable global namespace with a target entry.
+        _seed_team(catalog, "global", user_id="anonymous")
+        catalog.create(make_meta_entry("global", shareable=False))
+        catalog.create(
+            Entry(
+                id="shared",
+                kind="prompt",
+                namespace="global",
+                user_id="anonymous",
+                model_type=_AGENT_TYPE,
+                payload=_agent_payload("shared"),
+            )
+        )
+        agent_with_cross_ns = _agent_payload("a")
+        agent_with_cross_ns["metadata"] = {"ptr": {REF_KEY: "shared", "__namespace__": "global"}}
+        yaml_text = _default_bundle_yaml(
+            namespace="tenant-A",
+            user_id="alice",
+            agents={"a": {"payload": agent_with_cross_ns}},
+        )
+        report = catalog.validate_namespace_yaml(yaml_text)
+        assert report.ok is False
+        assert report.entry_issues, "expected per-entry issue for cross-ns ref"
+        joined = " | ".join(err for issue in report.entry_issues for err in issue.errors)
+        assert "is not shareable" in joined
+        # Cross-ns errors live in entry_issues only — the dangling-ref walker
+        # must NOT flag the cross-ns marker as a global error.
+        assert not any("dangling ref" in m for m in report.global_errors), (
+            f"unexpected dangling-ref leak for cross-ns marker: "
+            f"global_errors={report.global_errors!r}"
+        )


### PR DESCRIPTION
## Summary

Dry-run bundle validation (`Catalog.validate_namespace_yaml`, backing `POST /catalog/namespace/validate`) now resolves same-bundle sibling `{__ref__: ...}` markers against the bundle's own not-yet-persisted entries — exactly as the import path already does. Adding a new entry plus a new sibling it references in a single save now validates successfully instead of failing with a spurious `Ref '<id>' not found in namespace`.

## The bug

`validate_namespace_yaml` passed the bare live `self._repository` to `validate_entries`. The transient per-entry check (`populate_refs` → `model_validate`) therefore resolved `{__ref__: sibling}` against persisted state only. A not-yet-persisted same-bundle sibling reported "not found", even though importing the identical bundle succeeded — the dry-run and import paths disagreed.

A real user edit triggered this: a `PromptTemplate` referencing a brand-new `NativeValue` sibling (`{__ref__: framework}`) added in the same save was rejected, while the identical import succeeded.

## The fix (overlay parity with import)

On the successful-parse path only, stage the same `_BundleOverlayRepository(self._repository, entries)` that `import_namespace_yaml` already constructs, and pass it (preserving `is_namespace_shareable=self._is_namespace_shareable`) to `validate_entries`. The dry-run and import paths now resolve same-bundle sibling refs identically.

The fix is localized to the single delegation site:
- `validate_namespace` (persisted-state) is unchanged — its entries are already persisted.
- The malformed-parse early-return path is unchanged — the overlay is only built after a successful parse.
- `_BundleOverlayRepository`, `validate_entries`, `populate_refs`, and the resolver are untouched.
- No `NativeValue` reference is introduced in `catalog.py` — the overlay is type-agnostic.

## Test coverage

- `test_new_sibling_ref_resolves_against_bundle_overlay` — new entry referencing a new `NativeValue` sibling in the same bundle returns `ok=True` (across both backends).
- `test_cross_ns_ref_to_persisted_target_resolves_via_overlay_fallthrough` — a cross-ns marker to a target persisted in a shareable namespace (absent from the bundle) resolves via the overlay's inner-repo fall-through; no dangling-ref leak.
- `test_dry_run_non_shareable_cross_ns_ref_appears_in_entry_issues` — a dry-run cross-ns ref to a NON-shareable namespace still surfaces "is not shareable" per entry; the overlay does not loosen the gate.
- Existing guarantees stay green: `test_dangling_intra_bundle_ref` (genuine dangling ref still fails), `TestValidateNamespaceYamlIsReadOnly::test_put_and_delete_never_invoked` (zero `put`/`delete` with the overlay staged).

Full suite: 1089 passed, 26 skipped. `ruff check`, `ruff format --check`, and `mypy --strict` clean on both modified files.

## Scope

All changes stay inside `packages/akgentic-catalog/` (`src/akgentic/catalog/catalog.py` and `tests/v2/test_catalog_namespace_validate.py`). No cross-submodule edits.

Closes #192
