### PR TITLE
feat(akgentic-catalog): epic 27 — Namespace-Delete Capability (ADR-028)

### DIFF
--- a/src/akgentic/catalog/api/router.py
+++ b/src/akgentic/catalog/api/router.py
@@ -609,6 +609,23 @@ async def delete_entry(
     return Response(status_code=204)
 
 
+async def delete_namespace(namespace: str) -> Response:
+    """Delete an entire namespace (all entries + ``_meta``); 204 on success.
+
+    Implements ADR-028 §Decision 5. Delegates to
+    ``Catalog.delete_namespace`` with no added try/except so the per-entry
+    delete error contract is preserved: ``EntryNotFoundError`` (empty/absent
+    namespace) propagates → HTTP 404, and ``CatalogValidationError`` (an
+    external inbound reference blocks the delete) propagates → HTTP 409, both
+    via the app-wide handlers in ``api/_errors.py``. The route carries NO
+    authorization dependency — owner-or-admin gating is enforced upstream by
+    the infra route gate (a separate epic).
+    """
+    logger.debug("DELETE /catalog/namespace/%s", namespace)
+    _get_catalog().delete_namespace(namespace)
+    return Response(status_code=204)
+
+
 # --- Route registration -----------------------------------------------------
 
 
@@ -643,6 +660,7 @@ def _register_static_routes(target: APIRouter) -> None:
         response_model=Entry,
         openapi_extra=_multi_format_body_openapi("NamespaceMeta"),
     )(put_namespace_meta)
+    target.delete("/namespace/{namespace}", status_code=204)(delete_namespace)
 
 
 def _register_generic_kind_routes(target: APIRouter) -> None:

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -413,6 +413,81 @@ class Catalog:
         self._repository.delete(namespace, id)
         self._invalidate_meta_caches(target)
 
+    def delete_namespace(self, namespace: str) -> None:
+        """Delete every entry in ``namespace`` (including ``_meta``) atomically.
+
+        Implements ADR-028 §Decision 5. The whole namespace is removed in a
+        single call, guarded only by a structural inbound-reference check —
+        the catalog performs NO caller / role / owner-vs-caller authorization
+        (per ADR-013 §"Out of scope" and ADR-028 §Decision 5, the catalog
+        stores ``user_id`` opaquely and defers *who-may-delete* policy to the
+        upstream infra route gate, a separate epic).
+
+        Inbound-reference guard:
+
+        * **Non-shareable namespace** — the shareable-flag gate (ADR-008 §D2)
+          blocked any cross-namespace ref *into* this namespace at create time,
+          so the namespace-local entry set is self-contained. Intra-namespace
+          references between the entries being removed never block the delete;
+          all entries are removed.
+        * **Shareable namespace** — before removing anything, the method runs
+          ``find_references_global`` per entry and collects referrers whose
+          ``namespace`` differs from ``namespace``. If any *external* referrer
+          exists, it raises :class:`CatalogValidationError` naming each one and
+          removes nothing.
+
+        Atomicity: the external-referrer pre-check runs over ALL entries and
+        raises *before* any ``repository.delete``. Either the whole namespace
+        is removed or nothing is — no partial deletion.
+
+        Cache invalidation: the ``_meta`` entry is removed through
+        :meth:`_invalidate_meta_caches`, evicting both the shareable and public
+        flag caches for ``namespace`` so a subsequent
+        :meth:`_is_namespace_shareable` / :meth:`_is_namespace_public` lookup
+        re-derives ``False`` (no meta entry present).
+
+        Args:
+            namespace: The namespace to delete in its entirety.
+
+        Raises:
+            EntryNotFoundError: If ``namespace`` has zero entries (maps to HTTP
+                404 — an unambiguous "nothing there" signal, mirroring the
+                single-entry :meth:`delete` missing-target contract).
+            CatalogValidationError: If any entry in another namespace
+                references an entry in ``namespace`` (shareable namespaces
+                only). The namespace is left byte-identical when this fires.
+        """
+        entries = self._repository.list_by_namespace(namespace)
+        if not entries:
+            raise EntryNotFoundError(f"Namespace '{namespace}' not found")
+        if self._is_namespace_shareable(namespace):
+            errors = self._collect_external_referrers(namespace, entries)
+            if errors:
+                raise CatalogValidationError(errors)
+        for entry in entries:
+            self._repository.delete(entry.namespace, entry.id)
+            self._invalidate_meta_caches(entry)
+
+    def _collect_external_referrers(self, namespace: str, entries: _list[Entry]) -> _list[str]:
+        """Collect referrer messages for entries OUTSIDE ``namespace`` referencing it.
+
+        For each entry in ``entries`` (all within ``namespace``), runs
+        ``find_references_global`` and keeps only referrers whose
+        ``namespace`` differs from ``namespace`` — intra-namespace referrers
+        are being deleted together and MUST NOT block. The message shape
+        mirrors the single-entry :meth:`delete` widening guard.
+        """
+        errors: _list[str] = []
+        for entry in entries:
+            global_referrers = self._repository.find_references_global(namespace, entry.id)
+            errors.extend(
+                f"Entry '{r.id}' (kind={r.kind}) in namespace '{r.namespace}' "
+                f"references '{entry.id}'"
+                for r in global_referrers
+                if r.namespace != namespace
+            )
+        return errors
+
     # --- Clone ----------------------------------------------------------------
 
     def clone(

--- a/src/akgentic/catalog/catalog.py
+++ b/src/akgentic/catalog/catalog.py
@@ -317,6 +317,11 @@ class Catalog:
         if entry.kind == "team" and entry.namespace == UNSET_NAMESPACE:
             entry = self._mint_team_namespace(entry)
 
+        # ADR-028 §Decision 7 — stamp the caller as owner BEFORE the ownership
+        # check so both ``_check_ownership`` and the persisted entry see the
+        # caller's ``user_id``. No-op on the community path (contextvar None).
+        entry = self._stamp_owner(entry)
+
         self._check_duplicate(entry.namespace, entry.id)
         self._check_meta_singleton(entry)
 
@@ -366,6 +371,10 @@ class Catalog:
         if existing is None:
             raise EntryNotFoundError(f"Entry ({entry.namespace}, {entry.id}) not found")
         del existing  # Existence was the only invariant we needed.
+        # ADR-028 §Decision 7 — stamp the caller as owner BEFORE
+        # ``prepare_for_write`` / ``_check_ownership`` so the persisted entry
+        # and the ownership check both see the caller. No-op on community path.
+        entry = self._stamp_owner(entry)
         prepared = prepare_for_write(
             entry,
             self._repository,
@@ -521,9 +530,11 @@ class Catalog:
             src_namespace: Source namespace containing the entry to clone.
             src_id: Id of the source entry within ``src_namespace``.
             dst_namespace: Destination namespace receiving the cloned entries.
-            dst_user_id: ``user_id`` to stamp on every cloned entry. Defaults
-                to ``"anonymous"`` for community-tier deployments; department
-                / enterprise tiers pass the authenticated caller's identifier.
+            dst_user_id: Community-tier fallback ``user_id`` to stamp on every
+                cloned entry. Defaults to ``"anonymous"``. When a caller
+                identity is set (``as_caller``), the authenticated caller
+                SUPERSEDES this argument for ownership (ADR-028 §Decision 7);
+                ``dst_user_id`` is used only on the community path (no caller).
 
         Returns:
             The top-level cloned entry, as freshly re-read from the repository.
@@ -556,6 +567,10 @@ class Catalog:
                     f"not the owner and the source namespace is not public"
                 ]
             )
+        # ADR-028 §Decision 7 — the authenticated caller supersedes
+        # ``dst_user_id`` for cloned-entry ownership. Community path
+        # (contextvar None) keeps ``dst_user_id`` exactly as before.
+        effective_user_id = caller if caller is not None else dst_user_id
         cloned: dict[tuple[str, str], str] = {}
         pending_writes: _list[Entry] = []
         top_new_id = self._clone_one(
@@ -564,7 +579,7 @@ class Catalog:
             cloned=cloned,
             pending_writes=pending_writes,
             dst_namespace=dst_namespace,
-            dst_user_id=dst_user_id,
+            dst_user_id=effective_user_id,
         )
         for entry in pending_writes:
             self._repository.put(entry)
@@ -955,6 +970,12 @@ class Catalog:
             )
             for e in parsed
         ]
+        # ADR-028 §Decision 7 — stamp every prepared bundle entry to the
+        # authenticated caller BEFORE the uniform-user_id invariant runs, so
+        # the bundle's owner uniformity holds by construction and the upserted
+        # ``_meta`` (which inherits user_id from the team / first prepared
+        # entry) also becomes caller-owned. No-op on the community path.
+        prepared = [self._stamp_owner(e) for e in prepared]
         self._validate_bundle_invariants(prepared, has_header_meta=header.present)
         self._check_bundle_refs(prepared)
         namespace = prepared[0].namespace
@@ -1434,6 +1455,27 @@ class Catalog:
         if entry.kind == "meta":
             self._shareable_flag_cache.pop(entry.namespace, None)
             self._public_flag_cache.pop(entry.namespace, None)
+
+    def _stamp_owner(self, entry: Entry) -> Entry:
+        """Return ``entry`` with ``user_id`` stamped to the authenticated caller when set.
+
+        Implements ADR-028 §Decision 7's write-path stamping rule: on write,
+        the entry owner IS the authenticated caller (``_caller_user_id``)
+        whenever a caller identity is set — the incoming body / YAML
+        ``user_id`` (and ``clone``'s ``dst_user_id``) is ignored for ownership.
+
+        Community parity: when the contextvar is ``None`` (community tier, no
+        ``as_caller`` scope) this is a no-op returning ``entry`` unchanged, so
+        the body / YAML / ``dst_user_id`` value is preserved byte-for-byte.
+
+        The helper is pure — it performs no repository I/O. The caller is
+        guaranteed non-empty by ``as_caller`` (which rejects ``""``), so the
+        resulting ``Entry.user_id`` always satisfies the non-empty contract.
+        """
+        caller = _caller_user_id.get()
+        if caller is None:
+            return entry
+        return entry.model_copy(update={"user_id": caller})
 
     def _check_ownership(self, entry: Entry) -> None:
         """Ensure ``entry.user_id`` matches the namespace anchor (team, then meta fallback)."""

--- a/tests/v2/test_api_router.py
+++ b/tests/v2/test_api_router.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from pydantic import BaseModel
 
 pytest.importorskip("fastapi")
 
@@ -18,8 +19,34 @@ from akgentic.catalog.catalog import Catalog  # noqa: E402
 from akgentic.catalog.models.entry import Entry  # noqa: E402
 from akgentic.catalog.models.namespace_meta import NamespaceMeta  # noqa: E402
 
+from .conftest import register_akgentic_test_module  # noqa: E402
+
 _TEAM_TYPE = "akgentic.team.models.TeamCard"
 _AGENT_TYPE = "akgentic.core.agent_card.AgentCard"
+
+
+class _RefLeaf(BaseModel):
+    """Permissive leaf used for cross-ns ref payloads (Story 27.1)."""
+
+    provider: str = "openai"
+
+
+class _RefHolder(BaseModel):
+    """Holder payload carrying a cross-ns ref (Story 27.1)."""
+
+    model_cfg: _RefLeaf | None = None
+
+
+@pytest.fixture
+def ref_model_paths(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    """Register permissive cross-ns ref models and return their dotted paths."""
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_api_27_1_delete_namespace",
+        Leaf=_RefLeaf,
+        Holder=_RefHolder,
+    )
+    return f"{module_name}.Leaf", f"{module_name}.Holder"
 
 
 # --- helpers ----------------------------------------------------------------
@@ -301,6 +328,80 @@ class TestDelete:
         client, _ = api_client
         response = client.delete("/catalog/agent/foo")
         assert response.status_code == 422
+
+
+class TestDeleteNamespace:
+    """DELETE /catalog/namespace/{namespace} — Story 27.1 (ADR-028 §Decision 5)."""
+
+    def test_delete_namespace_returns_204_and_gone(
+        self, api_client: tuple[TestClient, Catalog]
+    ) -> None:
+        client, catalog = api_client
+        _seed_team(catalog, "ns-nuke")
+        _seed_agent(catalog, "ns-nuke", id="a-1")
+        response = client.delete("/catalog/namespace/ns-nuke")
+        assert response.status_code == 204
+        follow = client.get("/catalog/agent/a-1", params={"namespace": "ns-nuke"})
+        assert follow.status_code == 404
+
+    def test_delete_namespace_absent_404(self, api_client: tuple[TestClient, Catalog]) -> None:
+        client, _ = api_client
+        response = client.delete("/catalog/namespace/ns-absent")
+        assert response.status_code == 404
+
+    def test_delete_namespace_external_ref_blocked_409(
+        self,
+        api_client: tuple[TestClient, Catalog],
+        ref_model_paths: tuple[str, str],
+    ) -> None:
+        client, catalog = api_client
+        leaf, holder = ref_model_paths
+        # Shareable namespace 'global' with a prompt referenced cross-ns.
+        _seed_team(catalog, "global")
+        catalog.create(
+            Entry(
+                id="_meta",
+                kind="meta",
+                namespace="global",
+                user_id="anonymous",
+                model_type="akgentic.catalog.models.namespace_meta.NamespaceMeta",
+                payload={
+                    "name": "global",
+                    "description": "",
+                    "properties": {},
+                    "shareable": True,
+                    "public": False,
+                },
+            )
+        )
+        catalog.create(
+            Entry(
+                id="shared-prompt",
+                kind="prompt",
+                namespace="global",
+                user_id="anonymous",
+                model_type=leaf,
+                payload={"provider": "shared"},
+            )
+        )
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-ref",
+                kind="agent",
+                namespace="tenant-A",
+                user_id="anonymous",
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+        response = client.delete("/catalog/namespace/global")
+        assert response.status_code == 409
 
 
 # --- Listing and search -----------------------------------------------------

--- a/tests/v2/test_catalog_caller_owner_stamping.py
+++ b/tests/v2/test_catalog_caller_owner_stamping.py
@@ -1,0 +1,279 @@
+"""Tests for Story 27.2 — catalog writes stamp the authenticated caller as owner.
+
+ADR-028 §Decision 7: on write, when a caller identity is set
+(``Catalog.as_caller``), the persisted entry's ``user_id`` IS the
+authenticated caller — the incoming body / YAML ``user_id`` (and ``clone``'s
+``dst_user_id``) is ignored for ownership. When no caller is set (community
+tier, ``_caller_user_id`` contextvar is ``None``), behaviour is byte-unchanged:
+``create`` / ``update`` keep the body ``user_id``; ``clone`` uses
+``dst_user_id`` (default ``"anonymous"``); ``import_namespace_yaml`` keeps the
+YAML per-entry ``user_id``.
+
+Both branches of the stamping helper are exercised — caller-set (stamp fires)
+and no-caller (community parity) — across YAML + Mongo backends via the
+``catalog_factory`` fixture.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+
+from .conftest import CatalogFactory, make_meta_entry, register_akgentic_test_module
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+class _Leaf(BaseModel):
+    """Permissive leaf payload used for stamping tests."""
+
+    provider: str = "openai"
+
+
+@pytest.fixture
+def leaf_type(monkeypatch: pytest.MonkeyPatch) -> str:
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_27_2_caller_owner_stamping",
+        Leaf=_Leaf,
+    )
+    return f"{module_name}.Leaf"
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+def _seed_team(catalog: Catalog, namespace: str, *, user_id: str = "anonymous") -> Entry:
+    return catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id=user_id,
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+def _leaf_entry(namespace: str, id: str, leaf_type: str, *, user_id: str = "anonymous") -> Entry:
+    return Entry(
+        id=id,
+        kind="prompt",
+        namespace=namespace,
+        user_id=user_id,
+        model_type=leaf_type,
+        payload={"provider": "x"},
+    )
+
+
+# --- create ---------------------------------------------------------------
+
+
+class TestStampOnCreate:
+    def test_create_under_caller_stamps_owner(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        with Catalog.as_caller("gpiroux"):
+            _seed_team(catalog, "ns")
+            catalog.create(_leaf_entry("ns", "leaf", leaf_type, user_id="anonymous"))
+        persisted = repo.get("ns", "leaf")
+        assert persisted is not None
+        assert persisted.user_id == "gpiroux"
+        # Team entry is also stamped (AC6) — keeps the ownership anchor uniform.
+        team = repo.get("ns", "team")
+        assert team is not None
+        assert team.user_id == "gpiroux"
+
+    def test_create_no_caller_is_byte_unchanged(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "ns")
+        catalog.create(_leaf_entry("ns", "leaf", leaf_type, user_id="anonymous"))
+        persisted = repo.get("ns", "leaf")
+        assert persisted is not None
+        assert persisted.user_id == "anonymous"
+
+    def test_create_check_ownership_passes_under_caller(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        # A non-team/non-meta entry whose incoming user_id differs from the
+        # caller still succeeds because the stamp fires BEFORE _check_ownership.
+        catalog, repo = catalog_factory()
+        with Catalog.as_caller("gpiroux"):
+            _seed_team(catalog, "ns")
+            catalog.create(_leaf_entry("ns", "leaf", leaf_type, user_id="someone-else"))
+        persisted = repo.get("ns", "leaf")
+        assert persisted is not None
+        assert persisted.user_id == "gpiroux"
+
+
+# --- update ---------------------------------------------------------------
+
+
+class TestStampOnUpdate:
+    def test_update_under_caller_stamps_owner(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        with Catalog.as_caller("gpiroux"):
+            _seed_team(catalog, "ns")
+            catalog.create(_leaf_entry("ns", "leaf", leaf_type, user_id="anonymous"))
+            # Candidate carries a foreign user_id; the stamp must override it.
+            candidate = _leaf_entry("ns", "leaf", leaf_type, user_id="someone-else")
+            candidate = candidate.model_copy(update={"description": "updated"})
+            catalog.update(candidate)
+        persisted = repo.get("ns", "leaf")
+        assert persisted is not None
+        assert persisted.user_id == "gpiroux"
+
+    def test_update_no_caller_keeps_candidate_user_id(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        # Seed a team owned by "owner" and a sub-entry owned by "owner".
+        _seed_team(catalog, "ns", user_id="owner")
+        catalog.create(_leaf_entry("ns", "leaf", leaf_type, user_id="owner"))
+        candidate = _leaf_entry("ns", "leaf", leaf_type, user_id="owner").model_copy(
+            update={"description": "updated"}
+        )
+        catalog.update(candidate)
+        persisted = repo.get("ns", "leaf")
+        assert persisted is not None
+        assert persisted.user_id == "owner"
+
+
+# --- clone ----------------------------------------------------------------
+
+
+class TestStampOnClone:
+    def test_clone_under_caller_supersedes_dst_user_id(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        # Source namespace owned by "gpiroux" so the caller can see it.
+        with Catalog.as_caller("gpiroux"):
+            _seed_team(catalog, "src")
+            catalog.create(_leaf_entry("src", "leaf", leaf_type))
+            _seed_team(catalog, "dst")
+            # dst_user_id explicitly set to something else — caller supersedes it.
+            catalog.clone("src", "leaf", "dst", dst_user_id="ignored-owner")
+        cloned = repo.get("dst", "leaf")
+        assert cloned is not None
+        assert cloned.user_id == "gpiroux"
+
+    def test_clone_no_caller_uses_dst_user_id(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "src")
+        catalog.create(_leaf_entry("src", "leaf", leaf_type))
+        _seed_team(catalog, "dst")
+        catalog.clone("src", "leaf", "dst", dst_user_id="bob")
+        cloned = repo.get("dst", "leaf")
+        assert cloned is not None
+        assert cloned.user_id == "bob"
+
+    def test_clone_no_caller_default_anonymous(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "src")
+        catalog.create(_leaf_entry("src", "leaf", leaf_type))
+        _seed_team(catalog, "dst")
+        catalog.clone("src", "leaf", "dst")
+        cloned = repo.get("dst", "leaf")
+        assert cloned is not None
+        assert cloned.user_id == "anonymous"
+
+
+# --- import_namespace_yaml ------------------------------------------------
+
+
+class TestStampOnImport:
+    def _seed_anonymous_namespace(self, catalog: Catalog, namespace: str, leaf_type: str) -> None:
+        _seed_team(catalog, namespace, user_id="anonymous")
+        catalog.create(make_meta_entry(namespace, shareable=False, public=False))
+        catalog.create(_leaf_entry(namespace, "leaf", leaf_type, user_id="anonymous"))
+
+    def test_import_under_caller_stamps_every_entry_and_meta(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        # Build a bundle from an anonymous-owned namespace (the reported bug).
+        self._seed_anonymous_namespace(catalog, "src", leaf_type)
+        bundle = catalog.export_namespace_yaml("src")
+
+        # Re-import the same bundle (same namespace) under a caller.
+        with Catalog.as_caller("gpiroux"):
+            persisted = catalog.import_namespace_yaml(bundle)
+
+        for entry in persisted:
+            assert entry.user_id == "gpiroux", f"{entry.id} not stamped"
+        # The hoisted _meta entry (upserted) is also caller-owned.
+        meta = repo.get("src", "_meta")
+        assert meta is not None
+        assert meta.user_id == "gpiroux"
+        # And the persisted team / leaf in the repository.
+        team = repo.get("src", "team")
+        leaf = repo.get("src", "leaf")
+        assert team is not None and team.user_id == "gpiroux"
+        assert leaf is not None and leaf.user_id == "gpiroux"
+
+    def test_import_no_caller_keeps_yaml_user_id(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        catalog, repo = catalog_factory()
+        self._seed_anonymous_namespace(catalog, "src", leaf_type)
+        bundle = catalog.export_namespace_yaml("src")
+        persisted = catalog.import_namespace_yaml(bundle)
+        for entry in persisted:
+            assert entry.user_id == "anonymous"
+        meta = repo.get("src", "_meta")
+        assert meta is not None
+        assert meta.user_id == "anonymous"
+
+    def test_import_bundle_uniformity_preserved_under_caller(
+        self, catalog_factory: CatalogFactory, leaf_type: str
+    ) -> None:
+        # A multi-entry bundle whose YAML entries carry mixed/anonymous owners
+        # still passes _validate_bundle_invariants under a caller (all stamped
+        # to the caller first), and persists successfully.
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "src", user_id="anonymous")
+        catalog.create(make_meta_entry("src", shareable=False, public=False))
+        catalog.create(_leaf_entry("src", "leaf-a", leaf_type, user_id="anonymous"))
+        catalog.create(_leaf_entry("src", "leaf-b", leaf_type, user_id="anonymous"))
+        bundle = catalog.export_namespace_yaml("src")
+
+        with Catalog.as_caller("gpiroux"):
+            persisted = catalog.import_namespace_yaml(bundle)
+
+        ids = {e.id for e in persisted}
+        assert {"team", "leaf-a", "leaf-b"} <= ids
+        for e in persisted:
+            assert e.user_id == "gpiroux"

--- a/tests/v2/test_catalog_delete_namespace.py
+++ b/tests/v2/test_catalog_delete_namespace.py
@@ -1,0 +1,278 @@
+"""Tests for Story 27.1 — ``Catalog.delete_namespace``.
+
+``Catalog.delete_namespace(namespace)`` removes every entry in a namespace
+(including ``_meta``) in one atomic call. Its only guard is the structural
+inbound-reference check (ADR-028 §Decision 5): for a shareable namespace, an
+entry in *another* namespace referencing any entry being deleted blocks the
+whole operation (``CatalogValidationError``); intra-namespace references never
+block. An empty/absent namespace raises ``EntryNotFoundError``.
+
+Behaviour is parametrised across the YAML and Mongo backends via
+``catalog_factory``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from akgentic.catalog.catalog import Catalog
+from akgentic.catalog.models.entry import Entry
+from akgentic.catalog.models.errors import CatalogValidationError, EntryNotFoundError
+
+from .conftest import (
+    CatalogFactory,
+    CountingEntryRepository,
+    FakeEntryRepository,
+    make_meta_entry,
+    register_akgentic_test_module,
+)
+
+_TEAM_TYPE = "akgentic.team.models.TeamCard"
+
+
+class _Leaf(BaseModel):
+    """Permissive leaf used for cross-ns ref payloads."""
+
+    provider: str = "openai"
+
+
+class _Holder(BaseModel):
+    """Holder payload for cross-ns ref tests."""
+
+    model_cfg: _Leaf | None = None
+
+
+def _team_payload() -> dict[str, Any]:
+    return {
+        "name": "team",
+        "description": "",
+        "entry_point": {
+            "card": {
+                "role": "entry",
+                "description": "",
+                "skills": [],
+                "agent_class": "akgentic.core.agent.Akgent",
+                "config": {"name": "entry", "role": "entry"},
+            },
+            "headcount": 1,
+            "members": [],
+        },
+        "members": [],
+        "agent_profiles": [],
+    }
+
+
+@pytest.fixture
+def model_paths(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    module_name = register_akgentic_test_module(
+        monkeypatch,
+        "tests_fixture_27_1_delete_namespace",
+        Leaf=_Leaf,
+        Holder=_Holder,
+    )
+    return f"{module_name}.Leaf", f"{module_name}.Holder"
+
+
+def _seed_team(catalog: Catalog, namespace: str) -> None:
+    catalog.create(
+        Entry(
+            id="team",
+            kind="team",
+            namespace=namespace,
+            user_id="anonymous",
+            model_type=_TEAM_TYPE,
+            payload=_team_payload(),
+        )
+    )
+
+
+def _seed_leaf(catalog: Catalog, namespace: str, id: str, leaf_type: str) -> None:
+    catalog.create(
+        Entry(
+            id=id,
+            kind="prompt",
+            namespace=namespace,
+            user_id="anonymous",
+            model_type=leaf_type,
+            payload={"provider": id},
+        )
+    )
+
+
+class TestHappyPath:
+    """A namespace with a team + entries + ``_meta`` is fully deleted."""
+
+    def test_full_namespace_deleted(
+        self, catalog_factory: CatalogFactory, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, _holder = model_paths
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "ns-del")
+        catalog.create(make_meta_entry("ns-del", shareable=False))
+        _seed_leaf(catalog, "ns-del", "p-1", leaf)
+        _seed_leaf(catalog, "ns-del", "p-2", leaf)
+
+        catalog.delete_namespace("ns-del")
+
+        assert repo.list_by_namespace("ns-del") == []
+        with pytest.raises(EntryNotFoundError):
+            catalog.get("ns-del", "p-1")
+        with pytest.raises(EntryNotFoundError):
+            catalog.get("ns-del", "team")
+        with pytest.raises(EntryNotFoundError):
+            catalog.get("ns-del", "_meta")
+
+
+class TestInboundRefGuardNonShareable:
+    """A non-shareable namespace with intra-namespace refs deletes cleanly."""
+
+    def test_internal_refs_do_not_block(
+        self, catalog_factory: CatalogFactory, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "ns-internal")
+        _seed_leaf(catalog, "ns-internal", "shared", leaf)
+        # agent in the SAME namespace references the prompt (intra-ns ref).
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="ns-internal",
+                user_id="anonymous",
+                model_type=holder,
+                payload={"model_cfg": {"__ref__": "shared"}},
+            )
+        )
+
+        catalog.delete_namespace("ns-internal")
+
+        assert repo.list_by_namespace("ns-internal") == []
+
+
+class TestInboundRefGuardShareableExternalReferrer:
+    """A shareable namespace with an external referrer is blocked + intact."""
+
+    def test_external_referrer_blocks_and_leaves_intact(
+        self, catalog_factory: CatalogFactory, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shareable=True))
+        _seed_leaf(catalog, "global", "shared-prompt", leaf)
+        # tenant-A (different namespace) references global.shared-prompt.
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id="anonymous",
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+
+        before = {(e.namespace, e.id) for e in repo.list_by_namespace("global")}
+        with pytest.raises(CatalogValidationError) as exc_info:
+            catalog.delete_namespace("global")
+        joined = " | ".join(exc_info.value.errors)
+        assert "tenant-A" in joined
+        assert "agent-1" in joined
+        # Namespace left intact — every original entry still present.
+        after = {(e.namespace, e.id) for e in repo.list_by_namespace("global")}
+        assert after == before
+
+
+class TestAtomicity:
+    """A refused delete leaves the entry count unchanged."""
+
+    def test_blocked_delete_preserves_count(
+        self, catalog_factory: CatalogFactory, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, holder = model_paths
+        catalog, repo = catalog_factory()
+        _seed_team(catalog, "global")
+        catalog.create(make_meta_entry("global", shareable=True))
+        _seed_leaf(catalog, "global", "shared-prompt", leaf)
+        _seed_leaf(catalog, "global", "other", leaf)
+        _seed_team(catalog, "tenant-A")
+        catalog.create(
+            Entry(
+                id="agent-1",
+                kind="agent",
+                namespace="tenant-A",
+                user_id="anonymous",
+                model_type=holder,
+                payload={
+                    "model_cfg": {
+                        "__ref__": "shared-prompt",
+                        "__namespace__": "global",
+                    }
+                },
+            )
+        )
+
+        count_before = len(repo.list_by_namespace("global"))
+        with pytest.raises(CatalogValidationError):
+            catalog.delete_namespace("global")
+        count_after = len(repo.list_by_namespace("global"))
+        assert count_after == count_before
+
+
+class TestMissingOrEmptyNamespace:
+    """Deleting a namespace with no entries raises ``EntryNotFoundError``."""
+
+    def test_absent_namespace_raises_not_found(self, catalog_factory: CatalogFactory) -> None:
+        catalog, _repo = catalog_factory()
+        with pytest.raises(EntryNotFoundError):
+            catalog.delete_namespace("does-not-exist")
+
+
+class TestCacheInvalidation:
+    """Deleting a shareable/public namespace re-derives flags to ``False``."""
+
+    def test_flags_re_derive_false_after_delete(
+        self, catalog_factory: CatalogFactory, model_paths: tuple[str, str]
+    ) -> None:
+        leaf, _holder = model_paths
+        catalog, _repo = catalog_factory()
+        _seed_team(catalog, "ns-flags")
+        catalog.create(make_meta_entry("ns-flags", shareable=True, public=True))
+        _seed_leaf(catalog, "ns-flags", "p-1", leaf)
+        # Warm the caches so a stale True would surface if not invalidated.
+        assert catalog._is_namespace_shareable("ns-flags") is True
+        assert catalog._is_namespace_public("ns-flags") is True
+
+        catalog.delete_namespace("ns-flags")
+
+        assert catalog._is_namespace_shareable("ns-flags") is False
+        assert catalog._is_namespace_public("ns-flags") is False
+
+
+class TestNonShareableShortCircuit:
+    """A non-shareable namespace delete skips the global referrer scan."""
+
+    def test_non_shareable_skips_global_call(self, model_paths: tuple[str, str]) -> None:
+        leaf, _holder = model_paths
+        inner = FakeEntryRepository()
+        counting = CountingEntryRepository(inner)
+        catalog = Catalog(counting)  # type: ignore[arg-type]
+        _seed_team(catalog, "tenant-A")
+        # Meta entry with shareable=False ⇒ not shareable.
+        catalog.create(make_meta_entry("tenant-A", shareable=False))
+        _seed_leaf(catalog, "tenant-A", "leaf-1", leaf)
+        counting.reset()
+
+        catalog.delete_namespace("tenant-A")
+
+        assert counting.count("find_references_global") == 0


### PR DESCRIPTION
## Epic 27 — Namespace-Delete Capability + write-path owner stamping (ADR-028)

Adds the catalog-side capabilities for ADR-028: a `Catalog.delete_namespace(namespace)` service method with a `DELETE /catalog/namespace/{namespace}` static route (§Decision 5), and write-path caller-owner stamping so every catalog write records the authenticated caller as the entry owner (§Decision 7). This is the catalog slice of ADR-028's multi-submodule chain — the infra owner-or-admin route gate and the frontend Delete button (separate epics) depend on this work.

### Stories

- [x] 27-1-catalog-delete-namespace-service-and-route — `Catalog.delete_namespace` service method + `DELETE /catalog/namespace/{namespace}` route (Relates to #194)
- [x] 27-2-write-path-caller-owner-stamping — catalog writes stamp the authenticated caller as owner via `_stamp_owner` (Relates to #196)

### What changed

**27-1 — namespace delete**

- **`Catalog.delete_namespace(namespace)`** — enumerates every entry in the namespace (including `_meta`) and removes them atomically. Guarded only by a structural inbound-reference check: for a shareable namespace an external (cross-namespace) referrer blocks the whole delete (`CatalogValidationError`, nothing removed); intra-namespace refs never block; an empty/absent namespace raises `EntryNotFoundError`. Meta-cache invalidation routes through `_invalidate_meta_caches`. No caller/role/owner authorization — that gate lives upstream in the infra tier.
- **`DELETE /catalog/namespace/{namespace}`** — static route registered in `_register_static_routes`, delegates with no added try/except, inheriting the per-entry delete error mapping (204 success / 404 empty-or-absent / 409 inbound-ref-blocked). No authorization dependency — gate-agnostic.
- Tests: new `tests/v2/test_catalog_delete_namespace.py` (service-layer, parametrized across YAML + Mongo via `catalog_factory`) and extended `tests/v2/test_api_router.py::TestDeleteNamespace` (204/404/409 route round-trips).

**27-2 — write-path caller-owner stamping (ADR-028 §Decision 7)**

- **`Catalog._stamp_owner(entry) -> Entry`** — pure private helper: when the `_caller_user_id` contextvar (set via `Catalog.as_caller`) is non-`None`, returns the entry with `user_id` overridden to the caller; when `None` (community tier), returns the entry unchanged (byte-for-byte parity).
- **`create` / `update`** — stamp the entry BEFORE `_check_ownership` / `prepare_for_write`, so both the ownership check and the persisted entry see the caller.
- **`clone`** — the authenticated caller supersedes the `dst_user_id` argument when set; `dst_user_id` (default `"anonymous"`) remains the community-path fallback.
- **`import_namespace_yaml`** — stamps every prepared bundle entry before `_validate_bundle_invariants`, so bundle owner-uniformity holds by construction and the upserted `_meta` (which inherits `user_id` from the now-stamped team / first prepared entry) is also caller-owned. Fixes the reported bug where an authenticated import persisted every entry as `user_id: anonymous`.
- Tests: new `tests/v2/test_catalog_caller_owner_stamping.py` (stamp + no-caller community-parity for all four write methods, parametrized across YAML + Mongo), including the anonymous-bundle import bug reproduction.

## Review status

- **27-1** — APPROVED. Implementation mirrors the proven `Catalog.delete` reference exactly: identical referrer-message shape, inherited 404/409 error mapping, cache invalidation through the canonical `_invalidate_meta_caches` helper, and all-or-nothing atomicity via a pre-check pass that raises before any `repository.delete`. All 19 acceptance criteria verified at code level. Tests are real (assert both return values and side effects; parametrized backends). No HIGH/MEDIUM/CRITICAL findings — no fixup commit required.
- **27-2 review: PASS** — All 17 ACs verified at code level. The single pure `_stamp_owner` helper is correctly invoked at the right ordering in all four write methods (stamp-before-ownership-check and stamp-before-bundle-invariant), giving caller==anchor uniformity by construction; community parity (contextvar `None`) is a clean no-op. `clone` reuses the already-resolved `caller` variable (no duplicate `_caller_user_id.get()`). Tests assert on `user_id` values, not ADR strings (Golden Rule #8 clean). Full suite `pytest packages/akgentic-catalog/tests/` → 1153 passed; `ruff check`, `ruff format --check`, and `mypy --strict src/` all clean. Scope confined to `packages/akgentic-catalog/`. No HIGH/MEDIUM/CRITICAL findings — no fixup commit required.

## Scope guard

All code changes are confined to `packages/akgentic-catalog/` — `src/akgentic/catalog/catalog.py`, `src/akgentic/catalog/api/router.py`, and the test files under `tests/v2/`. No edits to any other submodule. The architecture/index/sprint-status updates live under `_bmad-output/akgentic-catalog/` (planning artifacts, tracked in the workspace root, not another submodule's code).

## Epic 27 slice complete

Both stories of Epic 27's catalog slice have landed and passed review. The catalog now (1) exposes the `DELETE /catalog/namespace/{namespace}` endpoint the downstream infra route-gate and frontend Delete-button epics depend on, and (2) stamps the authenticated caller as owner on every write, so the upstream infra owner-or-admin authorization gate (Epic 31) can recognise the real owner — closing the `user_id: anonymous` clone/import defect from ADR-028 §"Prerequisite defect". Quality gates: `pytest packages/akgentic-catalog/tests/` → 1153 passed; `ruff check`, `ruff format --check`, and `mypy --strict` clean on every modified source file.

Closes #194
Closes #196
